### PR TITLE
runtime: add /tools alias parsing

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -193,6 +193,12 @@ func parseToolInvocation(text string) (string, string, bool) {
 	if lower == "tool" || lower == "/tool" {
 		return "", "", true
 	}
+	if lower == "/tools" {
+		return "tools.list", "", true
+	}
+	if strings.HasPrefix(lower, "/tools@") {
+		return "tools.list", "", true
+	}
 	if strings.HasPrefix(lower, "tool:") {
 		rest := strings.TrimSpace(trimmed[len("tool:"):])
 		name, args := splitToolArgs(rest)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -146,3 +146,29 @@ func TestParseToolInvocationSlashToolMentionColon(t *testing.T) {
 		t.Fatalf("unexpected args: %q", args)
 	}
 }
+
+func TestParseToolInvocationSlashToolsAlias(t *testing.T) {
+	name, args, ok := parseToolInvocation("/tools")
+	if !ok {
+		t.Fatal("expected tool invocation")
+	}
+	if name != "tools.list" {
+		t.Fatalf("expected name tools.list, got %s", name)
+	}
+	if args != "" {
+		t.Fatalf("expected empty args, got %q", args)
+	}
+}
+
+func TestParseToolInvocationSlashToolsMention(t *testing.T) {
+	name, args, ok := parseToolInvocation("/tools@bot:")
+	if !ok {
+		t.Fatal("expected tool invocation")
+	}
+	if name != "tools.list" {
+		t.Fatalf("expected name tools.list, got %s", name)
+	}
+	if args != "" {
+		t.Fatalf("expected empty args, got %q", args)
+	}
+}


### PR DESCRIPTION
## Summary
- add /tools alias parsing for tools.list
- support /tools@BotName and /tools@BotName: forms
- add runtime tests covering the new alias

## Testing
- go test ./...

Fixes #139