### PR TITLE
feat(telegram): add polling mode (getUpdates)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,18 @@ channels:
     allowedUsers:
       - 1234567890
 
-    # Optional: start a local webhook server
-    webhookListenAddr: "0.0.0.0:18790"
-    webhookPath: "/telegram/webhook"
+    # Recommended: long polling (local/dev friendly)
+    mode: "polling"
+    pollingTimeoutSeconds: 25
+    pollingLimit: 100
+    pollingOffsetFile: "./workspace/telegram.offset"
 
-    # Optional: register webhook with Telegram on startup
-    webhookPublicURL: "https://your-domain.example/telegram/webhook"
-    webhookSecretToken: "replace-with-random-secret"
+    # Optional: webhook mode (public HTTPS required)
+    # mode: "webhook"
+    # webhookListenAddr: "0.0.0.0:18790"
+    # webhookPath: "/telegram/webhook"
+    # webhookPublicURL: "https://your-domain.example/telegram/webhook"
+    # webhookSecretToken: "replace-with-random-secret"
 
 agents:
   workspace: ./workspace

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -19,17 +19,29 @@ channels:
     allowedUsers:
       - 1234567890
 
-    # Webhook server (local)
+    # Mode controls how FractalBot receives Telegram updates.
+    # - polling: long polling via getUpdates (recommended for local/dev)
+    # - webhook: Telegram calls your HTTPS endpoint
+    # If empty, FractalBot auto-selects (webhook if webhook* configured, else polling).
+    mode: "polling"
+
+    # Long polling settings (only used in mode: polling)
+    pollingTimeoutSeconds: 25
+    pollingLimit: 100
+    # Persist next update offset (UpdateID+1) to avoid re-processing after restart
+    pollingOffsetFile: "./workspace/telegram.offset"
+
+    # Webhook server (local) (only used in mode: webhook)
     # If empty, webhook server will not start.
-    webhookListenAddr: "0.0.0.0:18790"
+    webhookListenAddr: ""
     webhookPath: "/telegram/webhook"
 
-    # Webhook registration (Telegram)
+    # Webhook registration (Telegram) (only used in mode: webhook)
     # If set, FractalBot will call Telegram setWebhook() on startup.
     # Must be publicly reachable HTTPS URL.
-    webhookPublicURL: "https://your-domain.example/telegram/webhook"
+    webhookPublicURL: ""
     # Verified via header: X-Telegram-Bot-Api-Secret-Token
-    webhookSecretToken: "replace-with-random-secret"
+    webhookSecretToken: ""
 
   # Slack channel configuration (optional)
   slack:

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -45,6 +45,12 @@ func (m *Manager) Start(ctx context.Context) error {
 			return fmt.Errorf("failed to init telegram bot: %w", err)
 		}
 
+		bot.ConfigureMode(m.cfg.Telegram.Mode)
+		bot.ConfigurePolling(
+			m.cfg.Telegram.PollingTimeoutSeconds,
+			m.cfg.Telegram.PollingLimit,
+			m.cfg.Telegram.PollingOffsetFile,
+		)
 		bot.ConfigureWebhook(
 			m.cfg.Telegram.WebhookListenAddr,
 			m.cfg.Telegram.WebhookPath,

--- a/internal/channels/telegram_polling_test.go
+++ b/internal/channels/telegram_polling_test.go
@@ -1,0 +1,76 @@
+package channels
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTelegramPollingOffset_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	bot, err := NewTelegramBot("token", nil, 0)
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	dir := t.TempDir()
+	bot.pollingOffsetFile = filepath.Join(dir, "telegram.offset")
+
+	if err := bot.loadPollingOffset(); err != nil {
+		t.Fatalf("loadPollingOffset: %v", err)
+	}
+	if bot.nextUpdateID != 0 {
+		t.Fatalf("expected nextUpdateID=0, got %d", bot.nextUpdateID)
+	}
+}
+
+func TestTelegramPollingOffset_LoadsValue(t *testing.T) {
+	t.Parallel()
+
+	bot, err := NewTelegramBot("token", nil, 0)
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "telegram.offset")
+	if err := os.WriteFile(path, []byte("42\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	bot.pollingOffsetFile = path
+
+	if err := bot.loadPollingOffset(); err != nil {
+		t.Fatalf("loadPollingOffset: %v", err)
+	}
+	if bot.nextUpdateID != 42 {
+		t.Fatalf("expected nextUpdateID=42, got %d", bot.nextUpdateID)
+	}
+}
+
+func TestTelegramPollingOffset_PersistsValue(t *testing.T) {
+	t.Parallel()
+
+	bot, err := NewTelegramBot("token", nil, 0)
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "state", "telegram.offset")
+	bot.pollingOffsetFile = path
+	bot.nextUpdateID = 99
+
+	if err := bot.persistPollingOffset(); err != nil {
+		t.Fatalf("persistPollingOffset: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	got := string(data)
+	if got != "99\n" {
+		t.Fatalf("expected file content %q, got %q", "99\n", got)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,17 @@ type TelegramConfig struct {
 	AllowedUsers []int64 `yaml:"allowedUsers,omitempty"`
 	AdminID      int64   `yaml:"adminID,omitempty"`
 
+	// Mode controls how FractalBot receives Telegram updates.
+	// Supported values: "polling", "webhook". Empty means auto.
+	Mode string `yaml:"mode,omitempty"`
+
+	// PollingTimeoutSeconds is the long polling timeout used by getUpdates().
+	PollingTimeoutSeconds int `yaml:"pollingTimeoutSeconds,omitempty"`
+	// PollingLimit is the maximum number of updates returned per request.
+	PollingLimit int `yaml:"pollingLimit,omitempty"`
+	// PollingOffsetFile persists the next update offset (UpdateID+1).
+	PollingOffsetFile string `yaml:"pollingOffsetFile,omitempty"`
+
 	// WebhookListenAddr is the local bind address for receiving webhooks.
 	// Example: "0.0.0.0:18790".
 	WebhookListenAddr string `yaml:"webhookListenAddr,omitempty"`


### PR DESCRIPTION
Implements Telegram long polling mode for local/dev usage.

- Adds `channels.telegram.mode` (polling|webhook|auto)
- Adds polling settings: `pollingTimeoutSeconds`, `pollingLimit`, `pollingOffsetFile`
- On polling startup, calls `deleteWebhook()` to avoid webhook/getUpdates conflict
- Persists UpdateID offset to file to prevent re-processing after restart
- Refactors update handling so webhook + polling share the same path
- Updates `config.example.yaml` and README

Related: #1