### PR TITLE
runtime: add sandboxed file.tail tool

### DIFF
--- a/internal/runtime/file_tail_tool.go
+++ b/internal/runtime/file_tail_tool.go
@@ -1,0 +1,127 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	fileTailDefaultLines = 50
+	fileTailMaxLines     = 200
+	fileTailMaxBytes     = 64 * 1024
+)
+
+// FileTailTool reads the last N lines from a file within sandbox roots.
+type FileTailTool struct {
+	sandbox PathSandbox
+}
+
+// NewFileTailTool creates a new file.tail tool.
+func NewFileTailTool(sandbox PathSandbox) Tool {
+	return FileTailTool{sandbox: sandbox}
+}
+
+// Name returns the tool name.
+func (FileTailTool) Name() string {
+	return "file.tail"
+}
+
+// Execute reads the last N lines from a sandboxed file path.
+func (t FileTailTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	path, lines, err := parseTailArgs(req.Args)
+	if err != nil {
+		return "", err
+	}
+	safePath, err := t.sandbox.ValidatePath(path)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(safePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to access file")
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("path is a directory")
+	}
+	out, err := tailFile(safePath, lines)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file")
+	}
+	return out, nil
+}
+
+func parseTailArgs(args string) (string, int, error) {
+	trimmed := strings.TrimSpace(args)
+	if trimmed == "" {
+		return "", 0, fmt.Errorf("path is required")
+	}
+	lines := strings.SplitN(trimmed, "\n", 2)
+	path := strings.TrimSpace(lines[0])
+	if path == "" {
+		return "", 0, fmt.Errorf("path is required")
+	}
+	count := fileTailDefaultLines
+	if len(lines) > 1 {
+		raw := strings.TrimSpace(lines[1])
+		if raw != "" {
+			parsed, err := strconv.Atoi(raw)
+			if err != nil || parsed <= 0 {
+				return "", 0, fmt.Errorf("invalid line count")
+			}
+			count = parsed
+		}
+	}
+	if count > fileTailMaxLines {
+		count = fileTailMaxLines
+	}
+	return path, count, nil
+}
+
+func tailFile(path string, lines int) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return "", err
+	}
+	size := info.Size()
+	if size <= 0 {
+		return "", nil
+	}
+	readSize := size
+	if readSize > fileTailMaxBytes {
+		readSize = fileTailMaxBytes
+	}
+	offset := size - readSize
+
+	buf := make([]byte, int(readSize))
+	reader := io.NewSectionReader(file, offset, readSize)
+	if _, err := io.ReadFull(reader, buf); err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return "", err
+	}
+
+	text := string(buf)
+	parts := strings.Split(text, "\n")
+	if offset > 0 && len(parts) > 1 {
+		parts = parts[1:]
+	}
+	if len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	if len(parts) == 0 {
+		return "", nil
+	}
+	if lines > len(parts) {
+		lines = len(parts)
+	}
+	return strings.Join(parts[len(parts)-lines:], "\n"), nil
+}

--- a/internal/runtime/file_tail_tool_test.go
+++ b/internal/runtime/file_tail_tool_test.go
@@ -1,0 +1,104 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestFileTailToolRejectsEmptyRoots(t *testing.T) {
+	tool := NewFileTailTool(PathSandbox{})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: "note.txt"}); err == nil {
+		t.Fatal("expected error for empty roots")
+	}
+}
+
+func TestFileTailToolRejectsOutsideRoot(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "note.txt")
+	if err := os.WriteFile(outside, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileTailTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: outside}); err == nil {
+		t.Fatal("expected error for outside root")
+	}
+}
+
+func TestFileTailToolRejectsDirectory(t *testing.T) {
+	root := t.TempDir()
+	tool := NewFileTailTool(PathSandbox{Roots: []string{root}})
+	if _, err := tool.Execute(context.Background(), ToolRequest{Args: root}); err == nil {
+		t.Fatal("expected error for directory path")
+	}
+}
+
+func TestFileTailToolReturnsLastLines(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "note.txt")
+	content := "line1\nline2\nline3\nline4\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileTailTool(PathSandbox{Roots: []string{root}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: path + "\n2"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if out != "line3\nline4" {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestFileTailToolCapsLines(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "note.txt")
+	var builder strings.Builder
+	for i := 0; i < fileTailMaxLines+10; i++ {
+		builder.WriteString(fmt.Sprintf("line-%03d\n", i))
+	}
+	if err := os.WriteFile(path, []byte(builder.String()), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileTailTool(PathSandbox{Roots: []string{root}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: path + "\n999"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != fileTailMaxLines {
+		t.Fatalf("expected %d lines, got %d", fileTailMaxLines, len(lines))
+	}
+	if lines[0] != fmt.Sprintf("line-%03d", 10) {
+		t.Fatalf("unexpected first line: %q", lines[0])
+	}
+}
+
+func TestFileTailToolCapsBytes(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "note.txt")
+	lineSize := len(fmt.Sprintf("line-%06d\n", 0))
+	linesNeeded := (fileTailMaxBytes / lineSize) + 20
+	var builder strings.Builder
+	for i := 0; i < linesNeeded; i++ {
+		builder.WriteString(fmt.Sprintf("line-%06d\n", i))
+	}
+	if err := os.WriteFile(path, []byte(builder.String()), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	tool := NewFileTailTool(PathSandbox{Roots: []string{root}})
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: path + "\n5"})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != 5 {
+		t.Fatalf("expected 5 lines, got %d", len(lines))
+	}
+	if lines[4] != fmt.Sprintf("line-%06d", linesNeeded-1) {
+		t.Fatalf("unexpected last line: %q", lines[4])
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -79,6 +79,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewFileListTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
+	if err := registry.Register(NewFileTailTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
+		return nil, err
+	}
 	if err := registry.Register(NewCommandExecTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- add file.tail tool with sandbox validation and file-only enforcement
- implement capped tail reader with line count limit
- add unit tests for sandbox errors and tail behavior

## Testing
- go test ./...

Fixes #110