### PR TITLE
Add runnable fractalbot entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ fractalbot-*
 *.dll
 *.so
 *.dylib
+!cmd/fractalbot/
+!cmd/fractalbot/**
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+	"github.com/fractalmind-ai/fractalbot/internal/gateway"
+)
+
+func main() {
+	configPath := flag.String("config", "./config.yaml", "path to config file")
+	portOverride := flag.Int("port", 0, "override gateway port")
+	verbose := flag.Bool("verbose", false, "enable verbose logging")
+	flag.Parse()
+
+	if *verbose {
+		log.SetFlags(log.LstdFlags | log.Lshortfile)
+	}
+
+	cfg, err := config.LoadConfig(*configPath)
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	if cfg.Gateway == nil {
+		cfg.Gateway = &config.GatewayConfig{Bind: "127.0.0.1", Port: 18789}
+	}
+	if *portOverride > 0 {
+		cfg.Gateway.Port = *portOverride
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server, err := gateway.NewServer(cfg)
+	if err != nil {
+		log.Fatalf("failed to initialize gateway: %v", err)
+	}
+
+	if err := server.Start(ctx); err != nil {
+		log.Printf("gateway error: %v", err)
+	}
+
+	if err := server.Stop(); err != nil {
+		log.Printf("gateway shutdown error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary\n- add minimal cmd/fractalbot CLI to load config and run gateway\n- allow optional --config and --port overrides, plus --verbose logging\n- unignore cmd/fractalbot in .gitignore for source inclusion\n\n## Run\n- make build && ./fractalbot --config ./config.yaml\n- make run (uses ./cmd/fractalbot)\n\n## Testing\n- go test ./...\n\nRefs #4 (enables 可体验版本)