### PR TITLE
runtime: hint on bare tool command

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -149,7 +149,7 @@ func (r *BasicRuntime) HandleTask(ctx context.Context, task Task) (string, error
 	name, args, ok := parseToolInvocation(text)
 	if ok {
 		if name == "" {
-			return r.truncate("❌ tool name is required"), nil
+			return r.truncate("usage: tool <name> <args...> (see tools.list)"), nil
 		}
 		out, err := r.registry.Execute(ctx, name, ToolRequest{Args: args, Task: task})
 		if err != nil {
@@ -190,6 +190,9 @@ func (r *BasicRuntime) truncate(text string) string {
 func parseToolInvocation(text string) (string, string, bool) {
 	trimmed := strings.TrimSpace(text)
 	lower := strings.ToLower(trimmed)
+	if lower == "tool" || lower == "/tool" {
+		return "", "", true
+	}
 	if strings.HasPrefix(lower, "tool:") {
 		rest := strings.TrimSpace(trimmed[len("tool:"):])
 		name, args := splitToolArgs(rest)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -72,6 +72,29 @@ func TestRuntimeToolOutputTruncation(t *testing.T) {
 	}
 }
 
+func TestRuntimeToolUsageHint(t *testing.T) {
+	rt, err := NewRuntime(&config.RuntimeConfig{
+		Enabled:      true,
+		AllowedTools: []string{"echo", "tools.list"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	for _, input := range []string{"tool", "/tool"} {
+		reply, err := rt.HandleTask(context.Background(), Task{
+			Agent:   "qa-1",
+			Text:    input,
+			Channel: "telegram",
+		})
+		if err != nil {
+			t.Fatalf("HandleTask: %v", err)
+		}
+		if !strings.Contains(reply, "tools.list") {
+			t.Fatalf("expected usage hint with tools.list, got %q", reply)
+		}
+	}
+}
+
 func TestParseToolInvocationPreservesArgs(t *testing.T) {
 	name, args, ok := parseToolInvocation("tool echo line1\nline2")
 	if !ok {


### PR DESCRIPTION
## Summary
- return a usage hint for bare tool invocations (tool or /tool)
- mention tools.list to discover allowed tools
- add runtime tests for the new hint behavior

## Testing
- go test ./...

Fixes #128