### PR TITLE
channels: hint config when /agents empty

### DIFF
--- a/internal/channels/agent_selection.go
+++ b/internal/channels/agent_selection.go
@@ -11,6 +11,7 @@ import (
 var agentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
 
 var errDefaultAgentMissing = errors.New("default agent is not configured")
+var noAgentsConfiguredMessage = "⚠️ No agents configured.\nSet agents.ohMyCode.defaultAgent or agents.ohMyCode.allowedAgents."
 
 // AgentSelection describes the resolved target agent and task text.
 type AgentSelection struct {

--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -308,7 +308,7 @@ func (b *DiscordBot) handleCommand(ctx context.Context, msg *discordInboundMessa
 			}
 		}
 		if len(names) == 0 {
-			return true, b.reply(ctx, msg, "⚠️ No agents configured")
+			return true, b.reply(ctx, msg, noAgentsConfiguredMessage)
 		}
 		var sb strings.Builder
 		sb.WriteString("Allowed agents:\n")

--- a/internal/channels/discord_test.go
+++ b/internal/channels/discord_test.go
@@ -128,6 +128,34 @@ func TestDiscordWhoamiAllowedWithoutAllowlist(t *testing.T) {
 	}
 }
 
+func TestDiscordAgentsEmptyConfigHint(t *testing.T) {
+	bot, err := NewDiscordBot("token", []string{"123"}, "", nil)
+	if err != nil {
+		t.Fatalf("NewDiscordBot: %v", err)
+	}
+
+	var sent discordSendCapture
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		sent = discordSendCapture{channelID: channelID, text: text}
+		return nil
+	}
+
+	bot.handleMessageEvent(context.Background(), &discordInboundMessage{
+		text:        "/agents",
+		userID:      "123",
+		channelID:   "D123",
+		channelType: "dm",
+	})
+
+	if !strings.Contains(sent.text, "agents.ohMyCode.defaultAgent") {
+		t.Fatalf("expected defaultAgent hint, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "agents.ohMyCode.allowedAgents") {
+		t.Fatalf("expected allowedAgents hint, got %q", sent.text)
+	}
+}
+
 func TestDiscordIgnoreNonDM(t *testing.T) {
 	bot, err := NewDiscordBot("token", []string{"123"}, "", nil)
 	if err != nil {

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -347,7 +347,7 @@ func (b *FeishuBot) handleCommand(ctx context.Context, msg *feishuInboundMessage
 			names = filterOutAgentName(names, defaultName)
 		}
 		if len(names) == 0 && defaultName == "" {
-			return true, b.reply(ctx, msg, "⚠️ No agents configured")
+			return true, b.reply(ctx, msg, noAgentsConfiguredMessage)
 		}
 		var sb strings.Builder
 		sb.WriteString("Allowed agents:\n")

--- a/internal/channels/feishu_test.go
+++ b/internal/channels/feishu_test.go
@@ -180,6 +180,28 @@ func TestFeishuAgentsAllowlistUnset(t *testing.T) {
 	}
 }
 
+func TestFeishuAgentsEmptyConfigHint(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+
+	var sent feishuSendCapture
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		sent = feishuSendCapture{receiveIDType: receiveIDType, receiveID: receiveID, text: text}
+		return nil
+	}
+
+	bot.handleMessageEvent(context.Background(), buildFeishuEvent("/agents", "p2p", "ou_me", "u_me", "chat1"))
+
+	if !strings.Contains(sent.text, "agents.ohMyCode.defaultAgent") {
+		t.Fatalf("expected defaultAgent hint, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "agents.ohMyCode.allowedAgents") {
+		t.Fatalf("expected allowedAgents hint, got %q", sent.text)
+	}
+}
+
 func TestFeishuAgentAllowlistHint(t *testing.T) {
 	bot, err := NewFeishuBot("app", "secret", "feishu", []string{"ou_allowed"}, "coder-a", []string{"coder-a"})
 	if err != nil {

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -332,7 +332,7 @@ func (b *SlackBot) handleCommand(ctx context.Context, msg *slackInboundMessage) 
 			}
 		}
 		if len(names) == 0 {
-			return true, b.reply(ctx, msg, "⚠️ No agents configured")
+			return true, b.reply(ctx, msg, noAgentsConfiguredMessage)
 		}
 		var sb strings.Builder
 		sb.WriteString("Allowed agents:\n")

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -165,6 +165,34 @@ func TestSlackWhoamiAllowedWithoutAllowlist(t *testing.T) {
 	}
 }
 
+func TestSlackAgentsEmptyConfigHint(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	var sent slackSendCapture
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		sent = slackSendCapture{channelID: channelID, text: text}
+		return nil
+	}
+
+	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
+		text:        "/agents",
+		userID:      "U123",
+		channelID:   "D456",
+		channelType: "im",
+	})
+
+	if !strings.Contains(sent.text, "agents.ohMyCode.defaultAgent") {
+		t.Fatalf("expected defaultAgent hint, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "agents.ohMyCode.allowedAgents") {
+		t.Fatalf("expected allowedAgents hint, got %q", sent.text)
+	}
+}
+
 func TestSlackReplyTruncation(t *testing.T) {
 	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, "", nil)
 	if err != nil {

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -763,7 +763,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 			names = filterOutAgentName(names, defaultName)
 		}
 		if len(names) == 0 && defaultName == "" {
-			return true, b.SendMessage(b.ctx, msg.Chat.ID, "⚠️ No agents configured")
+			return true, b.SendMessage(b.ctx, msg.Chat.ID, noAgentsConfiguredMessage)
 		}
 		var sb strings.Builder
 		sb.WriteString("Allowed agents:\n")

--- a/internal/channels/telegram_agents_test.go
+++ b/internal/channels/telegram_agents_test.go
@@ -68,6 +68,36 @@ func TestTelegramAgentsAllowlistUnset(t *testing.T) {
 	}
 }
 
+func TestTelegramAgentsEmptyConfigHint(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "", nil)
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	msg := &TelegramMessage{
+		Text: "/agents",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 99},
+	}
+
+	handled, err := bot.handleCommand(msg)
+	if !handled {
+		t.Fatalf("expected handled")
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(payload.Text, "agents.ohMyCode.defaultAgent") {
+		t.Fatalf("expected defaultAgent hint, got %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "agents.ohMyCode.allowedAgents") {
+		t.Fatalf("expected allowedAgents hint, got %q", payload.Text)
+	}
+}
+
 func TestTelegramAgentSelectionErrorIncludesHint(t *testing.T) {
 	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
 	if err != nil {


### PR DESCRIPTION
## Summary
- return an actionable config hint when /agents has no default or allowlist
- apply to Telegram, Feishu, Slack, and Discord
- add tests for empty-config /agents replies across channels

## Testing
- go test ./...

Fixes #134