### PR TITLE
runtime: add /tool prefix and tools.list

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,6 +64,9 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewVersionTool()); err != nil {
 		return nil, err
 	}
+	if err := registry.Register(NewToolsListTool(cfg.AllowedTools)); err != nil {
+		return nil, err
+	}
 	if err := registry.Register(NewFileReadTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {
 		return nil, err
 	}
@@ -192,8 +195,18 @@ func parseToolInvocation(text string) (string, string, bool) {
 		name, args := splitToolArgs(rest)
 		return name, args, true
 	}
+	if strings.HasPrefix(lower, "/tool:") {
+		rest := strings.TrimSpace(trimmed[len("/tool:"):])
+		name, args := splitToolArgs(rest)
+		return name, args, true
+	}
 	if strings.HasPrefix(lower, "tool ") {
 		rest := strings.TrimSpace(trimmed[len("tool "):])
+		name, args := splitToolArgs(rest)
+		return name, args, true
+	}
+	if strings.HasPrefix(lower, "/tool ") {
+		rest := strings.TrimSpace(trimmed[len("/tool "):])
 		name, args := splitToolArgs(rest)
 		return name, args, true
 	}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -84,3 +84,16 @@ func TestParseToolInvocationPreservesArgs(t *testing.T) {
 		t.Fatalf("unexpected args: %q", args)
 	}
 }
+
+func TestParseToolInvocationSlashTool(t *testing.T) {
+	name, args, ok := parseToolInvocation("/tool echo line1\nline2")
+	if !ok {
+		t.Fatal("expected tool invocation")
+	}
+	if name != "echo" {
+		t.Fatalf("expected name echo, got %s", name)
+	}
+	if args != "line1\nline2" {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}

--- a/internal/runtime/tools_list_tool.go
+++ b/internal/runtime/tools_list_tool.go
@@ -1,0 +1,49 @@
+package runtime
+
+import (
+	"context"
+	"sort"
+	"strings"
+)
+
+// ToolsListTool returns the allowlisted tool names.
+type ToolsListTool struct {
+	tools []string
+}
+
+// NewToolsListTool creates a new tools.list tool.
+func NewToolsListTool(allowed []string) Tool {
+	return ToolsListTool{tools: normalizeToolNames(allowed)}
+}
+
+// Name returns the tool name.
+func (ToolsListTool) Name() string {
+	return "tools.list"
+}
+
+// Execute lists allowlisted tool names.
+func (t ToolsListTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	_ = req
+	if len(t.tools) == 0 {
+		return "", nil
+	}
+	return strings.Join(t.tools, "\n"), nil
+}
+
+func normalizeToolNames(allowed []string) []string {
+	unique := make(map[string]struct{})
+	for _, name := range allowed {
+		trimmed := strings.ToLower(strings.TrimSpace(name))
+		if trimmed == "" {
+			continue
+		}
+		unique[trimmed] = struct{}{}
+	}
+	out := make([]string, 0, len(unique))
+	for name := range unique {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/runtime/tools_list_tool_test.go
+++ b/internal/runtime/tools_list_tool_test.go
@@ -1,0 +1,18 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+func TestToolsListToolOutputsSortedAllowlist(t *testing.T) {
+	tool := NewToolsListTool([]string{"version", "echo", "tools.list", "echo"})
+	out, err := tool.Execute(context.Background(), ToolRequest{})
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	expected := "echo\ntools.list\nversion"
+	if out != expected {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add /tool prefix parsing alongside tool/tool:
- add tools.list tool to list allowlisted tool names
- add tests for /tool parsing and tools.list output

## Testing
- go test ./...

Fixes #120