### PR TITLE
telegram: allow /tools + /tool to reach runtime

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -718,7 +718,8 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command == "/agent" {
+	command = strings.ToLower(command)
+	if command == "/agent" || isRuntimeToolCommand(command) {
 		return false, nil
 	}
 
@@ -921,6 +922,13 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 func (b *TelegramBot) sanitizeLifecycleError(command string, err error) error {
 	log.Printf("Telegram command %s failed: %v", command, err)
 	return errors.New("agent-manager error; please check server logs")
+}
+
+func isRuntimeToolCommand(command string) bool {
+	return command == "/tool" ||
+		command == "/tools" ||
+		strings.HasPrefix(command, "/tool:") ||
+		strings.HasPrefix(command, "/tools:")
 }
 
 func isAgentAllowlistError(err error) bool {

--- a/internal/channels/telegram_handler_reply_test.go
+++ b/internal/channels/telegram_handler_reply_test.go
@@ -70,6 +70,56 @@ func TestTelegramHandlerErrorSanitized(t *testing.T) {
 	}
 }
 
+func TestTelegramToolsCommandRoutedToHandler(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	const sentinel = "tools routed"
+	bot.SetHandler(&fakeReplyHandler{reply: sentinel})
+
+	msg := &TelegramMessage{
+		Text: "/tools",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if payload.Text != sentinel {
+		t.Fatalf("expected handler reply %q, got %q", sentinel, payload.Text)
+	}
+}
+
+func TestTelegramToolCommandRoutedToHandler(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	const sentinel = "tool routed"
+	bot.SetHandler(&fakeReplyHandler{reply: sentinel})
+
+	msg := &TelegramMessage{
+		Text: "/tool: echo hi",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if payload.Text != sentinel {
+		t.Fatalf("expected handler reply %q, got %q", sentinel, payload.Text)
+	}
+}
+
 type errSentinel string
 
 func (e errSentinel) Error() string {


### PR DESCRIPTION
## Summary\n- let /tools and /tool variants fall through to runtime handler\n- add Telegram handler routing tests for /tools and /tool: variants\n\nFixes #168