### PR TITLE
fix: sanitize Telegram handler replies

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -564,10 +564,10 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 		replyText, err := b.handler.HandleIncoming(b.ctx, msg)
 		if err != nil {
 			log.Printf("Telegram handler error: %v", err)
-			replyText = fmt.Sprintf("❌ %v", err)
+			replyText = "❌ Something went wrong. Please try again."
 		}
 		if strings.TrimSpace(replyText) != "" {
-			_ = b.SendMessage(b.ctx, message.Chat.ID, replyText)
+			_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(replyText))
 		}
 		return
 	}

--- a/internal/channels/telegram_handler_reply_test.go
+++ b/internal/channels/telegram_handler_reply_test.go
@@ -1,0 +1,77 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type fakeReplyHandler struct {
+	reply string
+	err   error
+}
+
+func (f *fakeReplyHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	return f.reply, f.err
+}
+
+func TestTelegramHandlerReplyTruncated(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	longText := strings.Repeat("x", 4000)
+	bot.SetHandler(&fakeReplyHandler{reply: longText})
+
+	msg := &TelegramMessage{
+		Text: "hello",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if !strings.Contains(payload.Text, "…(truncated)") {
+		t.Fatalf("expected truncated suffix, got %q", payload.Text)
+	}
+}
+
+func TestTelegramHandlerErrorSanitized(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	sentinel := "SECRET_ERROR"
+	bot.SetHandler(&fakeReplyHandler{err: errSentinel(sentinel)})
+
+	msg := &TelegramMessage{
+		Text: "hello",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if strings.Contains(payload.Text, sentinel) {
+		t.Fatalf("expected sanitized error, got %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "Something went wrong") {
+		t.Fatalf("expected generic error, got %q", payload.Text)
+	}
+}
+
+type errSentinel string
+
+func (e errSentinel) Error() string {
+	return string(e)
+}


### PR DESCRIPTION
Fixes #38.

## Summary
- Truncate handler replies before sending to Telegram.
- Sanitize handler errors in chat while logging details.
- Add tests for truncation and error sanitization.

## How to test
1) `go test ./...`
2) Trigger a long handler reply and confirm truncation.
