### PR TITLE
agent: make ohMyCode prompt channel-agnostic

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -186,16 +186,11 @@ func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride st
 			agentName = defaultOhMyCodeDefaultAgent
 		}
 	}
-	name, err := m.validateOhMyCodeAgent(agentName)
-	if err != nil {
-		return "", err
-	}
-
 	validatedName, err := m.validateOhMyCodeAgent(agentName)
 	if err != nil {
 		return "", err
 	}
-	agentName = validatedName
+	name := validatedName
 
 	timeout := defaultOhMyCodeAssignTimeout
 	if m.config.OhMyCode.AssignTimeoutSeconds > 0 {
@@ -389,7 +384,7 @@ func runOhMyCodeAgentManager(ctx context.Context, workspace, script, stdin strin
 }
 
 func buildOhMyCodeTaskPrompt(userText string) string {
-	return fmt.Sprintf("Telegram user message:\n%s\n", strings.TrimSpace(userText))
+	return fmt.Sprintf("User message:\n%s\n", strings.TrimSpace(userText))
 }
 
 func extractMonitorSnapshot(monitorOutput string) string {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -60,3 +60,16 @@ func TestValidateOhMyCodeAgentInvalidName(t *testing.T) {
 		t.Fatalf("expected invalid name error, got %v", err)
 	}
 }
+
+func TestBuildOhMyCodeTaskPrompt(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("hello world")
+	if !strings.HasPrefix(out, "User message:\n") {
+		t.Fatalf("expected user message prefix, got %q", out)
+	}
+	if strings.Contains(out, "Telegram") {
+		t.Fatalf("did not expect channel-specific wording, got %q", out)
+	}
+	if !strings.Contains(out, "hello world") {
+		t.Fatalf("expected message content, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- update ohMyCode task prompt to be channel-agnostic
- remove duplicate agent validation call
- add unit test for prompt formatting

## Testing
- go test ./...

Fixes #141