### PR TITLE
feat: optional WebSocket origin allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Create `config.yaml`:
 gateway:
   port: 18789
   bind: 127.0.0.1
+  # Optional: restrict allowed WebSocket origins
+  # allowedOrigins:
+  #   - "http://localhost:3000"
 
 channels:
   telegram:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,9 @@ gateway:
   port: 18789
   # Bind address (127.0.0.1 for local only)
   bind: 127.0.0.1
+  # Optional: restrict allowed WebSocket origins (scheme + host + optional port)
+  # allowedOrigins:
+  #   - "http://localhost:3000"
 
 channels:
   # Telegram channel configuration

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,8 @@ type Config struct {
 type GatewayConfig struct {
 	Port int    `yaml:"port"`
 	Bind string `yaml:"bind"`
+	// AllowedOrigins restricts WebSocket origins. Empty means allow all.
+	AllowedOrigins []string `yaml:"allowedOrigins,omitempty"`
 }
 
 // ChannelsConfig contains channel configurations.

--- a/internal/gateway/origin_test.go
+++ b/internal/gateway/origin_test.go
@@ -1,0 +1,55 @@
+package gateway
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOriginCheckerAllowsAllWhenUnset(t *testing.T) {
+	checker := buildOriginChecker(nil)
+
+	req := httptest.NewRequest("GET", "http://example/ws", nil)
+	if !checker(req) {
+		t.Fatalf("expected allow when allowlist unset")
+	}
+
+	req.Header.Set("Origin", "https://example.com")
+	if !checker(req) {
+		t.Fatalf("expected allow for any origin when allowlist unset")
+	}
+}
+
+func TestOriginCheckerAllowsConfiguredOrigins(t *testing.T) {
+	checker := buildOriginChecker([]string{"https://example.com", "http://localhost:3000"})
+
+	req := httptest.NewRequest("GET", "http://example/ws", nil)
+	req.Header.Set("Origin", "https://example.com")
+	if !checker(req) {
+		t.Fatalf("expected allow for listed origin")
+	}
+
+	req.Header.Set("Origin", "https://example.com/")
+	if !checker(req) {
+		t.Fatalf("expected allow for normalized origin")
+	}
+
+	req.Header.Set("Origin", "https://evil.com")
+	if checker(req) {
+		t.Fatalf("expected reject for unlisted origin")
+	}
+
+	req.Header.Del("Origin")
+	if checker(req) {
+		t.Fatalf("expected reject when origin missing and allowlist configured")
+	}
+}
+
+func TestOriginCheckerRejectsInvalidAllowlist(t *testing.T) {
+	checker := buildOriginChecker([]string{"not a url"})
+
+	req := httptest.NewRequest("GET", "http://example/ws", nil)
+	req.Header.Set("Origin", "https://example.com")
+	if checker(req) {
+		t.Fatalf("expected reject when allowlist invalid")
+	}
+}


### PR DESCRIPTION
Fixes #26.

## Summary
- Add optional WebSocket origin allowlist (opt-in only).
- Add origin check unit tests.
- Document the new config field in README and config.example.

## How to test
1) `go test ./...`
2) Set `gateway.allowedOrigins` and verify non-listed Origin headers are rejected.
