### PR TITLE
channels: add /status to Slack and Discord

### DIFF
--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -300,6 +300,8 @@ func (b *DiscordBot) handleCommand(ctx context.Context, msg *discordInboundMessa
 	switch command {
 	case "/help", "/start":
 		return true, b.reply(ctx, msg, b.helpText())
+	case "/status":
+		return true, b.reply(ctx, msg, b.statusText())
 	case "/agents":
 		names := b.agentAllow.Names()
 		defaultName := strings.TrimSpace(b.defaultAgent)
@@ -337,6 +339,7 @@ func (b *DiscordBot) helpText() string {
 		"",
 		"Commands:",
 		"  /help - show this help",
+		"  /status - bot status",
 		"  /agents - list allowed agents",
 		"  /whoami - show your Discord IDs",
 		"",
@@ -344,6 +347,30 @@ func (b *DiscordBot) helpText() string {
 		"  /agent <name> <task...>",
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (b *DiscordBot) statusText() string {
+	lastActivity := "never"
+	if ts := b.LastActivity(); !ts.IsZero() {
+		lastActivity = ts.UTC().Format(time.RFC3339)
+	}
+	lastError := "none"
+	if ts := b.LastError(); !ts.IsZero() {
+		lastError = ts.UTC().Format(time.RFC3339)
+	}
+	defaultAgent := strings.TrimSpace(b.defaultAgent)
+	if defaultAgent == "" {
+		defaultAgent = "(none)"
+	}
+	allowlistConfigured := b.agentAllow.configured
+	return strings.Join([]string{
+		"Bot Status",
+		fmt.Sprintf("running: %t", b.IsRunning()),
+		fmt.Sprintf("last_activity: %s", lastActivity),
+		fmt.Sprintf("last_error: %s", lastError),
+		fmt.Sprintf("default_agent: %s", defaultAgent),
+		fmt.Sprintf("allowed_agents_configured: %t", allowlistConfigured),
+	}, "\n")
 }
 
 func isDiscordSafeCommand(text string) bool {

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -324,6 +324,8 @@ func (b *SlackBot) handleCommand(ctx context.Context, msg *slackInboundMessage) 
 	switch command {
 	case "/help", "/start":
 		return true, b.reply(ctx, msg, b.helpText())
+	case "/status":
+		return true, b.reply(ctx, msg, b.statusText())
 	case "/agents":
 		names := b.agentAllow.Names()
 		defaultName := strings.TrimSpace(b.defaultAgent)
@@ -361,6 +363,7 @@ func (b *SlackBot) helpText() string {
 		"",
 		"Commands:",
 		"  /help - show this help",
+		"  /status - bot status",
 		"  /agents - list allowed agents",
 		"  /whoami - show your Slack IDs",
 		"",
@@ -368,6 +371,30 @@ func (b *SlackBot) helpText() string {
 		"  /agent <name> <task...>",
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (b *SlackBot) statusText() string {
+	lastActivity := "never"
+	if ts := b.LastActivity(); !ts.IsZero() {
+		lastActivity = ts.UTC().Format(time.RFC3339)
+	}
+	lastError := "none"
+	if ts := b.LastError(); !ts.IsZero() {
+		lastError = ts.UTC().Format(time.RFC3339)
+	}
+	defaultAgent := strings.TrimSpace(b.defaultAgent)
+	if defaultAgent == "" {
+		defaultAgent = "(none)"
+	}
+	allowlistConfigured := b.agentAllow.configured
+	return strings.Join([]string{
+		"Bot Status",
+		fmt.Sprintf("running: %t", b.IsRunning()),
+		fmt.Sprintf("last_activity: %s", lastActivity),
+		fmt.Sprintf("last_error: %s", lastError),
+		fmt.Sprintf("default_agent: %s", defaultAgent),
+		fmt.Sprintf("allowed_agents_configured: %t", allowlistConfigured),
+	}, "\n")
 }
 
 func isSlackSafeCommand(text string) bool {

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -282,3 +282,31 @@ func TestSlackIgnoreNonDM(t *testing.T) {
 		t.Fatalf("expected no reply for non-DM, got %q", sent.text)
 	}
 }
+
+func TestSlackStatusDoesNotLeakTokens(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-secret", "xapp-secret", []string{"U123"}, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	var sent slackSendCapture
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		sent = slackSendCapture{channelID: channelID, text: text}
+		return nil
+	}
+
+	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
+		text:        "/status",
+		userID:      "U123",
+		channelID:   "D456",
+		channelType: "im",
+	})
+
+	if !strings.Contains(sent.text, "Bot Status") {
+		t.Fatalf("expected status header, got %q", sent.text)
+	}
+	if strings.Contains(sent.text, "xoxb-secret") || strings.Contains(sent.text, "xapp-secret") {
+		t.Fatalf("expected status to omit tokens, got %q", sent.text)
+	}
+}


### PR DESCRIPTION
## Summary
- add /status command to Slack/Discord DM handlers
- include running/telemetry/agent settings without secrets
- update help text and add tests to guard against token leakage

## Testing
- go test ./...

Fixes #148