### PR TITLE
Add Telegram agent selection + allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,12 @@ agents:
     enabled: false
     workspace: "/home/elliot245/workspace/elliot245/oh-my-code"
     defaultAgent: "qa-1"
+    allowedAgents:
+      - "qa-1"
+      - "coder-a"
 ```
+
+Telegram supports `/agent <name> <task...>` to route tasks to a specific agent; if omitted, `defaultAgent` is used. When `allowedAgents` is set, only those names are accepted.
 
 ### Running the Gateway
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -70,5 +70,9 @@ agents:
     agentManagerScript: ".claude/skills/agent-manager/scripts/main.py"
     # Which agent receives Telegram messages by default
     defaultAgent: "qa-1"
+    # Optional allowlist for /agent routing (defaults to only defaultAgent)
+    allowedAgents:
+      - "qa-1"
+      - "coder-a"
     # How long to wait for agent-manager output
     assignTimeoutSeconds: 90

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -92,7 +92,8 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 	}
 
 	if m.isOhMyCodeEnabled() {
-		out, err := m.assignOhMyCode(ctx, text)
+		agentName, _ := data["agent"].(string)
+		out, err := m.assignOhMyCode(ctx, text, agentName)
 		if err != nil {
 			return "", err
 		}
@@ -112,7 +113,7 @@ func (m *Manager) isOhMyCodeEnabled() bool {
 	return strings.TrimSpace(m.config.OhMyCode.Workspace) != ""
 }
 
-func (m *Manager) assignOhMyCode(ctx context.Context, userText string) (string, error) {
+func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride string) (string, error) {
 	if m.config == nil || m.config.OhMyCode == nil {
 		return "", errors.New("agents.ohMyCode is not configured")
 	}
@@ -130,9 +131,12 @@ func (m *Manager) assignOhMyCode(ctx context.Context, userText string) (string, 
 		script = filepath.Join(workspace, script)
 	}
 
-	agentName := strings.TrimSpace(m.config.OhMyCode.DefaultAgent)
+	agentName := strings.TrimSpace(agentOverride)
 	if agentName == "" {
-		agentName = defaultOhMyCodeDefaultAgent
+		agentName = strings.TrimSpace(m.config.OhMyCode.DefaultAgent)
+		if agentName == "" {
+			agentName = defaultOhMyCodeDefaultAgent
+		}
 	}
 
 	timeout := defaultOhMyCodeAssignTimeout

--- a/internal/channels/agent_selection.go
+++ b/internal/channels/agent_selection.go
@@ -1,0 +1,119 @@
+package channels
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var agentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
+
+// AgentSelection describes the resolved target agent and task text.
+type AgentSelection struct {
+	Agent     string
+	Task      string
+	Specified bool
+}
+
+// AgentAllowlist enforces allowed agent names.
+type AgentAllowlist struct {
+	configured bool
+	allowed    map[string]struct{}
+}
+
+// NewAgentAllowlist builds an allowlist from configured names.
+func NewAgentAllowlist(names []string) AgentAllowlist {
+	allowed := make(map[string]struct{})
+	for _, name := range names {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		allowed[trimmed] = struct{}{}
+	}
+	return AgentAllowlist{configured: len(allowed) > 0, allowed: allowed}
+}
+
+// ParseAgentSelection extracts a target agent and task from chat text.
+// Supported syntax: /agent <name> <task...>
+func ParseAgentSelection(text string) (AgentSelection, error) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return AgentSelection{Task: ""}, nil
+	}
+
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return AgentSelection{Task: ""}, nil
+	}
+
+	first := fields[0]
+	if strings.HasPrefix(first, "/agent") {
+		command := first
+		if idx := strings.IndexByte(command, '@'); idx != -1 {
+			command = command[:idx]
+		}
+		if command != "/agent" {
+			return AgentSelection{Task: trimmed}, nil
+		}
+		if len(fields) < 3 {
+			return AgentSelection{}, fmt.Errorf("usage: /agent <name> <task>")
+		}
+		return AgentSelection{
+			Agent:     fields[1],
+			Task:      strings.Join(fields[2:], " "),
+			Specified: true,
+		}, nil
+	}
+
+	return AgentSelection{Task: trimmed}, nil
+}
+
+// ResolveAgentSelection applies defaults and allowlist validation.
+func ResolveAgentSelection(selection AgentSelection, defaultAgent string, allowlist AgentAllowlist) (AgentSelection, error) {
+	agent := strings.TrimSpace(selection.Agent)
+	if !selection.Specified {
+		agent = strings.TrimSpace(defaultAgent)
+		if agent == "" {
+			return AgentSelection{}, fmt.Errorf("default agent is not configured")
+		}
+	}
+
+	if err := ValidateAgentName(agent); err != nil {
+		return AgentSelection{}, err
+	}
+
+	if err := allowlist.Validate(agent, defaultAgent); err != nil {
+		return AgentSelection{}, err
+	}
+
+	selection.Agent = agent
+	return selection, nil
+}
+
+// ValidateAgentName enforces allowed agent naming.
+func ValidateAgentName(name string) error {
+	if !agentNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid agent name %q", name)
+	}
+	return nil
+}
+
+// Validate ensures the agent is allowed per configuration.
+func (a AgentAllowlist) Validate(agentName, defaultAgent string) error {
+	if a.configured {
+		if _, ok := a.allowed[agentName]; !ok {
+			return fmt.Errorf("agent %q is not allowed", agentName)
+		}
+		return nil
+	}
+
+	defaultName := strings.TrimSpace(defaultAgent)
+	if defaultName == "" {
+		return fmt.Errorf("default agent is not configured")
+	}
+	if agentName != defaultName {
+		return fmt.Errorf("agent %q is not allowed", agentName)
+	}
+	return nil
+}

--- a/internal/channels/agent_selection_test.go
+++ b/internal/channels/agent_selection_test.go
@@ -1,0 +1,101 @@
+package channels
+
+import "testing"
+
+func TestParseAgentSelection(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectTask  string
+		expectAgent string
+		specified   bool
+		expectErr   bool
+	}{
+		{
+			name:        "agent command",
+			input:       "/agent coder-a do the thing",
+			expectAgent: "coder-a",
+			expectTask:  "do the thing",
+			specified:   true,
+		},
+		{
+			name:        "agent command with bot",
+			input:       "/agent@bot coder_b run",
+			expectAgent: "coder_b",
+			expectTask:  "run",
+			specified:   true,
+		},
+		{
+			name:       "plain text",
+			input:      "hello world",
+			expectTask: "hello world",
+			specified:  false,
+		},
+		{
+			name:      "missing task",
+			input:     "/agent coder",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selection, err := ParseAgentSelection(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if selection.Task != tt.expectTask {
+				t.Fatalf("task mismatch: got %q want %q", selection.Task, tt.expectTask)
+			}
+			if selection.Agent != tt.expectAgent {
+				t.Fatalf("agent mismatch: got %q want %q", selection.Agent, tt.expectAgent)
+			}
+			if selection.Specified != tt.specified {
+				t.Fatalf("specified mismatch: got %v want %v", selection.Specified, tt.specified)
+			}
+		})
+	}
+}
+
+func TestResolveAgentSelection(t *testing.T) {
+	allowlist := NewAgentAllowlist([]string{"coder-a", "coder_b"})
+
+	selection := AgentSelection{Task: "do it"}
+	resolved, err := ResolveAgentSelection(selection, "coder-a", allowlist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Agent != "coder-a" {
+		t.Fatalf("expected default agent, got %q", resolved.Agent)
+	}
+
+	selection = AgentSelection{Agent: "coder_b", Task: "go", Specified: true}
+	resolved, err = ResolveAgentSelection(selection, "coder-a", allowlist)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resolved.Agent != "coder_b" {
+		t.Fatalf("expected specified agent, got %q", resolved.Agent)
+	}
+
+	selection = AgentSelection{Agent: "coder-x", Task: "go", Specified: true}
+	if _, err := ResolveAgentSelection(selection, "coder-a", allowlist); err == nil {
+		t.Fatalf("expected allowlist error")
+	}
+
+	selection = AgentSelection{Task: "go"}
+	if _, err := ResolveAgentSelection(selection, "", NewAgentAllowlist(nil)); err == nil {
+		t.Fatalf("expected default agent error")
+	}
+
+	selection = AgentSelection{Agent: "-bad", Task: "go", Specified: true}
+	if _, err := ResolveAgentSelection(selection, "coder-a", allowlist); err == nil {
+		t.Fatalf("expected name validation error")
+	}
+}

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -10,15 +10,16 @@ import (
 
 // Manager starts and stops configured channels.
 type Manager struct {
-	cfg     *config.ChannelsConfig
-	handler IncomingMessageHandler
+	cfg       *config.ChannelsConfig
+	agentsCfg *config.AgentsConfig
+	handler   IncomingMessageHandler
 
 	telegram *TelegramBot
 }
 
 // NewManager creates a new channel manager.
-func NewManager(cfg *config.ChannelsConfig) *Manager {
-	return &Manager{cfg: cfg}
+func NewManager(cfg *config.ChannelsConfig, agentsCfg *config.AgentsConfig) *Manager {
+	return &Manager{cfg: cfg, agentsCfg: agentsCfg}
 }
 
 // SetHandler sets the inbound message handler used by channels.
@@ -40,7 +41,13 @@ func (m *Manager) Start(ctx context.Context) error {
 			return errors.New("channels.telegram.botToken is required when telegram is enabled")
 		}
 
-		bot, err := NewTelegramBot(m.cfg.Telegram.BotToken, m.cfg.Telegram.AllowedUsers, m.cfg.Telegram.AdminID)
+		var defaultAgent string
+		var allowedAgents []string
+		if m.agentsCfg != nil && m.agentsCfg.OhMyCode != nil {
+			defaultAgent = m.agentsCfg.OhMyCode.DefaultAgent
+			allowedAgents = m.agentsCfg.OhMyCode.AllowedAgents
+		}
+		bot, err := NewTelegramBot(m.cfg.Telegram.BotToken, m.cfg.Telegram.AllowedUsers, m.cfg.Telegram.AdminID, defaultAgent, allowedAgents)
 		if err != nil {
 			return fmt.Errorf("failed to init telegram bot: %w", err)
 		}

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -28,7 +28,9 @@ const (
 
 // TelegramBot implements Telegram channel.
 type TelegramBot struct {
-	botToken string
+	botToken       string
+	defaultAgent   string
+	agentAllowlist AgentAllowlist
 
 	handler     IncomingMessageHandler
 	userManager *UserManager
@@ -56,7 +58,7 @@ type TelegramBot struct {
 }
 
 // NewTelegramBot creates a new Telegram bot instance.
-func NewTelegramBot(token string, allowedUsers []int64, adminID int64) (*TelegramBot, error) {
+func NewTelegramBot(token string, allowedUsers []int64, adminID int64, defaultAgent string, allowedAgents []string) (*TelegramBot, error) {
 	if strings.TrimSpace(token) == "" {
 		return nil, errors.New("telegram bot token is required")
 	}
@@ -68,6 +70,8 @@ func NewTelegramBot(token string, allowedUsers []int64, adminID int64) (*Telegra
 
 	return &TelegramBot{
 		botToken:       token,
+		defaultAgent:   strings.TrimSpace(defaultAgent),
+		agentAllowlist: NewAgentAllowlist(allowedAgents),
 		userManager:    userManager,
 		adminID:        adminID,
 		webhookPath:    defaultTelegramWebhookPath,
@@ -512,7 +516,21 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 		return
 	}
 
-	msg := b.convertToProtocolMessage(message)
+	selection, err := ParseAgentSelection(message.Text)
+	if err != nil {
+		_ = b.SendMessage(b.ctx, message.Chat.ID, fmt.Sprintf("❌ %v", err))
+		return
+	}
+	if strings.TrimSpace(selection.Task) == "" {
+		return
+	}
+	selection, err = ResolveAgentSelection(selection, b.defaultAgent, b.agentAllowlist)
+	if err != nil {
+		_ = b.SendMessage(b.ctx, message.Chat.ID, fmt.Sprintf("❌ %v", err))
+		return
+	}
+
+	msg := b.convertToProtocolMessage(message, selection.Task, selection.Agent)
 
 	if b.handler != nil {
 		replyText, err := b.handler.HandleIncoming(b.ctx, msg)
@@ -526,8 +544,8 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 		return
 	}
 
-	if message.Text != "" {
-		reply := fmt.Sprintf("echo: %s", message.Text)
+	if selection.Task != "" {
+		reply := fmt.Sprintf("echo: %s", selection.Task)
 		_ = b.SendMessage(b.ctx, message.Chat.ID, reply)
 	}
 }
@@ -549,6 +567,9 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 	command := parts[0]
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
+	}
+	if command == "/agent" {
+		return false, nil
 	}
 
 	requireAdmin := func() error {
@@ -661,13 +682,14 @@ type TelegramChat struct {
 	ID int64 `json:"id"`
 }
 
-func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage) *protocol.Message {
+func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent string) *protocol.Message {
 	return &protocol.Message{
 		Kind:   protocol.MessageKindChannel,
 		Action: protocol.ActionCreate,
 		Data: map[string]interface{}{
 			"channel":  "telegram",
-			"text":     msg.Text,
+			"text":     text,
+			"agent":    agent,
 			"chat_id":  msg.Chat.ID,
 			"user_id":  msg.From.ID,
 			"username": msg.From.UserName,

--- a/internal/channels/telegram_polling_test.go
+++ b/internal/channels/telegram_polling_test.go
@@ -9,7 +9,7 @@ import (
 func TestTelegramPollingOffset_MissingFile(t *testing.T) {
 	t.Parallel()
 
-	bot, err := NewTelegramBot("token", nil, 0)
+	bot, err := NewTelegramBot("token", nil, 0, "", nil)
 	if err != nil {
 		t.Fatalf("NewTelegramBot: %v", err)
 	}
@@ -28,7 +28,7 @@ func TestTelegramPollingOffset_MissingFile(t *testing.T) {
 func TestTelegramPollingOffset_LoadsValue(t *testing.T) {
 	t.Parallel()
 
-	bot, err := NewTelegramBot("token", nil, 0)
+	bot, err := NewTelegramBot("token", nil, 0, "", nil)
 	if err != nil {
 		t.Fatalf("NewTelegramBot: %v", err)
 	}
@@ -51,7 +51,7 @@ func TestTelegramPollingOffset_LoadsValue(t *testing.T) {
 func TestTelegramPollingOffset_PersistsValue(t *testing.T) {
 	t.Parallel()
 
-	bot, err := NewTelegramBot("token", nil, 0)
+	bot, err := NewTelegramBot("token", nil, 0, "", nil)
 	if err != nil {
 		t.Fatalf("NewTelegramBot: %v", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,10 @@ type OhMyCodeConfig struct {
 	// Example: "qa-1".
 	DefaultAgent string `yaml:"defaultAgent,omitempty"`
 
+	// AllowedAgents restricts which agents can be targeted by Telegram messages.
+	// If empty, only DefaultAgent is allowed.
+	AllowedAgents []string `yaml:"allowedAgents,omitempty"`
+
 	// AssignTimeoutSeconds limits how long we wait for agent-manager output.
 	AssignTimeoutSeconds int `yaml:"assignTimeoutSeconds,omitempty"`
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -34,7 +34,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	}
 
 	// Initialize channels
-	channelManager := channels.NewManager(cfg.Channels)
+	channelManager := channels.NewManager(cfg.Channels, cfg.Agents)
 
 	// Initialize agent manager
 	agentManager := agent.NewManager(cfg.Agents)


### PR DESCRIPTION
## Summary\n- add Telegram /agent routing with allowlist + default agent enforcement\n- pass selected agent into oh-my-code assignment flow\n- add unit tests and update config/docs\n\nRefs #1