### PR TITLE
test: add startup smoke tests

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"flag"
+	"io"
 	"log"
 	"os"
 	"os/signal"
@@ -13,22 +14,37 @@ import (
 )
 
 func main() {
-	os.Exit(run())
+	os.Exit(Run(os.Args[1:], os.Stderr))
 }
 
-func run() int {
-	configPath := flag.String("config", "./config.yaml", "path to config file")
-	portOverride := flag.Int("port", 0, "override gateway port")
-	verbose := flag.Bool("verbose", false, "enable verbose logging")
-	flag.Parse()
+// Run executes the fractalbot CLI.
+func Run(args []string, out io.Writer) int {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
 
+	return runWithContext(ctx, args, out)
+}
+
+func runWithContext(ctx context.Context, args []string, out io.Writer) int {
+	fs := flag.NewFlagSet("fractalbot", flag.ContinueOnError)
+	fs.SetOutput(out)
+
+	configPath := fs.String("config", "./config.yaml", "path to config file")
+	portOverride := fs.Int("port", 0, "override gateway port")
+	verbose := fs.Bool("verbose", false, "enable verbose logging")
+
+	if err := fs.Parse(args); err != nil {
+		return 1
+	}
+
+	logger := log.New(out, "", log.LstdFlags)
 	if *verbose {
-		log.SetFlags(log.LstdFlags | log.Lshortfile)
+		logger.SetFlags(log.LstdFlags | log.Lshortfile)
 	}
 
 	cfg, err := config.LoadConfig(*configPath)
 	if err != nil {
-		log.Printf("failed to load config: %v", err)
+		logger.Printf("failed to load config: %v", err)
 		return 1
 	}
 
@@ -39,25 +55,22 @@ func run() int {
 		cfg.Gateway.Port = *portOverride
 	}
 
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
 	server, err := gateway.NewServer(cfg)
 	if err != nil {
-		log.Printf("failed to initialize gateway: %v", err)
+		logger.Printf("failed to initialize gateway: %v", err)
 		return 1
 	}
 
 	if err := server.Start(ctx); err != nil {
-		log.Printf("gateway error: %v", err)
+		logger.Printf("gateway error: %v", err)
 		if err := server.Stop(); err != nil {
-			log.Printf("gateway shutdown error: %v", err)
+			logger.Printf("gateway shutdown error: %v", err)
 		}
 		return 1
 	}
 
 	if err := server.Stop(); err != nil {
-		log.Printf("gateway shutdown error: %v", err)
+		logger.Printf("gateway shutdown error: %v", err)
 		return 1
 	}
 

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunMissingConfig(t *testing.T) {
+	var buf bytes.Buffer
+	code := runWithContext(context.Background(), []string{"--config", "/nope/config.yaml"}, &buf)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit code")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "failed to load config") && !strings.Contains(out, "failed to read config") {
+		t.Fatalf("unexpected error output: %q", out)
+	}
+}
+
+func TestRunMinimalConfigExitsOnCancel(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	configContents := []byte("gateway:\n  bind: 127.0.0.1\n  port: 0\n")
+	if err := os.WriteFile(configPath, configContents, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	var buf bytes.Buffer
+	code := runWithContext(ctx, []string{"--config", configPath}, &buf)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
+	}
+}


### PR DESCRIPTION
Fixes #32.

## Summary
- Refactor CLI into `Run(args, out)` using a dedicated FlagSet.
- Add startup smoke tests for missing config and clean exit on canceled context.

## How to test
1) `go test ./...`
