### PR TITLE
runtime: list registered allowlisted tools

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -64,7 +64,7 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 	if err := registry.Register(NewVersionTool()); err != nil {
 		return nil, err
 	}
-	if err := registry.Register(NewToolsListTool(cfg.AllowedTools)); err != nil {
+	if err := registry.Register(NewToolsListTool(registry)); err != nil {
 		return nil, err
 	}
 	if err := registry.Register(NewFileReadTool(PathSandbox{Roots: cfg.SandboxRoots})); err != nil {

--- a/internal/runtime/tools.go
+++ b/internal/runtime/tools.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -84,6 +85,21 @@ func (r *ToolRegistry) isAllowed(name string) bool {
 	}
 	_, ok := r.allowed[name]
 	return ok
+}
+
+// ListAllowedTools returns sorted tool names that are both registered and allowed.
+func (r *ToolRegistry) ListAllowedTools() []string {
+	if r == nil || !r.configured {
+		return nil
+	}
+	out := make([]string, 0, len(r.tools))
+	for name := range r.tools {
+		if r.isAllowed(name) {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // NewEchoTool returns a simple echo tool.

--- a/internal/runtime/tools_list_tool.go
+++ b/internal/runtime/tools_list_tool.go
@@ -2,18 +2,17 @@ package runtime
 
 import (
 	"context"
-	"sort"
 	"strings"
 )
 
 // ToolsListTool returns the allowlisted tool names.
 type ToolsListTool struct {
-	tools []string
+	registry *ToolRegistry
 }
 
 // NewToolsListTool creates a new tools.list tool.
-func NewToolsListTool(allowed []string) Tool {
-	return ToolsListTool{tools: normalizeToolNames(allowed)}
+func NewToolsListTool(registry *ToolRegistry) Tool {
+	return ToolsListTool{registry: registry}
 }
 
 // Name returns the tool name.
@@ -25,25 +24,12 @@ func (ToolsListTool) Name() string {
 func (t ToolsListTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
 	_ = ctx
 	_ = req
-	if len(t.tools) == 0 {
+	if t.registry == nil {
 		return "", nil
 	}
-	return strings.Join(t.tools, "\n"), nil
-}
-
-func normalizeToolNames(allowed []string) []string {
-	unique := make(map[string]struct{})
-	for _, name := range allowed {
-		trimmed := strings.ToLower(strings.TrimSpace(name))
-		if trimmed == "" {
-			continue
-		}
-		unique[trimmed] = struct{}{}
+	tools := t.registry.ListAllowedTools()
+	if len(tools) == 0 {
+		return "", nil
 	}
-	out := make([]string, 0, len(unique))
-	for name := range unique {
-		out = append(out, name)
-	}
-	sort.Strings(out)
-	return out
+	return strings.Join(tools, "\n"), nil
 }

--- a/internal/runtime/tools_list_tool_test.go
+++ b/internal/runtime/tools_list_tool_test.go
@@ -6,7 +6,17 @@ import (
 )
 
 func TestToolsListToolOutputsSortedAllowlist(t *testing.T) {
-	tool := NewToolsListTool([]string{"version", "echo", "tools.list", "echo"})
+	registry := NewToolRegistry([]string{"version", "echo", "tools.list", "echo", "ghost"})
+	if err := registry.Register(NewVersionTool()); err != nil {
+		t.Fatalf("register version: %v", err)
+	}
+	if err := registry.Register(NewEchoTool()); err != nil {
+		t.Fatalf("register echo: %v", err)
+	}
+	if err := registry.Register(NewToolsListTool(registry)); err != nil {
+		t.Fatalf("register tools.list: %v", err)
+	}
+	tool := NewToolsListTool(registry)
 	out, err := tool.Execute(context.Background(), ToolRequest{})
 	if err != nil {
 		t.Fatalf("execute: %v", err)


### PR DESCRIPTION
## Summary
- make tools.list return registered ∩ allowlisted tools only
- keep output sorted and lowercased
- update tools.list tests for registered filtering

## Testing
- go test ./...

Fixes #126