### PR TITLE
runtime: hint tools.list on tool errors

### DIFF
--- a/internal/runtime/tools.go
+++ b/internal/runtime/tools.go
@@ -71,10 +71,10 @@ func (r *ToolRegistry) Execute(ctx context.Context, name string, req ToolRequest
 	}
 	tool, ok := r.tools[trimmed]
 	if !ok {
-		return "", fmt.Errorf("unknown tool %q", trimmed)
+		return "", fmt.Errorf("unknown tool %q (see tools.list)", trimmed)
 	}
 	if !r.isAllowed(trimmed) {
-		return "", fmt.Errorf("tool %q is not allowed", trimmed)
+		return "", fmt.Errorf("tool %q is not allowed (see tools.list)", trimmed)
 	}
 	return tool.Execute(ctx, req)
 }

--- a/internal/runtime/tools_test.go
+++ b/internal/runtime/tools_test.go
@@ -1,0 +1,35 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestToolRegistryUnknownToolSuggestsList(t *testing.T) {
+	registry := NewToolRegistry([]string{"echo"})
+	if err := registry.Register(NewEchoTool()); err != nil {
+		t.Fatalf("register echo: %v", err)
+	}
+	_, err := registry.Execute(context.Background(), "missing", ToolRequest{})
+	if err == nil {
+		t.Fatal("expected error for unknown tool")
+	}
+	if !strings.Contains(err.Error(), "tools.list") {
+		t.Fatalf("expected tools.list hint, got %q", err.Error())
+	}
+}
+
+func TestToolRegistryDisallowedToolSuggestsList(t *testing.T) {
+	registry := NewToolRegistry([]string{"version"})
+	if err := registry.Register(NewEchoTool()); err != nil {
+		t.Fatalf("register echo: %v", err)
+	}
+	_, err := registry.Execute(context.Background(), "echo", ToolRequest{})
+	if err == nil {
+		t.Fatal("expected error for disallowed tool")
+	}
+	if !strings.Contains(err.Error(), "tools.list") {
+		t.Fatalf("expected tools.list hint, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- add tools.list hints to unknown and disallowed tool errors
- add unit tests for both error paths

## Testing
- go test ./...

Fixes #130