### PR TITLE
feat(telegram): harden webhook lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ channels:
     # webhookPath: "/telegram/webhook"
     # webhookPublicURL: "https://your-domain.example/telegram/webhook"
     # webhookSecretToken: "replace-with-random-secret"
+    # webhookRegisterOnStart: true
+    # webhookDeleteOnStop: true
 
 agents:
   workspace: ./workspace

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,11 +40,14 @@ channels:
     webhookPath: "/telegram/webhook"
 
     # Webhook registration (Telegram) (only used in mode: webhook)
-    # If set, FractalBot will call Telegram setWebhook() on startup.
     # Must be publicly reachable HTTPS URL.
     webhookPublicURL: ""
     # Verified via header: X-Telegram-Bot-Api-Secret-Token
     webhookSecretToken: ""
+    # If true, FractalBot will call Telegram setWebhook() on startup.
+    webhookRegisterOnStart: false
+    # If true, FractalBot will call Telegram deleteWebhook() on shutdown.
+    webhookDeleteOnStop: false
 
   # Slack channel configuration (optional)
   slack:

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -155,6 +155,10 @@ func (m *Manager) registerConfiguredChannels() error {
 			m.cfg.Telegram.WebhookPublicURL,
 			m.cfg.Telegram.WebhookSecretToken,
 		)
+		bot.ConfigureWebhookLifecycle(
+			m.cfg.Telegram.WebhookRegisterOnStart,
+			m.cfg.Telegram.WebhookDeleteOnStop,
+		)
 
 		if err := m.Register(bot); err != nil {
 			return fmt.Errorf("failed to register telegram bot: %w", err)

--- a/internal/channels/telegram_webhook_test.go
+++ b/internal/channels/telegram_webhook_test.go
@@ -1,0 +1,88 @@
+package channels
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func okTelegramBoolResponse() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"ok":true,"result":true}`)),
+		Header:     make(http.Header),
+	}
+}
+
+func TestTelegramWebhookRegisterOnStart(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	bot.ConfigureMode("webhook")
+	bot.ConfigureWebhook("", "/telegram/webhook", "https://example.com/telegram/webhook", "")
+	bot.ConfigureWebhookLifecycle(true, false)
+
+	setCalls := 0
+	bot.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Path, "setWebhook") {
+				setCalls++
+			}
+			return okTelegramBoolResponse(), nil
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := bot.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if setCalls != 1 {
+		t.Fatalf("expected setWebhook call, got %d", setCalls)
+	}
+	if err := bot.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestTelegramWebhookDeleteOnStop(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	bot.ConfigureMode("webhook")
+	bot.ConfigureWebhook("", "/telegram/webhook", "https://example.com/telegram/webhook", "")
+	bot.ConfigureWebhookLifecycle(false, true)
+
+	deleteCalls := 0
+	bot.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.URL.Path, "deleteWebhook") {
+				deleteCalls++
+			}
+			return okTelegramBoolResponse(), nil
+		}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := bot.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if deleteCalls != 0 {
+		t.Fatalf("expected deleteWebhook not called on start")
+	}
+	if err := bot.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("expected deleteWebhook call, got %d", deleteCalls)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,10 @@ type TelegramConfig struct {
 	WebhookPublicURL string `yaml:"webhookPublicURL,omitempty"`
 	// WebhookSecretToken is verified against X-Telegram-Bot-Api-Secret-Token.
 	WebhookSecretToken string `yaml:"webhookSecretToken,omitempty"`
+	// WebhookRegisterOnStart controls whether FractalBot registers the webhook on startup.
+	WebhookRegisterOnStart bool `yaml:"webhookRegisterOnStart,omitempty"`
+	// WebhookDeleteOnStop controls whether FractalBot deletes the webhook on shutdown.
+	WebhookDeleteOnStop bool `yaml:"webhookDeleteOnStop,omitempty"`
 }
 
 // FeishuConfig contains Feishu/Lark channel settings.


### PR DESCRIPTION
## Summary
- add config flags to control webhook registration/deletion
- expose webhook mode/status in /status
- add webhook lifecycle tests

## Testing
- go test ./...

Fixes #50