### PR TITLE
docs: refresh progress and roadmap

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,7 +3,7 @@
 ## Status Update
 **Date**: 2026-02-02
 **Phase**: Phase 2 - Channel Integrations
-**Overall Progress**: ~80%
+**Overall Progress**: ~90%
 
 ---
 
@@ -12,6 +12,9 @@
 - **#43** Telegram polling backoff hardening
 - **#47/#51/#53/#55/#57/#63/#65** Telegram + Feishu UX hardening (agent selection hints, allowlist parity, /whoami, /agents, error messaging, status tweaks)
 - **#66** One-click installer (install.sh + README)
+- **#72** Slack DM-only skeleton + /whoami onboarding
+- **#73** Discord DM-only skeleton + /whoami onboarding
+- **#74** Phase 3 runtime skeleton (default-deny tools)
 
 ---
 
@@ -23,24 +26,26 @@
 | Phase 2 - Channel Integrations | 🚧 In Progress | 80% |
 | Telegram Channel | ✅ Complete | 100% |
 | Feishu/Lark Channel | ✅ Complete | 100% |
-| Slack Channel | 📋 Not Started | 0% |
-| Discord Channel | 📋 Not Started | 0% |
-| Phase 3 - Agent Runtime | 🔜 Planned | 0% |
+| Slack Channel | 🧪 Skeleton | 30% |
+| Discord Channel | 🧪 Skeleton | 30% |
+| Phase 3 - Agent Runtime | 🚧 Started | 10% |
 
 ---
 
 ## Current Capabilities
 
 - Telegram + Feishu message routing with agent selection + allowlist UX parity
+- Slack + Discord DM-only skeletons with /whoami onboarding
 - Core commands: /help, /whoami, /agents, /ping, /status (+ admin lifecycle commands on Telegram)
 - Safer error messaging and reply truncation
 - One-click local install script (XDG-friendly)
+- Phase 3 runtime skeleton with default-deny tool registry (echo/version)
 
 ---
 
 ## Next Steps
 
-- **Slack + Discord channels** (Phase 2 completion)
+- **Slack + Discord channels** (complete transport + non-DM support)
 - **Agent Runtime (Phase 3)**: lifecycle, isolation, memory, tool execution
 
 ---

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ channels:
       - "123456789012345678"
 ```
 
+Tip: `/whoami` works in Slack/Discord DMs even before allowlisting, so users can self-identify.
+
 ### Local Demo (Telegram + polling + oh-my-code)
 
 This is the fastest path to a local, end-to-end demo after the CLI entrypoint lands.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 **Current Phase**: Phase 2 - Channel Integrations
 
-**Progress**: Core gateway complete. Telegram + Feishu/Lark channels are production-ready; Slack/Discord pending. Agent runtime still planned.
+**Progress**: Core gateway complete. Telegram + Feishu/Lark channels are production-ready; Slack/Discord DM-only skeletons landed. Agent runtime skeleton started.
 
 ---
 
@@ -41,6 +41,7 @@
 **Estimated**: Complete
 
 #### Slack Channel
+- [x] DM-only skeleton + allowlist + /whoami onboarding
 - [ ] Bot initialization and RTM connection
 - [ ] Event handling (message, mention, reaction)
 - [ ] Team/channel authorization
@@ -51,6 +52,7 @@
 **Estimated**: 2-3 days
 
 #### Discord Channel
+- [x] DM-only skeleton + allowlist + /whoami onboarding
 - [ ] Bot initialization and gateway connection
 - [ ] Event handling (message, interaction)
 - [ ] Guild/channel authorization
@@ -75,7 +77,7 @@
 **Estimated**: 5-7 days
 
 #### Tool Execution Engine
-- [ ] Tool registry and discovery
+- [x] Tool registry skeleton (default-deny allowlist)
 - [ ] Tool execution with sandboxing
 - [ ] File operations (read/write/edit)
 - [ ] System command execution


### PR DESCRIPTION
## Summary
- update PROGRESS with recent Slack/Discord/runtime merges
- mark Slack/Discord skeletons and runtime tool registry in ROADMAP
- add /whoami onboarding note for Slack/Discord

Fixes #70.

## Testing
- not run (docs-only)