### PR TITLE
feat: add Telegram /whoami

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -612,6 +612,23 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 	case "/help", "/start":
 		return true, b.SendMessage(b.ctx, msg.Chat.ID, b.helpText())
 
+	case "/whoami":
+		username := strings.TrimSpace(msg.From.UserName)
+		if username != "" {
+			username = "@" + username
+		} else {
+			username = "(none)"
+		}
+		isAdmin := b.adminID != 0 && msg.From.ID == b.adminID
+		reply := fmt.Sprintf(
+			"User ID: %d\nUsername: %s\nChat ID: %d\nIs admin: %t",
+			msg.From.ID,
+			username,
+			msg.Chat.ID,
+			isAdmin,
+		)
+		return true, b.SendMessage(b.ctx, msg.Chat.ID, TruncateTelegramReply(reply))
+
 	case "/agents":
 		names := b.agentAllowlist.Names()
 		if len(names) == 0 {
@@ -783,6 +800,7 @@ func (b *TelegramBot) helpText() string {
 	sb.WriteString("\n")
 	sb.WriteString("Commands:\n")
 	sb.WriteString("  /help - show this help\n")
+	sb.WriteString("  /whoami - show your Telegram IDs\n")
 	sb.WriteString("  /status - bot status\n")
 	sb.WriteString("  /agents - list allowed agents\n")
 	sb.WriteString("  /monitor <name> [lines] - show recent agent output\n")

--- a/internal/channels/telegram_help_test.go
+++ b/internal/channels/telegram_help_test.go
@@ -15,6 +15,9 @@ func TestTelegramHelpTextIncludesAgentInfo(t *testing.T) {
 	if !strings.Contains(text, "/agent <name> <task") {
 		t.Fatalf("expected help text to include /agent usage")
 	}
+	if !strings.Contains(text, "/whoami") {
+		t.Fatalf("expected help text to include /whoami command")
+	}
 	if !strings.Contains(text, "/agents") {
 		t.Fatalf("expected help text to include /agents command")
 	}

--- a/internal/channels/telegram_whoami_test.go
+++ b/internal/channels/telegram_whoami_test.go
@@ -1,0 +1,110 @@
+package channels
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+type sendMessagePayload struct {
+	ChatID int64  `json:"chat_id"`
+	Text   string `json:"text"`
+}
+
+func captureHTTPClient(t *testing.T, payload *sendMessagePayload) *http.Client {
+	return &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if err := json.Unmarshal(body, payload); err != nil {
+				t.Fatalf("unmarshal payload: %v", err)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+}
+
+func TestTelegramWhoAmI(t *testing.T) {
+	cases := []struct {
+		name      string
+		userID    int64
+		username  string
+		chatID    int64
+		adminID   int64
+		wantUser  string
+		wantName  string
+		wantChat  string
+		wantAdmin string
+	}{
+		{
+			name:      "admin-with-username",
+			userID:    42,
+			username:  "alice",
+			chatID:    99,
+			adminID:   42,
+			wantUser:  "User ID: 42",
+			wantName:  "Username: @alice",
+			wantChat:  "Chat ID: 99",
+			wantAdmin: "Is admin: true",
+		},
+		{
+			name:      "non-admin-no-username",
+			userID:    7,
+			username:  "",
+			chatID:    100,
+			adminID:   42,
+			wantUser:  "User ID: 7",
+			wantName:  "Username: (none)",
+			wantChat:  "Chat ID: 100",
+			wantAdmin: "Is admin: false",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bot, err := NewTelegramBot("token", nil, tc.adminID, "qa-1", []string{"qa-1"})
+			if err != nil {
+				t.Fatalf("NewTelegramBot: %v", err)
+			}
+			var payload sendMessagePayload
+			bot.httpClient = captureHTTPClient(t, &payload)
+
+			msg := &TelegramMessage{
+				Text: "/whoami",
+				From: &TelegramUser{ID: tc.userID, UserName: tc.username},
+				Chat: &TelegramChat{ID: tc.chatID},
+			}
+
+			handled, err := bot.handleCommand(msg)
+			if !handled {
+				t.Fatalf("expected handled")
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if payload.ChatID != tc.chatID {
+				t.Fatalf("chat_id=%d want %d", payload.ChatID, tc.chatID)
+			}
+			if !strings.Contains(payload.Text, tc.wantUser) {
+				t.Fatalf("missing user id in reply: %q", payload.Text)
+			}
+			if !strings.Contains(payload.Text, tc.wantName) {
+				t.Fatalf("missing username in reply: %q", payload.Text)
+			}
+			if !strings.Contains(payload.Text, tc.wantChat) {
+				t.Fatalf("missing chat id in reply: %q", payload.Text)
+			}
+			if !strings.Contains(payload.Text, tc.wantAdmin) {
+				t.Fatalf("missing admin flag in reply: %q", payload.Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #28.

## Summary
- Add `/whoami` Telegram command to show user ID, username, chat ID, and admin status.
- Extend help text and add unit tests with HTTP stub.

## How to test
1) `go test ./...`
2) In Telegram, send `/whoami` and verify the reply fields.
