### PR TITLE
runtime: tool args parsing + file.read

### DIFF
--- a/internal/runtime/file_read_tool.go
+++ b/internal/runtime/file_read_tool.go
@@ -1,0 +1,41 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// FileReadTool reads files from within the sandbox roots.
+type FileReadTool struct {
+	sandbox PathSandbox
+}
+
+// NewFileReadTool creates a new file.read tool.
+func NewFileReadTool(sandbox PathSandbox) Tool {
+	return FileReadTool{sandbox: sandbox}
+}
+
+// Name returns the tool name.
+func (FileReadTool) Name() string {
+	return "file.read"
+}
+
+// Execute reads a file from a sandboxed path.
+func (t FileReadTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	path := strings.TrimSpace(req.Args)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	safePath, err := t.sandbox.ValidatePath(path)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(safePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file")
+	}
+	return string(data), nil
+}

--- a/internal/runtime/file_read_tool_test.go
+++ b/internal/runtime/file_read_tool_test.go
@@ -1,0 +1,36 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileReadToolReadsFile(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "note.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileReadTool(PathSandbox{Roots: []string{root}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: path})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if out != "hello" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestFileReadToolRejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("secret"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileReadTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: outside}); err == nil {
+		t.Fatal("expected error for outside root")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 )
@@ -61,6 +62,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 		return nil, err
 	}
 	if err := registry.Register(NewVersionTool()); err != nil {
+		return nil, err
+	}
+	if err := registry.Register(NewFileReadTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
 	if memoryCfg != nil && memoryCfg.Enabled {
@@ -172,14 +176,17 @@ func parseToolInvocation(text string) (string, string, bool) {
 }
 
 func splitToolArgs(rest string) (string, string) {
-	fields := strings.Fields(rest)
-	if len(fields) == 0 {
+	trimmed := strings.TrimSpace(rest)
+	if trimmed == "" {
 		return "", ""
 	}
-	name := strings.ToLower(strings.TrimSpace(fields[0]))
-	args := ""
-	if len(fields) > 1 {
-		args = strings.Join(fields[1:], " ")
+	for idx, ch := range trimmed {
+		if unicode.IsSpace(ch) {
+			name := strings.ToLower(strings.TrimSpace(trimmed[:idx]))
+			args := strings.TrimLeftFunc(trimmed[idx:], unicode.IsSpace)
+			return name, args
+		}
 	}
-	return name, strings.TrimSpace(args)
+	name := strings.ToLower(strings.TrimSpace(trimmed))
+	return name, ""
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -71,3 +71,16 @@ func TestRuntimeToolOutputTruncation(t *testing.T) {
 		t.Fatalf("expected truncated suffix, got %q", reply)
 	}
 }
+
+func TestParseToolInvocationPreservesArgs(t *testing.T) {
+	name, args, ok := parseToolInvocation("tool echo line1\nline2")
+	if !ok {
+		t.Fatal("expected tool invocation")
+	}
+	if name != "echo" {
+		t.Fatalf("expected name echo, got %s", name)
+	}
+	if args != "line1\nline2" {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}


### PR DESCRIPTION
## Summary
- preserve tool args by splitting on first whitespace
- add sandboxed file.read tool
- add parsing + file.read tests

## Testing
- go test ./...

Fixes #93