### PR TITLE
runtime: sandbox tool file ops

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -122,6 +122,9 @@ agents:
       - "version"
     # Optional: cap runtime replies
     maxReplyChars: 2000
+    # Tool file sandbox roots (empty = deny all file access)
+    sandboxRoots:
+      - "/home/you/fractalbot"
 
   # Optional: local semantic memory search (Issue #81 WIP)
   memory:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,6 +164,8 @@ type RuntimeConfig struct {
 	Enabled       bool     `yaml:"enabled,omitempty"`
 	AllowedTools  []string `yaml:"allowedTools,omitempty"`
 	MaxReplyChars int      `yaml:"maxReplyChars,omitempty"`
+	// SandboxRoots restricts tool file access to these roots. Empty means deny all.
+	SandboxRoots []string `yaml:"sandboxRoots,omitempty"`
 }
 
 // LoadConfig loads configuration from file.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,7 +64,8 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 		return nil, err
 	}
 	if memoryCfg != nil && memoryCfg.Enabled {
-		tool, err := NewMemorySearchTool(memoryCfg)
+		sandbox := PathSandbox{Roots: cfg.SandboxRoots}
+		tool, err := NewMemorySearchTool(memoryCfg, sandbox)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/runtime/sandbox.go
+++ b/internal/runtime/sandbox.go
@@ -1,0 +1,114 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// PathSandbox enforces filesystem access under configured roots.
+type PathSandbox struct {
+	Roots []string
+}
+
+// ValidatePath validates candidate paths and returns a safe, absolute path.
+func (s PathSandbox) ValidatePath(candidate string) (string, error) {
+	trimmed := strings.TrimSpace(candidate)
+	if trimmed == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if len(s.Roots) == 0 {
+		return "", fmt.Errorf("sandbox roots are not configured")
+	}
+
+	var lastErr error
+	for _, root := range s.Roots {
+		if strings.TrimSpace(root) == "" {
+			continue
+		}
+		resolved, err := validateUnderRoot(root, trimmed)
+		if err == nil {
+			return resolved, nil
+		}
+		lastErr = err
+	}
+	if lastErr != nil {
+		return "", lastErr
+	}
+	return "", fmt.Errorf("sandbox roots are not configured")
+}
+
+func validateUnderRoot(root, candidate string) (string, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve sandbox root: %w", err)
+	}
+	rootReal, err := filepath.EvalSymlinks(absRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve sandbox root: %w", err)
+	}
+
+	absCandidate := candidate
+	if !filepath.IsAbs(absCandidate) && !isWindowsAbsPath(absCandidate) {
+		absCandidate = filepath.Join(absRoot, absCandidate)
+	}
+	absCandidate = filepath.Clean(absCandidate)
+
+	candidateReal, err := resolveCandidatePath(absCandidate)
+	if err != nil {
+		return "", err
+	}
+
+	if err := ensureUnderRoot(rootReal, candidateReal); err != nil {
+		return "", err
+	}
+	return candidateReal, nil
+}
+
+func resolveCandidatePath(candidate string) (string, error) {
+	if _, err := os.Stat(candidate); err == nil {
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve path: %w", err)
+		}
+		return resolved, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("failed to access path: %w", err)
+	}
+
+	parent := filepath.Dir(candidate)
+	parentReal, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve parent path: %w", err)
+	}
+	return filepath.Join(parentReal, filepath.Base(candidate)), nil
+}
+
+func ensureUnderRoot(root, target string) error {
+	rel, err := filepath.Rel(root, target)
+	if err != nil {
+		return fmt.Errorf("failed to resolve sandbox relative path: %w", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("path escapes sandbox root")
+	}
+	return nil
+}
+
+func isWindowsAbsPath(path string) bool {
+	if strings.HasPrefix(path, `\\`) {
+		return true
+	}
+	if len(path) < 3 {
+		return false
+	}
+	drive := path[0]
+	if !((drive >= 'a' && drive <= 'z') || (drive >= 'A' && drive <= 'Z')) {
+		return false
+	}
+	if path[1] != ':' {
+		return false
+	}
+	return path[2] == '\\' || path[2] == '/'
+}

--- a/internal/runtime/sandbox_test.go
+++ b/internal/runtime/sandbox_test.go
@@ -1,0 +1,73 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestPathSandboxAcceptsRelative(t *testing.T) {
+	root := t.TempDir()
+	sandbox := PathSandbox{Roots: []string{root}}
+	target, err := sandbox.ValidatePath("notes.txt")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(target, root) {
+		t.Fatalf("expected target under root, got %s", target)
+	}
+}
+
+func TestPathSandboxRejectsTraversal(t *testing.T) {
+	root := t.TempDir()
+	sandbox := PathSandbox{Roots: []string{root}}
+	if _, err := sandbox.ValidatePath("../secrets"); err == nil {
+		t.Fatal("expected traversal to be rejected")
+	}
+}
+
+func TestPathSandboxRejectsAbsoluteOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	sandbox := PathSandbox{Roots: []string{root}}
+	outside := filepath.Join(filepath.Dir(root), "outside.txt")
+	if _, err := sandbox.ValidatePath(outside); err == nil {
+		t.Fatal("expected absolute path outside root to be rejected")
+	}
+}
+
+func TestPathSandboxRejectsWindowsAbsolute(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows absolute paths are handled by platform-specific logic")
+	}
+	root := t.TempDir()
+	sandbox := PathSandbox{Roots: []string{root}}
+	if _, err := sandbox.ValidatePath(`C:\Windows\system32`); err == nil {
+		t.Fatal("expected windows absolute path to be rejected")
+	}
+	if _, err := sandbox.ValidatePath(`\\server\share\file`); err == nil {
+		t.Fatal("expected UNC path to be rejected")
+	}
+}
+
+func TestPathSandboxRejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink tests are unreliable on Windows")
+	}
+	root := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+	linkPath := filepath.Join(root, "link")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Skipf("symlink not supported: %v", err)
+	}
+
+	sandbox := PathSandbox{Roots: []string{root}}
+	if _, err := sandbox.ValidatePath(linkPath); err == nil {
+		t.Fatal("expected symlink escape to be rejected")
+	}
+}


### PR DESCRIPTION
## Summary
- add PathSandbox to validate file access under configured roots
- enforce sandbox when memory tool resolves sourceRoot
- add sandbox config + tests for traversal, abs paths, symlink escape

## Testing
- go test ./...

Fixes #91