### PR TITLE
feat: Telegram agent lifecycle commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ agents:
 ```
 
 Telegram supports `/agent <name> <task...>` to route tasks to a specific agent; if omitted, `defaultAgent` is used. When `allowedAgents` is set, only those names are accepted.
+Additional lifecycle commands:
+- `/agents` (list allowed agent names)
+- `/monitor <name> [lines]` (show recent agent output; lines capped to 200)
+- `/startagent <name>` (admin only)
+- `/stopagent <name>` (admin only)
+- `/doctor` (admin only)
 
 ### Local Demo (Telegram + polling + oh-my-code)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -77,3 +77,9 @@ agents:
       - "coder-a"
     # How long to wait for agent-manager output
     assignTimeoutSeconds: 90
+    # Telegram lifecycle commands:
+    # - /agents (list allowed agent names)
+    # - /monitor <name> [lines] (show recent output, capped at 200 lines)
+    # - /startagent <name> (admin only)
+    # - /stopagent <name> (admin only)
+    # - /doctor (admin only)

--- a/internal/channels/handler.go
+++ b/internal/channels/handler.go
@@ -11,3 +11,11 @@ import (
 type IncomingMessageHandler interface {
 	HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error)
 }
+
+// AgentLifecycle enables channel commands to manage agent-manager processes.
+type AgentLifecycle interface {
+	MonitorAgent(ctx context.Context, agentName string, lines int) (string, error)
+	StartAgent(ctx context.Context, agentName string) (string, error)
+	StopAgent(ctx context.Context, agentName string) (string, error)
+	Doctor(ctx context.Context) (string, error)
+}

--- a/internal/channels/telegram_commands.go
+++ b/internal/channels/telegram_commands.go
@@ -1,0 +1,61 @@
+package channels
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	defaultMonitorLines = 60
+	maxMonitorLines     = 200
+)
+
+func parseMonitorArgs(parts []string) (string, int, error) {
+	if len(parts) < 2 || strings.TrimSpace(parts[1]) == "" {
+		return "", 0, fmt.Errorf("usage: /monitor <name> [lines]")
+	}
+	if len(parts) > 3 {
+		return "", 0, fmt.Errorf("usage: /monitor <name> [lines]")
+	}
+
+	agentName := strings.TrimSpace(parts[1])
+	lines := defaultMonitorLines
+	if len(parts) == 3 {
+		parsed, err := parseMonitorLines(parts[2])
+		if err != nil {
+			return "", 0, err
+		}
+		lines = parsed
+	}
+	if lines > maxMonitorLines {
+		lines = maxMonitorLines
+	}
+	return agentName, lines, nil
+}
+
+func parseMonitorLines(raw string) (int, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return defaultMonitorLines, nil
+	}
+	lines, err := strconv.Atoi(value)
+	if err != nil || lines <= 0 {
+		return 0, fmt.Errorf("invalid lines value %q", raw)
+	}
+	return lines, nil
+}
+
+func validateAgentCommandName(agentName, defaultAgent string, allowlist AgentAllowlist) error {
+	trimmed := strings.TrimSpace(agentName)
+	if trimmed == "" {
+		return fmt.Errorf("agent name is required")
+	}
+	if err := ValidateAgentName(trimmed); err != nil {
+		return err
+	}
+	if err := allowlist.Validate(trimmed, defaultAgent); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/channels/telegram_commands_test.go
+++ b/internal/channels/telegram_commands_test.go
@@ -1,0 +1,137 @@
+package channels
+
+import "testing"
+
+func TestParseMonitorArgs(t *testing.T) {
+	cases := []struct {
+		name      string
+		text      string
+		wantAgent string
+		wantLines int
+		wantErr   bool
+	}{
+		{
+			name:      "default-lines",
+			text:      "/monitor qa-1",
+			wantAgent: "qa-1",
+			wantLines: defaultMonitorLines,
+		},
+		{
+			name:      "explicit-lines",
+			text:      "/monitor qa-1 5",
+			wantAgent: "qa-1",
+			wantLines: 5,
+		},
+		{
+			name:      "cap-lines",
+			text:      "/monitor qa-1 500",
+			wantAgent: "qa-1",
+			wantLines: maxMonitorLines,
+		},
+		{
+			name:    "missing-agent",
+			text:    "/monitor",
+			wantErr: true,
+		},
+		{
+			name:    "invalid-lines",
+			text:    "/monitor qa-1 nope",
+			wantErr: true,
+		},
+		{
+			name:    "zero-lines",
+			text:    "/monitor qa-1 0",
+			wantErr: true,
+		},
+		{
+			name:    "too-many-args",
+			text:    "/monitor qa-1 5 extra",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agent, lines, err := parseMonitorArgs(splitCommand(tc.text))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if agent != tc.wantAgent {
+				t.Fatalf("agent=%q want %q", agent, tc.wantAgent)
+			}
+			if lines != tc.wantLines {
+				t.Fatalf("lines=%d want %d", lines, tc.wantLines)
+			}
+		})
+	}
+}
+
+func TestValidateAgentCommandName(t *testing.T) {
+	cases := []struct {
+		name         string
+		agent        string
+		defaultAgent string
+		allowlist    []string
+		wantErr      bool
+	}{
+		{
+			name:         "allowed-configured",
+			agent:        "coder-a",
+			defaultAgent: "qa-1",
+			allowlist:    []string{"qa-1", "coder-a"},
+		},
+		{
+			name:         "blocked-configured",
+			agent:        "coder-b",
+			defaultAgent: "qa-1",
+			allowlist:    []string{"qa-1", "coder-a"},
+			wantErr:      true,
+		},
+		{
+			name:         "default-only",
+			agent:        "qa-1",
+			defaultAgent: "qa-1",
+		},
+		{
+			name:         "default-only-block",
+			agent:        "coder-a",
+			defaultAgent: "qa-1",
+			wantErr:      true,
+		},
+		{
+			name:         "invalid-name",
+			agent:        "-bad",
+			defaultAgent: "qa-1",
+			allowlist:    []string{"qa-1", "-bad"},
+			wantErr:      true,
+		},
+		{
+			name:         "missing-default",
+			agent:        "qa-1",
+			defaultAgent: "",
+			wantErr:      true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			allowlist := NewAgentAllowlist(tc.allowlist)
+			err := validateAgentCommandName(tc.agent, tc.defaultAgent, allowlist)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/channels/telegram_help_test.go
+++ b/internal/channels/telegram_help_test.go
@@ -15,6 +15,12 @@ func TestTelegramHelpTextIncludesAgentInfo(t *testing.T) {
 	if !strings.Contains(text, "/agent <name> <task") {
 		t.Fatalf("expected help text to include /agent usage")
 	}
+	if !strings.Contains(text, "/agents") {
+		t.Fatalf("expected help text to include /agents command")
+	}
+	if !strings.Contains(text, "/monitor <name>") {
+		t.Fatalf("expected help text to include /monitor command")
+	}
 	if !strings.Contains(text, "Default agent: qa-1") {
 		t.Fatalf("expected help text to include default agent")
 	}

--- a/internal/channels/telegram_utils.go
+++ b/internal/channels/telegram_utils.go
@@ -1,0 +1,14 @@
+package channels
+
+import "strings"
+
+const maxTelegramReplyChars = 3500
+
+// TruncateTelegramReply limits outbound Telegram responses to the max Telegram message size.
+func TruncateTelegramReply(text string) string {
+	text = strings.TrimSpace(text)
+	if len(text) <= maxTelegramReplyChars {
+		return text
+	}
+	return strings.TrimSpace(text[:maxTelegramReplyChars]) + "\n…(truncated)"
+}


### PR DESCRIPTION
Fixes #1.

## Summary
- Add Telegram lifecycle commands for agent-manager (`/agents`, `/monitor`, `/startagent`, `/stopagent`, `/doctor`).
- Enforce allowlist + admin checks; reuse agent-manager runner with safe workspace/script paths.
- Add command parsing/allowlist tests and update docs/config examples.

## How to test
1) `go test ./...`
2) In Telegram:
   - `/agents` shows allowed agents (or default only if allowlist empty).
   - `/monitor qa-1 50` returns the latest agent output (capped to 200 lines).
   - `/startagent qa-1` and `/stopagent qa-1` work for admin only.

## Notes
- All command replies are truncated to Telegram message limits.
