### PR TITLE
feat(slack): add Socket Mode DM transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Additional lifecycle commands:
 - `/whoami` (show your Telegram IDs)
 - `/ping` (simple health check)
 
-Slack (skeleton, DM-only) requires allowlisting user IDs before messages are processed:
+Slack (DM-only) uses Socket Mode (no public ports) and requires allowlisting user IDs before messages are processed:
 
 ```yaml
 channels:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -52,6 +52,7 @@ channels:
   # Slack channel configuration (optional)
   slack:
     enabled: false
+    # Socket Mode (no public ports). Requires Slack App-Level token (xapp-).
     botToken: "xoxb-your-bot-token"
     appToken: "xapp-your-app-token"
     # Allowed Slack user IDs (DM-only; empty means deny all)

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,13 @@ module github.com/fractalmind-ai/fractalbot
 go 1.25.6
 
 require (
-	github.com/gorilla/websocket v1.5.1
+	github.com/gorilla/websocket v1.5.3
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3 // indirect
+	github.com/slack-go/slack v0.17.3 // indirect
 	golang.org/x/net v0.17.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,14 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/larksuite/oapi-sdk-go/v3 v3.5.3 h1:xvf8Dv29kBXC5/DNDCLhHkAFW8l/0LlQJimO5Zn+JUk=
 github.com/larksuite/oapi-sdk-go/v3 v3.5.3/go.mod h1:ZEplY+kwuIrj/nqw5uSCINNATcH3KdxSN7y+UxYY5fI=
+github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
+github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/channels/reply_utils.go
+++ b/internal/channels/reply_utils.go
@@ -5,6 +5,7 @@ import "strings"
 const (
 	truncateSuffix      = "\n…(truncated)"
 	maxFeishuReplyChars = 2000
+	maxSlackReplyChars  = 3000
 )
 
 func truncateReply(text string, maxChars int) string {
@@ -18,4 +19,9 @@ func truncateReply(text string, maxChars int) string {
 // TruncateFeishuReply limits outbound Feishu/Lark responses to a conservative size.
 func TruncateFeishuReply(text string) string {
 	return truncateReply(text, maxFeishuReplyChars)
+}
+
+// TruncateSlackReply limits outbound Slack responses to a conservative size.
+func TruncateSlackReply(text string) string {
+	return truncateReply(text, maxSlackReplyChars)
 }


### PR DESCRIPTION
## Summary
- add Slack Socket Mode transport for DM-only events (no public ports)
- enforce allowlist while letting /whoami(/help) work pre-allowlist
- truncate Slack replies and add Socket Mode tests (no network)

Fixes #76.

## Testing
- go test ./...