### PR TITLE
feat: add Telegram /ping + unauthorized hint

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -526,6 +526,8 @@ func (b *TelegramBot) handleUpdate(update telegramUpdate) {
 func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 	if !b.userManager.Authorize(message.From.ID) {
 		log.Printf("🚫 Unauthorized Telegram user: %d", message.From.ID)
+		hint := "❌ Unauthorized. Ask an admin to add your Telegram user ID in channels.telegram.allowedUsers.\nTip: use /whoami to get your user ID."
+		_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(hint))
 		return
 	}
 
@@ -611,6 +613,9 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 	switch command {
 	case "/help", "/start":
 		return true, b.SendMessage(b.ctx, msg.Chat.ID, b.helpText())
+
+	case "/ping":
+		return true, b.SendMessage(b.ctx, msg.Chat.ID, "pong")
 
 	case "/whoami":
 		username := strings.TrimSpace(msg.From.UserName)
@@ -800,6 +805,7 @@ func (b *TelegramBot) helpText() string {
 	sb.WriteString("\n")
 	sb.WriteString("Commands:\n")
 	sb.WriteString("  /help - show this help\n")
+	sb.WriteString("  /ping - simple health check\n")
 	sb.WriteString("  /whoami - show your Telegram IDs\n")
 	sb.WriteString("  /status - bot status\n")
 	sb.WriteString("  /agents - list allowed agents\n")

--- a/internal/channels/telegram_ping_test.go
+++ b/internal/channels/telegram_ping_test.go
@@ -1,0 +1,33 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTelegramPing(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	msg := &TelegramMessage{
+		Text: "/ping",
+		From: &TelegramUser{ID: 123, UserName: "alice"},
+		Chat: &TelegramChat{ID: 99},
+	}
+
+	handled, err := bot.handleCommand(msg)
+	if !handled {
+		t.Fatalf("expected handled")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(payload.Text) != "pong" {
+		t.Fatalf("unexpected ping reply: %q", payload.Text)
+	}
+}

--- a/internal/channels/telegram_unauthorized_test.go
+++ b/internal/channels/telegram_unauthorized_test.go
@@ -1,0 +1,49 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type fakeIncomingHandler struct {
+	called bool
+}
+
+func (f *fakeIncomingHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	f.called = true
+	return "", nil
+}
+
+func TestTelegramUnauthorizedHint(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	handler := &fakeIncomingHandler{}
+	bot.SetHandler(handler)
+
+	msg := &TelegramMessage{
+		Text: "/ping",
+		From: &TelegramUser{ID: 999, UserName: "intruder"},
+		Chat: &TelegramChat{ID: 55},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if handler.called {
+		t.Fatalf("expected handler not called for unauthorized user")
+	}
+	if !strings.Contains(payload.Text, "/whoami") {
+		t.Fatalf("expected /whoami hint in reply: %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "allowedUsers") {
+		t.Fatalf("expected allowedUsers hint in reply: %q", payload.Text)
+	}
+}


### PR DESCRIPTION
Fixes #30.

## Summary
- Add `/ping` command and include it in Telegram help output.
- Reply to unauthorized users with a short hint to use `/whoami` and update `allowedUsers`.
- Add tests for `/ping` and unauthorized hint behavior.

## How to test
1) `go test ./...`
2) In Telegram, send `/ping` and verify `pong`.
3) Send a message from an unauthorized user and verify the hint reply.
