### PR TITLE
feat: improve Telegram allowlist UX

### DIFF
--- a/internal/channels/telegram_agents_test.go
+++ b/internal/channels/telegram_agents_test.go
@@ -1,0 +1,55 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTelegramAgentsIncludesDefault(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1", "coder-a"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	msg := &TelegramMessage{
+		Text: "/agents",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 99},
+	}
+
+	handled, err := bot.handleCommand(msg)
+	if !handled {
+		t.Fatalf("expected handled")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(payload.Text, "Default agent: qa-1") {
+		t.Fatalf("expected default agent line, got %q", payload.Text)
+	}
+}
+
+func TestTelegramAgentSelectionErrorIncludesHint(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	msg := &TelegramMessage{
+		Text: "/agent hacker do stuff",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 99},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if !strings.Contains(payload.Text, "Tip: use /agents") {
+		t.Fatalf("expected /agents hint, got %q", payload.Text)
+	}
+}


### PR DESCRIPTION
Fixes #34.

## Summary
- /agents now includes a Default agent line when configured.
- Agent allowlist errors include a /agents tip for actionable guidance.
- Add tests for /agents output and selection error hint.

## How to test
1) `go test ./...`
2) In Telegram, send `/agents` and verify Default agent appears.
3) Send `/agent not-allowed test` and confirm the /agents hint.
