### PR TITLE
feat(memory): sanitize model ID cache paths

### DIFF
--- a/internal/memory/download.go
+++ b/internal/memory/download.go
@@ -32,7 +32,10 @@ func EnsureModelAssets(ctx context.Context, cacheDir string, spec ModelSpec) (Mo
 		return ModelAssets{}, fmt.Errorf("tokenizer URL and SHA256 are required")
 	}
 
-	dir := ModelDir(cacheDir, spec.ID)
+	dir, err := ModelDir(cacheDir, spec.ID)
+	if err != nil {
+		return ModelAssets{}, err
+	}
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return ModelAssets{}, fmt.Errorf("failed to create model dir: %w", err)
 	}

--- a/internal/memory/paths_test.go
+++ b/internal/memory/paths_test.go
@@ -1,0 +1,38 @@
+package memory
+
+import "testing"
+
+func TestValidateModelID(t *testing.T) {
+	valid := []string{
+		"multilingual-e5-small",
+		"model_v1.2",
+		"ABC-123",
+	}
+	for _, value := range valid {
+		if err := ValidateModelID(value); err != nil {
+			t.Fatalf("expected valid model ID %q: %v", value, err)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"../model",
+		"model/../x",
+		"foo/bar",
+		"foo\\bar",
+		"/absolute",
+		"C:\\model",
+		"model id",
+	}
+	for _, value := range invalid {
+		if err := ValidateModelID(value); err == nil {
+			t.Fatalf("expected invalid model ID %q", value)
+		}
+	}
+}
+
+func TestIndexPathRejectsInvalidModelID(t *testing.T) {
+	if _, err := IndexPath("/tmp/cache", "../oops"); err == nil {
+		t.Fatal("expected error for invalid model ID")
+	}
+}

--- a/internal/runtime/memory_tool.go
+++ b/internal/runtime/memory_tool.go
@@ -97,7 +97,11 @@ func (t *MemorySearchTool) ensureReady(ctx context.Context) error {
 			Counter:       memory.TokenizerCounter{Tokenizer: tokenizer},
 		}
 
-		indexPath := memory.IndexPath(cacheDir, spec.ID)
+		indexPath, err := memory.IndexPath(cacheDir, spec.ID)
+		if err != nil {
+			t.initErr = err
+			return
+		}
 		if err := ensureParentDir(indexPath); err != nil {
 			t.initErr = err
 			return


### PR DESCRIPTION
## Summary
- validate memory model IDs used for cache/index paths
- reject path traversal/absolute/invalid characters
- add unit tests for valid/invalid cases

## Testing
- go test ./...

Fixes #83