### PR TITLE
chore/install: add one-click installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ FractalBot is a Go-based reimagining of [Clawdbot](https://github.com/clawdbot/c
 
 ```bash
 # One-line install (pinned; builds and installs to ~/.local/bin)
-curl -fsSL https://raw.githubusercontent.com/fractalmind-ai/fractalbot/e4131c8e470dc92622d5c87c68ff426d7e5e05d1/install.sh | \
-  FRACTALBOT_REF=e4131c8e470dc92622d5c87c68ff426d7e5e05d1 bash
+curl -fsSL https://raw.githubusercontent.com/fractalmind-ai/fractalbot/cb052356b79b4e679efb03a93210ab4628590076/install.sh | \
+  FRACTALBOT_REF=cb052356b79b4e679efb03a93210ab4628590076 bash
 
 # Optional: install as a systemd user service (Linux)
-curl -fsSL https://raw.githubusercontent.com/fractalmind-ai/fractalbot/e4131c8e470dc92622d5c87c68ff426d7e5e05d1/install.sh | \
-  FRACTALBOT_REF=e4131c8e470dc92622d5c87c68ff426d7e5e05d1 bash -s -- --systemd-user
+curl -fsSL https://raw.githubusercontent.com/fractalmind-ai/fractalbot/cb052356b79b4e679efb03a93210ab4628590076/install.sh | \
+  FRACTALBOT_REF=cb052356b79b4e679efb03a93210ab4628590076 bash -s -- --systemd-user
 
 # Smoke check
 ~/.local/bin/fractalbot --help

--- a/install.sh
+++ b/install.sh
@@ -46,7 +46,7 @@ config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/fractalbot"
 config_path="${config_dir}/config.yaml"
 data_dir="${XDG_DATA_HOME:-$HOME/.local/share}/fractalbot"
 workspace_dir="${data_dir}/workspace"
-default_ref="e4131c8e470dc92622d5c87c68ff426d7e5e05d1"
+default_ref="cb052356b79b4e679efb03a93210ab4628590076"
 
 repo_root=""
 cleanup=""


### PR DESCRIPTION
## Summary
- add a one-click install script for local or curl|bash usage
- install config template, bin, and data/workspace paths under XDG defaults
- document one-line install snippet in README Quick Start

## Testing
- go test ./...