### PR TITLE
runtime: add sandboxed file.list tool

### DIFF
--- a/internal/runtime/file_list_tool.go
+++ b/internal/runtime/file_list_tool.go
@@ -1,0 +1,85 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+const (
+	fileListMaxEntries     = 200
+	fileListTruncateNotice = "...(truncated)"
+)
+
+// FileListTool lists directory entries within sandbox roots.
+type FileListTool struct {
+	sandbox PathSandbox
+}
+
+// NewFileListTool creates a new file.list tool.
+func NewFileListTool(sandbox PathSandbox) Tool {
+	return FileListTool{sandbox: sandbox}
+}
+
+// Name returns the tool name.
+func (FileListTool) Name() string {
+	return "file.list"
+}
+
+// Execute lists a sandboxed directory.
+func (t FileListTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	path := strings.TrimSpace(req.Args)
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	safePath, err := t.sandbox.ValidatePath(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(safePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to access directory")
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("path is not a directory")
+	}
+	entries, err := os.ReadDir(safePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to list directory")
+	}
+
+	items := make([]fileListEntry, 0, len(entries))
+	for _, entry := range entries {
+		items = append(items, fileListEntry{name: entry.Name(), isDir: entry.IsDir()})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].name < items[j].name
+	})
+
+	truncated := false
+	if len(items) > fileListMaxEntries {
+		items = items[:fileListMaxEntries]
+		truncated = true
+	}
+
+	lines := make([]string, 0, len(items)+1)
+	for _, item := range items {
+		name := item.name
+		if item.isDir {
+			name += "/"
+		}
+		lines = append(lines, name)
+	}
+	if truncated {
+		lines = append(lines, fileListTruncateNotice)
+	}
+	return strings.Join(lines, "\n"), nil
+}
+
+type fileListEntry struct {
+	name  string
+	isDir bool
+}

--- a/internal/runtime/file_list_tool_test.go
+++ b/internal/runtime/file_list_tool_test.go
@@ -1,0 +1,85 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileListToolListsDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "b.txt"), []byte("b"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("a"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := os.Mkdir(filepath.Join(root, "dir"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tool := NewFileListTool(PathSandbox{Roots: []string{root}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: root})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	expected := "a.txt\nb.txt\ndir/"
+	if out != expected {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestFileListToolTruncatesOutput(t *testing.T) {
+	root := t.TempDir()
+	for i := 0; i < fileListMaxEntries+5; i++ {
+		name := fmt.Sprintf("file-%03d.txt", i)
+		if err := os.WriteFile(filepath.Join(root, name), []byte("x"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+
+	tool := NewFileListTool(PathSandbox{Roots: []string{root}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: root})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != fileListMaxEntries+1 {
+		t.Fatalf("expected %d lines, got %d", fileListMaxEntries+1, len(lines))
+	}
+	if lines[len(lines)-1] != fileListTruncateNotice {
+		t.Fatalf("expected truncate notice, got %q", lines[len(lines)-1])
+	}
+}
+
+func TestFileListToolRejectsNonDirectory(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "note.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	tool := NewFileListTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: path}); err == nil {
+		t.Fatal("expected error for non-directory path")
+	}
+}
+
+func TestFileListToolRejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	tool := NewFileListTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: outside}); err == nil {
+		t.Fatal("expected error for outside root")
+	}
+}
+
+func TestFileListToolRejectsEmptyRoots(t *testing.T) {
+	tool := NewFileListTool(PathSandbox{})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: "notes"}); err == nil {
+		t.Fatal("expected error for empty roots")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -76,6 +76,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewFileDeleteTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
+	if err := registry.Register(NewFileListTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
+		return nil, err
+	}
 	if err := registry.Register(NewCommandExecTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- add file.list tool with sandbox validation + directory-only enforcement
- ensure lexicographic output with dir suffixes and truncation guard
- add unit tests for ordering, truncation, and sandbox checks

## Testing
- go test ./...

Fixes #107