### PR TITLE
runtime: support /tool@ mentions

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -200,6 +200,12 @@ func parseToolInvocation(text string) (string, string, bool) {
 		name, args := splitToolArgs(rest)
 		return name, args, true
 	}
+	if strings.HasPrefix(lower, "/tool@") {
+		rest := strings.TrimSpace(trimmed[len("/tool@"):])
+		rest = stripToolMention(rest)
+		name, args := splitToolArgs(rest)
+		return name, args, true
+	}
 	if strings.HasPrefix(lower, "tool ") {
 		rest := strings.TrimSpace(trimmed[len("tool "):])
 		name, args := splitToolArgs(rest)
@@ -227,4 +233,20 @@ func splitToolArgs(rest string) (string, string) {
 	}
 	name := strings.ToLower(strings.TrimSpace(trimmed))
 	return name, ""
+}
+
+func stripToolMention(rest string) string {
+	trimmed := strings.TrimSpace(rest)
+	if trimmed == "" {
+		return ""
+	}
+	for idx, ch := range trimmed {
+		if ch == ':' {
+			return strings.TrimSpace(trimmed[idx+1:])
+		}
+		if unicode.IsSpace(ch) {
+			return strings.TrimSpace(trimmed[idx+1:])
+		}
+	}
+	return ""
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -97,3 +97,29 @@ func TestParseToolInvocationSlashTool(t *testing.T) {
 		t.Fatalf("unexpected args: %q", args)
 	}
 }
+
+func TestParseToolInvocationSlashToolMentionSpace(t *testing.T) {
+	name, args, ok := parseToolInvocation("/tool@bot echo line1\nline2")
+	if !ok {
+		t.Fatal("expected tool invocation")
+	}
+	if name != "echo" {
+		t.Fatalf("expected name echo, got %s", name)
+	}
+	if args != "line1\nline2" {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}
+
+func TestParseToolInvocationSlashToolMentionColon(t *testing.T) {
+	name, args, ok := parseToolInvocation("/tool@bot: echo line1\nline2")
+	if !ok {
+		t.Fatal("expected tool invocation")
+	}
+	if name != "echo" {
+		t.Fatalf("expected name echo, got %s", name)
+	}
+	if args != "line1\nline2" {
+		t.Fatalf("unexpected args: %q", args)
+	}
+}


### PR DESCRIPTION
## Summary
- extend /tool parsing to accept /tool@bot and /tool@bot: forms
- preserve multiline args and ignore the mention suffix
- add unit tests for both mention variants

## Testing
- go test ./...

Fixes #122