### PR TITLE
runtime: hint config keys when tools disabled

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -30,7 +30,7 @@ const (
 	defaultOhMyCodeLifecycleTimeout = 20 * time.Second
 	maxOhMyCodeMonitorLines         = 200
 
-	runtimeToolsDisabledMessage = "⚠️ runtime tools are disabled"
+	runtimeToolsDisabledMessage = "⚠️ runtime tools are disabled. Set agents.runtime.enabled and agents.runtime.allowedTools."
 )
 
 // Manager is a minimal stub for agent lifecycle management.

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -100,5 +100,11 @@ func TestHandleIncomingToolDisabledWhenRuntimeOff(t *testing.T) {
 		if !strings.Contains(out, "runtime tools are disabled") {
 			t.Fatalf("expected disabled message for %q, got %q", input, out)
 		}
+		if !strings.Contains(out, "agents.runtime.enabled") {
+			t.Fatalf("expected enabled config hint for %q, got %q", input, out)
+		}
+		if !strings.Contains(out, "agents.runtime.allowedTools") {
+			t.Fatalf("expected allowedTools config hint for %q, got %q", input, out)
+		}
 	}
 }


### PR DESCRIPTION
## Summary\n- include agents.runtime.enabled and agents.runtime.allowedTools hints when tools are disabled\n- extend runtime-disabled tests to assert key hints\n\nFixes #170