### PR TITLE
Add Telegram /help for demo polish

### DIFF
--- a/internal/channels/agent_selection.go
+++ b/internal/channels/agent_selection.go
@@ -3,6 +3,7 @@ package channels
 import (
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -116,4 +117,17 @@ func (a AgentAllowlist) Validate(agentName, defaultAgent string) error {
 		return fmt.Errorf("agent %q is not allowed", agentName)
 	}
 	return nil
+}
+
+// Names returns the configured allowlist names in sorted order.
+func (a AgentAllowlist) Names() []string {
+	if !a.configured {
+		return nil
+	}
+	names := make([]string, 0, len(a.allowed))
+	for name := range a.allowed {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -608,6 +608,9 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 	}
 
 	switch command {
+	case "/help", "/start":
+		return true, b.SendMessage(b.ctx, msg.Chat.ID, b.helpText())
+
 	case "/adduser":
 		if err := requireAdmin(); err != nil {
 			return true, err
@@ -663,6 +666,31 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 	default:
 		return true, fmt.Errorf("unknown command: %s", command)
 	}
+}
+
+func (b *TelegramBot) helpText() string {
+	var sb strings.Builder
+	sb.WriteString("FractalBot Telegram Help\n")
+	sb.WriteString("\n")
+	sb.WriteString("Commands:\n")
+	sb.WriteString("  /help - show this help\n")
+	sb.WriteString("  /status - bot status\n")
+	sb.WriteString("  /adduser <user_id> - admin only\n")
+	sb.WriteString("  /removeuser <user_id> - admin only\n")
+	sb.WriteString("  /listusers - admin only\n")
+	sb.WriteString("\n")
+	sb.WriteString("Agent routing:\n")
+	sb.WriteString("  /agent <name> <task...>\n")
+	if b.defaultAgent != "" {
+		sb.WriteString(fmt.Sprintf("Default agent: %s\n", b.defaultAgent))
+	}
+	if names := b.agentAllowlist.Names(); len(names) > 0 {
+		sb.WriteString("Allowed agents:\n")
+		for _, name := range names {
+			sb.WriteString(fmt.Sprintf("  - %s\n", name))
+		}
+	}
+	return strings.TrimSpace(sb.String())
 }
 
 func splitCommand(text string) []string {

--- a/internal/channels/telegram_help_test.go
+++ b/internal/channels/telegram_help_test.go
@@ -1,0 +1,24 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTelegramHelpTextIncludesAgentInfo(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 0, "qa-1", []string{"qa-1", "coder-a"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	text := bot.helpText()
+	if !strings.Contains(text, "/agent <name> <task") {
+		t.Fatalf("expected help text to include /agent usage")
+	}
+	if !strings.Contains(text, "Default agent: qa-1") {
+		t.Fatalf("expected help text to include default agent")
+	}
+	if !strings.Contains(text, "coder-a") {
+		t.Fatalf("expected help text to include allowed agent")
+	}
+}


### PR DESCRIPTION
## Summary\n- add /help and /start responses to document Telegram usage\n- include allowlist/default agent details in help output\n- add a unit test for help text content\n\n## Manual Testing\n1) Run the gateway with Telegram enabled and oh-my-code configured.\n2) Send /help or /start in Telegram and confirm help output includes /agent usage and allowed agents.\n\n## Automated Testing\n- go test ./...\n\nRefs #1