### PR TITLE
runtime: add browser.canvas stub tool

### DIFF
--- a/internal/runtime/browser_canvas_tool.go
+++ b/internal/runtime/browser_canvas_tool.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// BrowserCanvasTool returns a stub response for canvas capture requests.
+type BrowserCanvasTool struct {
+	sandbox PathSandbox
+}
+
+// NewBrowserCanvasTool creates a new browser.canvas tool.
+func NewBrowserCanvasTool(sandbox PathSandbox) Tool {
+	return BrowserCanvasTool{sandbox: sandbox}
+}
+
+// Name returns the tool name.
+func (BrowserCanvasTool) Name() string {
+	return "browser.canvas"
+}
+
+// Execute validates args and returns a stub response.
+func (t BrowserCanvasTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	if len(t.sandbox.Roots) == 0 {
+		return "", fmt.Errorf("sandbox roots are not configured")
+	}
+	trimmed := strings.TrimSpace(req.Args)
+	if trimmed == "" {
+		return "", fmt.Errorf("args are required")
+	}
+	var args browserCanvasArgs
+	if err := json.Unmarshal([]byte(trimmed), &args); err != nil {
+		return "", fmt.Errorf("invalid args")
+	}
+	host, err := validateCanvasURL(args.URL)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(
+		"unsupported: browser.canvas not wired (host=%s width=%d height=%d)",
+		host,
+		args.Width,
+		args.Height,
+	), nil
+}
+
+type browserCanvasArgs struct {
+	URL    string `json:"url"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+}
+
+func validateCanvasURL(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("url is required")
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid url")
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return "", fmt.Errorf("url scheme must be http or https")
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("url host is required")
+	}
+	return parsed.Host, nil
+}

--- a/internal/runtime/browser_canvas_tool_test.go
+++ b/internal/runtime/browser_canvas_tool_test.go
@@ -1,0 +1,35 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestBrowserCanvasToolRejectsEmptyRoots(t *testing.T) {
+	tool := NewBrowserCanvasTool(PathSandbox{})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: `{"url":"https://example.com"}`}); err == nil {
+		t.Fatal("expected error for empty roots")
+	}
+}
+
+func TestBrowserCanvasToolRejectsNonHTTPURL(t *testing.T) {
+	tool := NewBrowserCanvasTool(PathSandbox{Roots: []string{"/tmp"}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: `{"url":"file:///tmp/test"}`}); err == nil {
+		t.Fatal("expected error for non-http url")
+	}
+}
+
+func TestBrowserCanvasToolReturnsStub(t *testing.T) {
+	tool := NewBrowserCanvasTool(PathSandbox{Roots: []string{"/tmp"}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: `{"url":"https://example.com/path","width":800,"height":600}`})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(out, "unsupported: browser.canvas not wired") {
+		t.Fatalf("unexpected output: %q", out)
+	}
+	if out != "unsupported: browser.canvas not wired (host=example.com width=800 height=600)" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -82,6 +82,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewCommandExecTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
+	if err := registry.Register(NewBrowserCanvasTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
+		return nil, err
+	}
 	if memoryCfg != nil && memoryCfg.Enabled {
 		sandbox := PathSandbox{Roots: cfg.SandboxRoots}
 		tool, err := NewMemorySearchTool(memoryCfg, sandbox)


### PR DESCRIPTION
## Summary
- add browser.canvas tool stub with http/https validation and sandbox root guard
- return deterministic stub output with sanitized host + dimensions
- add unit tests for root/url validation and stub response

## Testing
- go test ./...

Fixes #106