### PR TITLE
feat: route Telegram messages into agent handler

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/fractalmind-ai/fractalbot/internal/channels"
@@ -47,4 +49,30 @@ func (m *Manager) List() []protocol.AgentInfo {
 		agents = append(agents, info)
 	}
 	return agents
+}
+
+// HandleIncoming implements channels.IncomingMessageHandler.
+func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	_ = ctx
+	if msg == nil {
+		return "", nil
+	}
+
+	data, ok := msg.Data.(map[string]interface{})
+	if !ok {
+		return "", nil
+	}
+
+	channel, _ := data["channel"].(string)
+	if channel != "telegram" {
+		return "", nil
+	}
+
+	text, _ := data["text"].(string)
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return "", nil
+	}
+
+	return fmt.Sprintf("echo: %s", text), nil
 }

--- a/internal/channels/handler.go
+++ b/internal/channels/handler.go
@@ -1,0 +1,13 @@
+package channels
+
+import (
+	"context"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+// IncomingMessageHandler handles inbound channel messages and returns an optional reply.
+// Channel implementations are responsible for delivering the reply back to the user.
+type IncomingMessageHandler interface {
+	HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error)
+}

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -10,13 +10,23 @@ import (
 
 // Manager starts and stops configured channels.
 type Manager struct {
-	cfg      *config.ChannelsConfig
+	cfg     *config.ChannelsConfig
+	handler IncomingMessageHandler
+
 	telegram *TelegramBot
 }
 
 // NewManager creates a new channel manager.
 func NewManager(cfg *config.ChannelsConfig) *Manager {
 	return &Manager{cfg: cfg}
+}
+
+// SetHandler sets the inbound message handler used by channels.
+func (m *Manager) SetHandler(handler IncomingMessageHandler) {
+	m.handler = handler
+	if m.telegram != nil {
+		m.telegram.SetHandler(handler)
+	}
 }
 
 // Start starts configured channels.
@@ -41,6 +51,7 @@ func (m *Manager) Start(ctx context.Context) error {
 			m.cfg.Telegram.WebhookPublicURL,
 			m.cfg.Telegram.WebhookSecretToken,
 		)
+		bot.SetHandler(m.handler)
 
 		m.telegram = bot
 		if err := bot.Start(ctx); err != nil {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -39,6 +39,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	// Initialize agent manager
 	agentManager := agent.NewManager(cfg.Agents)
 	agentManager.ChannelManager = channelManager
+	channelManager.SetHandler(agentManager)
 
 	return &Server{
 		config: cfg,


### PR DESCRIPTION
Addresses Issue #1 (oh-my-code integration path) by wiring inbound Telegram messages into the agent runtime stub.

## What
- Introduce `channels.IncomingMessageHandler` interface (returns optional reply string).
- Wire `gateway.NewServer` to set the handler: `channelManager.SetHandler(agentManager)`.
- Telegram bot now calls the handler for non-command messages; falls back to local echo if no handler.
- Agent manager implements `HandleIncoming` (currently returns `echo: <text>` as MVP).
- Include `chat_id` in the protocol data for downstream routing.

## Why
This moves Telegram from "receive+echo in channel" → "receive → agent runtime → reply" (minimal end-to-end routing), which is a prerequisite for oh-my-code integration.

## Test
- `gofmt` + `go test ./...`
