### PR TITLE
channels: add /status to Feishu

### DIFF
--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -340,6 +340,8 @@ func (b *FeishuBot) handleCommand(ctx context.Context, msg *feishuInboundMessage
 	switch command {
 	case "/help", "/start":
 		return true, b.reply(ctx, msg, b.helpText())
+	case "/status":
+		return true, b.reply(ctx, msg, b.statusText())
 	case "/agents":
 		names := b.agentAllow.Names()
 		defaultName := strings.TrimSpace(b.defaultAgent)
@@ -372,6 +374,7 @@ func (b *FeishuBot) helpText() string {
 		"",
 		"Commands:",
 		"  /help - show this help",
+		"  /status - bot status",
 		"  /agents - list allowed agents",
 		"  /whoami - show your Feishu IDs",
 		"",
@@ -379,6 +382,31 @@ func (b *FeishuBot) helpText() string {
 		"  /agent <name> <task...>",
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (b *FeishuBot) statusText() string {
+	lastActivity := "never"
+	if ts := b.LastActivity(); !ts.IsZero() {
+		lastActivity = ts.UTC().Format(time.RFC3339)
+	}
+	lastError := "none"
+	if ts := b.LastError(); !ts.IsZero() {
+		lastError = ts.UTC().Format(time.RFC3339)
+	}
+	defaultAgent := strings.TrimSpace(b.defaultAgent)
+	if defaultAgent == "" {
+		defaultAgent = "(none)"
+	}
+	allowlistConfigured := b.agentAllow.configured
+	return strings.Join([]string{
+		"Bot Status",
+		"bot: feishu",
+		fmt.Sprintf("running: %t", b.IsRunning()),
+		fmt.Sprintf("last_activity: %s", lastActivity),
+		fmt.Sprintf("last_error: %s", lastError),
+		fmt.Sprintf("default_agent: %s", defaultAgent),
+		fmt.Sprintf("allowed_agents_configured: %t", allowlistConfigured),
+	}, "\n")
 }
 
 func (b *FeishuBot) reply(ctx context.Context, msg *feishuInboundMessage, text string) error {

--- a/internal/channels/feishu_test.go
+++ b/internal/channels/feishu_test.go
@@ -127,6 +127,31 @@ func TestFeishuWhoamiCommand(t *testing.T) {
 	}
 }
 
+func TestFeishuStatusDoesNotLeakSecret(t *testing.T) {
+	bot, err := NewFeishuBot("app", "feishu-secret", "feishu", nil, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+
+	var sent feishuSendCapture
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		sent = feishuSendCapture{receiveIDType: receiveIDType, receiveID: receiveID, text: text}
+		return nil
+	}
+
+	bot.handleMessageEvent(context.Background(), buildFeishuEvent("/status", "p2p", "ou_me", "u_me", "chat1"))
+
+	if !strings.Contains(sent.text, "Bot Status") {
+		t.Fatalf("expected status header, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "bot: feishu") {
+		t.Fatalf("expected bot name line, got %q", sent.text)
+	}
+	if strings.Contains(sent.text, "feishu-secret") {
+		t.Fatalf("expected status to omit secret, got %q", sent.text)
+	}
+}
+
 func TestFeishuAgentsCommand(t *testing.T) {
 	bot, err := NewFeishuBot("app", "secret", "feishu", nil, "qa-1", []string{"qa-1", "coder-a"})
 	if err != nil {


### PR DESCRIPTION
## Summary
- add /status command to Feishu DM handler with safe status fields
- update Feishu help text to mention /status
- add test to ensure status output omits appSecret

## Testing
- go test ./...

Fixes #150