### PR TITLE
channels: allow /agents without allowlist

### DIFF
--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -383,7 +383,7 @@ func isDiscordSafeCommand(text string) bool {
 		return false
 	}
 	switch fields[0] {
-	case "/help", "/start", "/whoami", "/status":
+	case "/help", "/start", "/whoami", "/status", "/agents":
 		return true
 	default:
 		return false

--- a/internal/channels/discord_test.go
+++ b/internal/channels/discord_test.go
@@ -319,3 +319,31 @@ func TestDiscordStatusAllowedWithoutAllowlist(t *testing.T) {
 		t.Fatalf("did not expect unauthorized for /status, got %q", sent.text)
 	}
 }
+
+func TestDiscordAgentsAllowedWithoutAllowlist(t *testing.T) {
+	bot, err := NewDiscordBot("discord-secret", []string{"123"}, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewDiscordBot: %v", err)
+	}
+
+	var sent discordSendCapture
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		sent = discordSendCapture{channelID: channelID, text: text}
+		return nil
+	}
+
+	bot.handleMessageEvent(context.Background(), &discordInboundMessage{
+		text:        "/agents",
+		userID:      "999",
+		channelID:   "D123",
+		channelType: "dm",
+	})
+
+	if strings.Contains(sent.text, "Unauthorized") {
+		t.Fatalf("did not expect unauthorized for /agents, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "Allowed agents:") && !strings.Contains(sent.text, "agents.ohMyCode.defaultAgent") {
+		t.Fatalf("expected agents output or config hint, got %q", sent.text)
+	}
+}

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -407,7 +407,7 @@ func isSlackSafeCommand(text string) bool {
 		return false
 	}
 	switch fields[0] {
-	case "/help", "/start", "/whoami", "/status":
+	case "/help", "/start", "/whoami", "/status", "/agents":
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
- treat /agents as a safe Slack/Discord command for DMs
- add tests to ensure non-allowlisted users can access /agents
- keep existing safety and token-leak tests intact

## Testing
- go test ./...

Fixes #154