### PR TITLE
feat(runtime): add Phase 3 skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ agents:
     allowedAgents:
       - "qa-1"
       - "coder-a"
+
+  # Optional: in-process runtime (Phase 3 skeleton)
+  runtime:
+    enabled: false
+    # Allowed tool names (empty = deny all)
+    allowedTools:
+      - "echo"
+      - "version"
+    # Optional: cap runtime replies
+    maxReplyChars: 2000
 ```
 
 Telegram supports `/agent <name> <task...>` to route tasks to a specific agent; if omitted, `defaultAgent` is used. When `allowedAgents` is set, only those names are accepted. Use `/agents` to see allowed agents; if you target a disallowed agent, the bot will suggest `/agents`.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -110,3 +110,13 @@ agents:
     # - /doctor (admin only)
     # - /whoami (show your Telegram IDs)
     # - /ping (simple health check)
+
+  # Optional: in-process runtime (Phase 3 skeleton)
+  runtime:
+    enabled: false
+    # Allowed tool names (empty = deny all)
+    allowedTools:
+      - "echo"
+      - "version"
+    # Optional: cap runtime replies
+    maxReplyChars: 2000

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,14 @@ type AgentsConfig struct {
 	Workspace     string          `yaml:"workspace"`
 	MaxConcurrent int             `yaml:"maxConcurrent"`
 	OhMyCode      *OhMyCodeConfig `yaml:"ohMyCode,omitempty"`
+	Runtime       *RuntimeConfig  `yaml:"runtime,omitempty"`
+}
+
+// RuntimeConfig enables the in-process agent runtime.
+type RuntimeConfig struct {
+	Enabled       bool     `yaml:"enabled,omitempty"`
+	AllowedTools  []string `yaml:"allowedTools,omitempty"`
+	MaxReplyChars int      `yaml:"maxReplyChars,omitempty"`
 }
 
 // LoadConfig loads configuration from file.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -1,0 +1,175 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+const (
+	defaultMaxReplyChars = 2000
+	truncateSuffix       = "\n...(truncated)"
+)
+
+// AgentRuntime handles routed tasks and tool execution.
+type AgentRuntime interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+	HandleTask(ctx context.Context, task Task) (string, error)
+}
+
+// Task represents a routed task with channel metadata.
+type Task struct {
+	Agent    string
+	Text     string
+	Channel  string
+	Metadata map[string]string
+}
+
+// Event is a structured runtime event for future monitoring.
+type Event struct {
+	Time    time.Time
+	Kind    string
+	Agent   string
+	Tool    string
+	Channel string
+	Message string
+}
+
+// BasicRuntime is a minimal in-process runtime.
+type BasicRuntime struct {
+	registry      *ToolRegistry
+	eventsMu      sync.Mutex
+	events        []Event
+	maxReplyChars int
+}
+
+// NewRuntime creates a runtime when enabled in config.
+func NewRuntime(cfg *config.RuntimeConfig) (AgentRuntime, error) {
+	if cfg == nil || !cfg.Enabled {
+		return nil, nil
+	}
+
+	registry := NewToolRegistry(cfg.AllowedTools)
+	if err := registry.Register(NewEchoTool()); err != nil {
+		return nil, err
+	}
+	if err := registry.Register(NewVersionTool()); err != nil {
+		return nil, err
+	}
+
+	maxChars := defaultMaxReplyChars
+	if cfg.MaxReplyChars > 0 {
+		maxChars = cfg.MaxReplyChars
+	}
+
+	return &BasicRuntime{
+		registry:      registry,
+		maxReplyChars: maxChars,
+	}, nil
+}
+
+// Start is a no-op for the basic runtime.
+func (r *BasicRuntime) Start(ctx context.Context) error {
+	_ = ctx
+	return nil
+}
+
+// Stop is a no-op for the basic runtime.
+func (r *BasicRuntime) Stop(ctx context.Context) error {
+	_ = ctx
+	return nil
+}
+
+// HandleTask executes tool commands or returns a lightweight acknowledgement.
+func (r *BasicRuntime) HandleTask(ctx context.Context, task Task) (string, error) {
+	if r.registry == nil {
+		return "", errors.New("runtime registry not configured")
+	}
+	text := strings.TrimSpace(task.Text)
+	if text == "" {
+		return "", nil
+	}
+
+	r.emitEvent(Event{
+		Time:    time.Now().UTC(),
+		Kind:    "task_received",
+		Agent:   task.Agent,
+		Channel: task.Channel,
+	})
+
+	name, args, ok := parseToolInvocation(text)
+	if ok {
+		if name == "" {
+			return r.truncate("❌ tool name is required"), nil
+		}
+		out, err := r.registry.Execute(ctx, name, ToolRequest{Args: args, Task: task})
+		if err != nil {
+			log.Printf("runtime tool error: tool=%s err=%v", name, err)
+			return r.truncate(fmt.Sprintf("❌ %v", err)), nil
+		}
+		r.emitEvent(Event{
+			Time:    time.Now().UTC(),
+			Kind:    "tool_executed",
+			Agent:   task.Agent,
+			Tool:    name,
+			Channel: task.Channel,
+		})
+		return r.truncate(out), nil
+	}
+
+	agentLabel := strings.TrimSpace(task.Agent)
+	if agentLabel == "" {
+		agentLabel = "default"
+	}
+	return r.truncate(fmt.Sprintf("runtime: received task for %s", agentLabel)), nil
+}
+
+func (r *BasicRuntime) emitEvent(event Event) {
+	r.eventsMu.Lock()
+	r.events = append(r.events, event)
+	r.eventsMu.Unlock()
+}
+
+func (r *BasicRuntime) truncate(text string) string {
+	text = strings.TrimSpace(text)
+	if r.maxReplyChars <= 0 || len(text) <= r.maxReplyChars {
+		return text
+	}
+	return strings.TrimSpace(text[:r.maxReplyChars]) + truncateSuffix
+}
+
+func parseToolInvocation(text string) (string, string, bool) {
+	trimmed := strings.TrimSpace(text)
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "tool:") {
+		rest := strings.TrimSpace(trimmed[len("tool:"):])
+		name, args := splitToolArgs(rest)
+		return name, args, true
+	}
+	if strings.HasPrefix(lower, "tool ") {
+		rest := strings.TrimSpace(trimmed[len("tool "):])
+		name, args := splitToolArgs(rest)
+		return name, args, true
+	}
+	return "", "", false
+}
+
+func splitToolArgs(rest string) (string, string) {
+	fields := strings.Fields(rest)
+	if len(fields) == 0 {
+		return "", ""
+	}
+	name := strings.ToLower(strings.TrimSpace(fields[0]))
+	args := ""
+	if len(fields) > 1 {
+		args = strings.Join(fields[1:], " ")
+	}
+	return name, strings.TrimSpace(args)
+}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -1,0 +1,73 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+func TestRuntimeUnknownToolDenied(t *testing.T) {
+	rt, err := NewRuntime(&config.RuntimeConfig{
+		Enabled:      true,
+		AllowedTools: []string{"echo"},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	reply, err := rt.HandleTask(context.Background(), Task{
+		Agent:   "qa-1",
+		Text:    "tool unknown hi",
+		Channel: "telegram",
+	})
+	if err != nil {
+		t.Fatalf("HandleTask: %v", err)
+	}
+	if !strings.Contains(reply, "unknown tool") {
+		t.Fatalf("expected unknown tool error, got %q", reply)
+	}
+}
+
+func TestRuntimeAllowlistedToolAllowed(t *testing.T) {
+	rt, err := NewRuntime(&config.RuntimeConfig{
+		Enabled:      true,
+		AllowedTools: []string{"echo"},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	reply, err := rt.HandleTask(context.Background(), Task{
+		Agent:   "qa-1",
+		Text:    "tool echo hello",
+		Channel: "telegram",
+	})
+	if err != nil {
+		t.Fatalf("HandleTask: %v", err)
+	}
+	if reply != "hello" {
+		t.Fatalf("expected echo reply, got %q", reply)
+	}
+}
+
+func TestRuntimeToolOutputTruncation(t *testing.T) {
+	rt, err := NewRuntime(&config.RuntimeConfig{
+		Enabled:       true,
+		AllowedTools:  []string{"echo"},
+		MaxReplyChars: 12,
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	reply, err := rt.HandleTask(context.Background(), Task{
+		Agent:   "qa-1",
+		Text:    "tool echo " + strings.Repeat("a", 50),
+		Channel: "telegram",
+	})
+	if err != nil {
+		t.Fatalf("HandleTask: %v", err)
+	}
+	if !strings.Contains(reply, "...(truncated)") {
+		t.Fatalf("expected truncated suffix, got %q", reply)
+	}
+}

--- a/internal/runtime/tools.go
+++ b/internal/runtime/tools.go
@@ -1,0 +1,116 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Tool executes a safe, deterministic operation.
+type Tool interface {
+	Name() string
+	Execute(ctx context.Context, req ToolRequest) (string, error)
+}
+
+// ToolRequest provides tool execution context.
+type ToolRequest struct {
+	Args string
+	Task Task
+}
+
+// ToolRegistry dispatches tool invocations with allowlist checks.
+type ToolRegistry struct {
+	tools      map[string]Tool
+	allowed    map[string]struct{}
+	configured bool
+}
+
+// NewToolRegistry creates a registry with an allowlist.
+func NewToolRegistry(allowed []string) *ToolRegistry {
+	allow := make(map[string]struct{})
+	for _, name := range allowed {
+		trimmed := strings.ToLower(strings.TrimSpace(name))
+		if trimmed == "" {
+			continue
+		}
+		allow[trimmed] = struct{}{}
+	}
+	return &ToolRegistry{
+		tools:      make(map[string]Tool),
+		allowed:    allow,
+		configured: len(allow) > 0,
+	}
+}
+
+// Register adds a tool to the registry.
+func (r *ToolRegistry) Register(tool Tool) error {
+	if tool == nil {
+		return errors.New("tool is nil")
+	}
+	name := strings.ToLower(strings.TrimSpace(tool.Name()))
+	if name == "" {
+		return errors.New("tool name is required")
+	}
+	if _, exists := r.tools[name]; exists {
+		return fmt.Errorf("tool %q already registered", name)
+	}
+	r.tools[name] = tool
+	return nil
+}
+
+// Execute runs an allowlisted tool.
+func (r *ToolRegistry) Execute(ctx context.Context, name string, req ToolRequest) (string, error) {
+	if r == nil {
+		return "", errors.New("tool registry is nil")
+	}
+	trimmed := strings.ToLower(strings.TrimSpace(name))
+	if trimmed == "" {
+		return "", errors.New("tool name is required")
+	}
+	tool, ok := r.tools[trimmed]
+	if !ok {
+		return "", fmt.Errorf("unknown tool %q", trimmed)
+	}
+	if !r.isAllowed(trimmed) {
+		return "", fmt.Errorf("tool %q is not allowed", trimmed)
+	}
+	return tool.Execute(ctx, req)
+}
+
+func (r *ToolRegistry) isAllowed(name string) bool {
+	if !r.configured {
+		return false
+	}
+	_, ok := r.allowed[name]
+	return ok
+}
+
+// NewEchoTool returns a simple echo tool.
+func NewEchoTool() Tool {
+	return echoTool{}
+}
+
+type echoTool struct{}
+
+func (echoTool) Name() string { return "echo" }
+
+func (echoTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	return strings.TrimSpace(req.Args), nil
+}
+
+// NewVersionTool returns a fixed version tool.
+func NewVersionTool() Tool {
+	return versionTool{}
+}
+
+type versionTool struct{}
+
+func (versionTool) Name() string { return "version" }
+
+func (versionTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	_ = req
+	return "runtime v0", nil
+}


### PR DESCRIPTION
## Summary
- add a minimal in-process runtime with default-deny tool registry
- wire runtime behind agents.runtime config flag and keep oh-my-code routing as fallback
- add safe demo tools (echo/version) and runtime tests, update docs/examples

Fixes #69.

## Testing
- go test ./...