### PR TITLE
fix(telegram): validate allowlist config

### DIFF
--- a/internal/channels/agent_selection.go
+++ b/internal/channels/agent_selection.go
@@ -1,6 +1,7 @@
 package channels
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -8,6 +9,8 @@ import (
 )
 
 var agentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
+
+var errDefaultAgentMissing = errors.New("default agent is not configured")
 
 // AgentSelection describes the resolved target agent and task text.
 type AgentSelection struct {
@@ -76,7 +79,7 @@ func ResolveAgentSelection(selection AgentSelection, defaultAgent string, allowl
 	if !selection.Specified {
 		agent = strings.TrimSpace(defaultAgent)
 		if agent == "" {
-			return AgentSelection{}, fmt.Errorf("default agent is not configured")
+			return AgentSelection{}, errDefaultAgentMissing
 		}
 	}
 
@@ -111,7 +114,7 @@ func (a AgentAllowlist) Validate(agentName, defaultAgent string) error {
 
 	defaultName := strings.TrimSpace(defaultAgent)
 	if defaultName == "" {
-		return fmt.Errorf("default agent is not configured")
+		return errDefaultAgentMissing
 	}
 	if agentName != defaultName {
 		return fmt.Errorf("agent %q is not allowed", agentName)

--- a/internal/channels/manager_validation_test.go
+++ b/internal/channels/manager_validation_test.go
@@ -1,0 +1,62 @@
+package channels
+
+import "testing"
+
+func TestValidateOhMyCodeAgentConfig(t *testing.T) {
+	cases := []struct {
+		name         string
+		defaultAgent string
+		allowed      []string
+		wantErr      bool
+	}{
+		{
+			name:         "default-empty-allowed-empty",
+			defaultAgent: "",
+			allowed:      nil,
+		},
+		{
+			name:         "default-empty-allowed-set",
+			defaultAgent: "",
+			allowed:      []string{"qa-1"},
+			wantErr:      true,
+		},
+		{
+			name:         "default-invalid",
+			defaultAgent: "-bad",
+			allowed:      nil,
+			wantErr:      true,
+		},
+		{
+			name:         "allowlist-invalid",
+			defaultAgent: "qa-1",
+			allowed:      []string{"-bad"},
+			wantErr:      true,
+		},
+		{
+			name:         "default-not-in-allowlist",
+			defaultAgent: "qa-1",
+			allowed:      []string{"coder-a"},
+			wantErr:      true,
+		},
+		{
+			name:         "default-in-allowlist",
+			defaultAgent: "qa-1",
+			allowed:      []string{"qa-1", "coder-a"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateOhMyCodeAgentConfig(tc.defaultAgent, tc.allowed)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/channels/telegram_default_agent_test.go
+++ b/internal/channels/telegram_default_agent_test.go
@@ -1,0 +1,31 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTelegramDefaultAgentMissingGuidance(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	msg := &TelegramMessage{
+		Text: "hello",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 99},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if !strings.Contains(payload.Text, "Default agent is not configured") {
+		t.Fatalf("expected default agent guidance, got %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "/agent <name> <task>") {
+		t.Fatalf("expected /agent hint, got %q", payload.Text)
+	}
+}


### PR DESCRIPTION
## Summary
- validate oh-my-code agent default/allowlist config before starting Telegram
- add guidance when default agent is missing for non-/agent messages
- cover config validation + default-agent guidance in tests

## Testing
- go test ./...

Fixes #40
