### PR TITLE
feat(memory): validate modelId cache safety

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,9 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 
+	"github.com/fractalmind-ai/fractalbot/internal/memory"
 	"gopkg.in/yaml.v3"
 )
 
@@ -175,6 +177,9 @@ func LoadConfig(path string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
+	if err := validateConfig(&config); err != nil {
+		return nil, err
+	}
 
 	return &config, nil
 }
@@ -210,4 +215,18 @@ func DefaultConfig() *Config {
 			MaxConcurrent: 4,
 		},
 	}
+}
+
+func validateConfig(cfg *Config) error {
+	if cfg == nil || cfg.Agents == nil || cfg.Agents.Memory == nil {
+		return nil
+	}
+	modelID := strings.TrimSpace(cfg.Agents.Memory.ModelID)
+	if modelID == "" {
+		return nil
+	}
+	if err := memory.ValidateModelID(modelID); err != nil {
+		return fmt.Errorf("agents.memory.modelId: %w", err)
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadConfigRejectsInvalidMemoryModelID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("agents:\n  memory:\n    modelId: \"../bad\"\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid modelId")
+	}
+	if !strings.Contains(err.Error(), "agents.memory.modelId") {
+		t.Fatalf("expected error to mention agents.memory.modelId, got %v", err)
+	}
+}
+
+func TestLoadConfigAcceptsValidMemoryModelID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("agents:\n  memory:\n    modelId: \"e5_small.v2\"\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/memory/paths_test.go
+++ b/internal/memory/paths_test.go
@@ -1,6 +1,9 @@
 package memory
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestValidateModelID(t *testing.T) {
 	valid := []string{
@@ -16,7 +19,9 @@ func TestValidateModelID(t *testing.T) {
 
 	invalid := []string{
 		"",
+		"..",
 		"../model",
+		"a/../b",
 		"model/../x",
 		"foo/bar",
 		"foo\\bar",
@@ -34,5 +39,13 @@ func TestValidateModelID(t *testing.T) {
 func TestIndexPathRejectsInvalidModelID(t *testing.T) {
 	if _, err := IndexPath("/tmp/cache", "../oops"); err == nil {
 		t.Fatal("expected error for invalid model ID")
+	}
+}
+
+func TestEnsureUnderRootRejectsOutside(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Clean(filepath.Join(root, "..", "outside"))
+	if err := ensureUnderRoot(root, outside); err == nil {
+		t.Fatal("expected error for outside path")
 	}
 }


### PR DESCRIPTION
## Summary
- validate agents.memory.modelId with explicit config error messaging
- enforce cache path containment under cache root
- add tests for invalid IDs, containment, and config errors

## Testing
- go test ./...

Fixes #84