### PR TITLE
runtime: add sandboxed file.delete

### DIFF
--- a/internal/runtime/file_delete_tool.go
+++ b/internal/runtime/file_delete_tool.go
@@ -1,0 +1,47 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// FileDeleteTool deletes files within sandbox roots.
+type FileDeleteTool struct {
+	sandbox PathSandbox
+}
+
+// NewFileDeleteTool creates a new file.delete tool.
+func NewFileDeleteTool(sandbox PathSandbox) Tool {
+	return FileDeleteTool{sandbox: sandbox}
+}
+
+// Name returns the tool name.
+func (FileDeleteTool) Name() string {
+	return "file.delete"
+}
+
+// Execute deletes a sandboxed file.
+func (t FileDeleteTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	path := strings.TrimSpace(req.Args)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	safePath, err := t.sandbox.ValidatePath(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(safePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to access file")
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory")
+	}
+	if err := os.Remove(safePath); err != nil {
+		return "", fmt.Errorf("failed to delete file")
+	}
+	return "ok", nil
+}

--- a/internal/runtime/file_delete_tool_test.go
+++ b/internal/runtime/file_delete_tool_test.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileDeleteToolDeletesFile(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "note.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileDeleteTool(PathSandbox{Roots: []string{root}})
+	_, err := tool.Execute(context.Background(), ToolRequest{Args: target})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if _, err := os.Stat(target); !os.IsNotExist(err) {
+		t.Fatalf("expected file deleted, got %v", err)
+	}
+}
+
+func TestFileDeleteToolRejectsDirectories(t *testing.T) {
+	root := t.TempDir()
+	tool := NewFileDeleteTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: root}); err == nil {
+		t.Fatal("expected directory delete to be rejected")
+	}
+}
+
+func TestFileDeleteToolRejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(target, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileDeleteTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: target}); err == nil {
+		t.Fatal("expected error for outside root")
+	}
+}
+
+func TestFileDeleteToolRejectsEmptyRoots(t *testing.T) {
+	tool := NewFileDeleteTool(PathSandbox{})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: "note.txt"}); err == nil {
+		t.Fatal("expected error for empty roots")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -73,6 +73,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewFileEditTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
+	if err := registry.Register(NewFileDeleteTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
+		return nil, err
+	}
 	if memoryCfg != nil && memoryCfg.Enabled {
 		sandbox := PathSandbox{Roots: cfg.SandboxRoots}
 		tool, err := NewMemorySearchTool(memoryCfg, sandbox)


### PR DESCRIPTION
## Summary
- add file.delete tool with sandbox validation
- deny directory deletion and empty roots
- add unit tests for success + error cases

## Testing
- go test ./...

Fixes #101