### PR TITLE
telegram: document /tools in help

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -977,6 +977,8 @@ func (b *TelegramBot) helpText() string {
 	sb.WriteString("  /doctor - admin only\n")
 	sb.WriteString("\n")
 	sb.WriteString("Runtime tools (if enabled):\n")
+	sb.WriteString("  /tools - list enabled tools (same as /tool tools.list)\n")
+	sb.WriteString("  /tools@BotName - same\n")
 	sb.WriteString("  /tool <name> <args...> (try: /tool tools.list)\n")
 	sb.WriteString("  /tool@BotName <name> <args...>\n")
 	sb.WriteString("\n")

--- a/internal/channels/telegram_help_test.go
+++ b/internal/channels/telegram_help_test.go
@@ -27,6 +27,9 @@ func TestTelegramHelpTextIncludesAgentInfo(t *testing.T) {
 	if !strings.Contains(text, "/tool <name> <args") {
 		t.Fatalf("expected help text to include /tool usage")
 	}
+	if !strings.Contains(text, "/tools") {
+		t.Fatalf("expected help text to include /tools usage")
+	}
 	if !strings.Contains(text, "Default agent: qa-1") {
 		t.Fatalf("expected help text to include default agent")
 	}


### PR DESCRIPTION
## Summary\n- add /tools lines to Telegram help text\n- assert /tools appears in help test\n\nFixes #174