### PR TITLE
feat(oh-my-code): route Telegram messages via agent-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ channels:
 agents:
   workspace: ./workspace
   maxConcurrent: 4
+
+  # Optional: route Telegram messages to oh-my-code agent-manager
+  # (requires python3 + tmux + agent-manager installed in that workspace)
+  ohMyCode:
+    enabled: false
+    workspace: "/home/elliot245/workspace/elliot245/oh-my-code"
+    defaultAgent: "qa-1"
 ```
 
 ### Running the Gateway

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -60,3 +60,15 @@ agents:
   workspace: ./workspace
   # Maximum concurrent agent sessions
   maxConcurrent: 4
+
+  # Optional: oh-my-code integration (route Telegram messages to agent-manager)
+  ohMyCode:
+    enabled: false
+    # Path to the oh-my-code repository
+    workspace: "/home/elliot245/workspace/elliot245/oh-my-code"
+    # Optional override (relative to workspace or absolute)
+    agentManagerScript: ".claude/skills/agent-manager/scripts/main.py"
+    # Which agent receives Telegram messages by default
+    defaultAgent: "qa-1"
+    # How long to wait for agent-manager output
+    assignTimeoutSeconds: 90

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -1,14 +1,26 @@
 package agent
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+const (
+	defaultOhMyCodeAgentManagerScript = ".claude/skills/agent-manager/scripts/main.py"
+	defaultOhMyCodeDefaultAgent       = "qa-1"
+	defaultOhMyCodeAssignTimeout      = 90 * time.Second
+	maxTelegramReplyChars             = 3500
 )
 
 // Manager is a minimal stub for agent lifecycle management.
@@ -53,7 +65,6 @@ func (m *Manager) List() []protocol.AgentInfo {
 
 // HandleIncoming implements channels.IncomingMessageHandler.
 func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
-	_ = ctx
 	if msg == nil {
 		return "", nil
 	}
@@ -74,5 +85,103 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 		return "", nil
 	}
 
+	if m.isOhMyCodeEnabled() {
+		out, err := m.assignOhMyCode(ctx, text)
+		if err != nil {
+			return "", err
+		}
+		return truncateTelegramReply(out), nil
+	}
+
 	return fmt.Sprintf("echo: %s", text), nil
+}
+
+func (m *Manager) isOhMyCodeEnabled() bool {
+	if m.config == nil || m.config.OhMyCode == nil {
+		return false
+	}
+	if !m.config.OhMyCode.Enabled {
+		return false
+	}
+	return strings.TrimSpace(m.config.OhMyCode.Workspace) != ""
+}
+
+func (m *Manager) assignOhMyCode(ctx context.Context, userText string) (string, error) {
+	if m.config == nil || m.config.OhMyCode == nil {
+		return "", errors.New("agents.ohMyCode is not configured")
+	}
+
+	workspace := strings.TrimSpace(m.config.OhMyCode.Workspace)
+	if workspace == "" {
+		return "", errors.New("agents.ohMyCode.workspace is required")
+	}
+
+	script := strings.TrimSpace(m.config.OhMyCode.AgentManagerScript)
+	if script == "" {
+		script = defaultOhMyCodeAgentManagerScript
+	}
+	if !filepath.IsAbs(script) {
+		script = filepath.Join(workspace, script)
+	}
+
+	agentName := strings.TrimSpace(m.config.OhMyCode.DefaultAgent)
+	if agentName == "" {
+		agentName = defaultOhMyCodeDefaultAgent
+	}
+
+	timeout := defaultOhMyCodeAssignTimeout
+	if m.config.OhMyCode.AssignTimeoutSeconds > 0 {
+		timeout = time.Duration(m.config.OhMyCode.AssignTimeoutSeconds) * time.Second
+	}
+
+	assignCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		assignCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(assignCtx, "python3", script, "assign", agentName)
+	cmd.Dir = workspace
+
+	prompt := buildOhMyCodeTaskPrompt(userText)
+	cmd.Stdin = strings.NewReader(prompt)
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err != nil {
+		errText := strings.TrimSpace(stderr.String())
+		if errText == "" {
+			errText = strings.TrimSpace(stdout.String())
+		}
+		if errText != "" {
+			return "", fmt.Errorf("oh-my-code agent-manager failed: %s", errText)
+		}
+		return "", fmt.Errorf("oh-my-code agent-manager failed: %w", err)
+	}
+
+	out := strings.TrimSpace(stdout.String())
+	if out == "" {
+		out = strings.TrimSpace(stderr.String())
+	}
+	if out == "" {
+		return "", nil
+	}
+	return out, nil
+}
+
+func buildOhMyCodeTaskPrompt(userText string) string {
+	return fmt.Sprintf("Telegram user message:\n%s\n", strings.TrimSpace(userText))
+}
+
+func truncateTelegramReply(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= maxTelegramReplyChars {
+		return text
+	}
+	return strings.TrimSpace(text[:maxTelegramReplyChars]) + "\n…(truncated)"
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,10 +70,32 @@ type DiscordConfig struct {
 	Token   string `yaml:"token,omitempty"`
 }
 
+// OhMyCodeConfig contains integration settings for the oh-my-code workspace.
+// This is a minimal bridge to route Telegram messages to the oh-my-code agent-manager.
+type OhMyCodeConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+
+	// Workspace is the path to the oh-my-code repository.
+	// Example: "/home/elliot245/workspace/elliot245/oh-my-code".
+	Workspace string `yaml:"workspace,omitempty"`
+
+	// AgentManagerScript is the path (relative to Workspace or absolute) to the agent-manager entrypoint.
+	// Default: ".claude/skills/agent-manager/scripts/main.py".
+	AgentManagerScript string `yaml:"agentManagerScript,omitempty"`
+
+	// DefaultAgent is the agent name to assign tasks to when a Telegram message is received.
+	// Example: "qa-1".
+	DefaultAgent string `yaml:"defaultAgent,omitempty"`
+
+	// AssignTimeoutSeconds limits how long we wait for agent-manager output.
+	AssignTimeoutSeconds int `yaml:"assignTimeoutSeconds,omitempty"`
+}
+
 // AgentsConfig contains agent runtime settings.
 type AgentsConfig struct {
-	Workspace     string `yaml:"workspace"`
-	MaxConcurrent int    `yaml:"maxConcurrent"`
+	Workspace     string          `yaml:"workspace"`
+	MaxConcurrent int             `yaml:"maxConcurrent"`
+	OhMyCode      *OhMyCodeConfig `yaml:"ohMyCode,omitempty"`
 }
 
 // LoadConfig loads configuration from file.


### PR DESCRIPTION
Adds a minimal integration to route Telegram messages to the `oh-my-code` workspace via `agent-manager`.

- New config: `agents.ohMyCode` (enabled/workspace/defaultAgent/agentManagerScript/assignTimeoutSeconds)
- `internal/agent.Manager` runs: `python3 <agentManagerScript> assign <defaultAgent>` with message text on stdin
- Output is returned to Telegram (truncated to avoid Telegram length limits)
- Updates `config.example.yaml` + README

Related: #1
