### PR TITLE
runtime: add command.exec allowlist

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -125,6 +125,10 @@ agents:
     # Tool file sandbox roots (empty = deny all file access)
     sandboxRoots:
       - "/home/you/fractalbot"
+    # command.exec allowlist (base command names only; empty = deny all)
+    commandExec:
+      allowlist:
+        - "go"
 
   # Optional: local semantic memory search (Issue #81 WIP)
   memory:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,6 +166,13 @@ type RuntimeConfig struct {
 	MaxReplyChars int      `yaml:"maxReplyChars,omitempty"`
 	// SandboxRoots restricts tool file access to these roots. Empty means deny all.
 	SandboxRoots []string `yaml:"sandboxRoots,omitempty"`
+	// CommandExec controls command.exec allowlist behavior.
+	CommandExec *CommandExecConfig `yaml:"commandExec,omitempty"`
+}
+
+// CommandExecConfig configures command.exec allowlist.
+type CommandExecConfig struct {
+	Allowlist []string `yaml:"allowlist,omitempty"`
 }
 
 // LoadConfig loads configuration from file.

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -82,7 +82,11 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewFileTailTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
-	if err := registry.Register(NewCommandExecTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
+	commandAllowlist := []string{}
+	if cfg.CommandExec != nil {
+		commandAllowlist = cfg.CommandExec.Allowlist
+	}
+	if err := registry.Register(NewCommandExecTool(PathSandbox{Roots: cfg.SandboxRoots}, commandAllowlist)); err != nil {
 		return nil, err
 	}
 	if err := registry.Register(NewBrowserCanvasTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {


### PR DESCRIPTION
## Summary
- add runtime config for command.exec allowlist and wire it into tool registration
- enforce allowlist by base command name with default-deny when empty
- add unit tests for allow/deny behavior

## Testing
- go test ./...

Fixes #112