### PR TITLE
runtime: add sandboxed file.edit

### DIFF
--- a/internal/runtime/file_edit_tool.go
+++ b/internal/runtime/file_edit_tool.go
@@ -1,0 +1,96 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// FileEditTool applies a deterministic in-place edit within sandbox roots.
+type FileEditTool struct {
+	sandbox PathSandbox
+}
+
+// NewFileEditTool creates a new file.edit tool.
+func NewFileEditTool(sandbox PathSandbox) Tool {
+	return FileEditTool{sandbox: sandbox}
+}
+
+// Name returns the tool name.
+func (FileEditTool) Name() string {
+	return "file.edit"
+}
+
+// Execute performs a single replacement edit.
+func (t FileEditTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	path, payload, err := parseEditArgs(req.Args)
+	if err != nil {
+		return "", err
+	}
+	safePath, err := t.sandbox.ValidatePath(path)
+	if err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(safePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file")
+	}
+
+	updated, err := applyEditPayload(string(data), payload)
+	if err != nil {
+		return "", err
+	}
+	if err := writeFileAtomic(safePath, []byte(updated)); err != nil {
+		return "", fmt.Errorf("failed to write file")
+	}
+	return "ok", nil
+}
+
+type editPayload struct {
+	OldText string `json:"oldText"`
+	NewText string `json:"newText"`
+}
+
+func parseEditArgs(args string) (string, editPayload, error) {
+	trimmed := strings.TrimSpace(args)
+	if trimmed == "" {
+		return "", editPayload{}, fmt.Errorf("path is required")
+	}
+	lines := strings.SplitN(trimmed, "\n", 2)
+	path := strings.TrimSpace(lines[0])
+	if path == "" {
+		return "", editPayload{}, fmt.Errorf("path is required")
+	}
+	if len(lines) < 2 {
+		return "", editPayload{}, fmt.Errorf("payload is required")
+	}
+	payloadRaw := strings.TrimLeft(lines[1], "\r\n")
+	if strings.TrimSpace(payloadRaw) == "" {
+		return "", editPayload{}, fmt.Errorf("payload is required")
+	}
+	var payload editPayload
+	if err := json.Unmarshal([]byte(payloadRaw), &payload); err != nil {
+		return "", editPayload{}, fmt.Errorf("invalid payload")
+	}
+	if payload.OldText == "" {
+		return "", editPayload{}, fmt.Errorf("oldText is required")
+	}
+	return path, payload, nil
+}
+
+func applyEditPayload(content string, payload editPayload) (string, error) {
+	index := strings.Index(content, payload.OldText)
+	if index == -1 {
+		return "", fmt.Errorf("oldText not found")
+	}
+	var builder strings.Builder
+	builder.Grow(len(content) - len(payload.OldText) + len(payload.NewText))
+	builder.WriteString(content[:index])
+	builder.WriteString(payload.NewText)
+	builder.WriteString(content[index+len(payload.OldText):])
+	return builder.String(), nil
+}

--- a/internal/runtime/file_edit_tool_test.go
+++ b/internal/runtime/file_edit_tool_test.go
@@ -1,0 +1,72 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileEditToolReplacesFirstOccurrence(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "note.txt")
+	if err := os.WriteFile(target, []byte("hello hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	payload := `{"oldText":"hello","newText":"hi"}`
+	tool := NewFileEditTool(PathSandbox{Roots: []string{root}})
+	_, err := tool.Execute(context.Background(), ToolRequest{Args: target + "\n" + payload})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	if string(data) != "hi hello" {
+		t.Fatalf("unexpected content: %q", string(data))
+	}
+}
+
+func TestFileEditToolRejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(outside, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	payload := `{"oldText":"hello","newText":"hi"}`
+	tool := NewFileEditTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: outside + "\n" + payload}); err == nil {
+		t.Fatal("expected error for outside root")
+	}
+}
+
+func TestFileEditToolRejectsMissingPayload(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "note.txt")
+	tool := NewFileEditTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: target}); err == nil {
+		t.Fatal("expected error for missing payload")
+	}
+}
+
+func TestFileEditToolRejectsOldTextMissing(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "note.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	payload := `{"oldText":"missing","newText":"hi"}`
+	tool := NewFileEditTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: target + "\n" + payload}); err == nil {
+		t.Fatal("expected error for missing oldText")
+	}
+}
+
+func TestFileEditToolRejectsEmptyRoots(t *testing.T) {
+	payload := `{"oldText":"hello","newText":"hi"}`
+	tool := NewFileEditTool(PathSandbox{})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: "note.txt\n" + payload}); err == nil {
+		t.Fatal("expected error for empty roots")
+	}
+}

--- a/internal/runtime/file_write_tool.go
+++ b/internal/runtime/file_write_tool.go
@@ -60,6 +60,7 @@ func parseWriteArgs(args string) (string, string, error) {
 	return path, content, nil
 }
 
+// writeFileAtomic writes data to a temp file and renames it into place.
 func writeFileAtomic(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0755); err != nil {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -70,6 +70,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewFileWriteTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
+	if err := registry.Register(NewFileEditTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
+		return nil, err
+	}
 	if memoryCfg != nil && memoryCfg.Enabled {
 		sandbox := PathSandbox{Roots: cfg.SandboxRoots}
 		tool, err := NewMemorySearchTool(memoryCfg, sandbox)


### PR DESCRIPTION
## Summary
- add file.edit tool using JSON payload for single replacement
- enforce sandbox validation before edits
- reuse atomic write helper
- add deterministic tests for success + errors

## Testing
- go test ./...

Fixes #97