### PR TITLE
telegram: include user id in unauthorized hint

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -629,7 +629,17 @@ func (b *TelegramBot) handleUpdate(update telegramUpdate) {
 func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 	if !b.userManager.Authorize(message.From.ID) {
 		log.Printf("🚫 Unauthorized Telegram user: %d", message.From.ID)
-		hint := "❌ Unauthorized. Ask an admin to add your Telegram user ID in channels.telegram.allowedUsers.\nTip: use /whoami to get your user ID."
+		username := strings.TrimSpace(message.From.UserName)
+		if username != "" {
+			username = "@" + username
+		} else {
+			username = "(none)"
+		}
+		hint := fmt.Sprintf(
+			"❌ Unauthorized. Ask an admin to add your Telegram user ID in channels.telegram.allowedUsers.\nUser ID: %d\nUsername: %s",
+			message.From.ID,
+			username,
+		)
 		_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(hint))
 		return
 	}

--- a/internal/channels/telegram_unauthorized_test.go
+++ b/internal/channels/telegram_unauthorized_test.go
@@ -40,10 +40,10 @@ func TestTelegramUnauthorizedHint(t *testing.T) {
 	if handler.called {
 		t.Fatalf("expected handler not called for unauthorized user")
 	}
-	if !strings.Contains(payload.Text, "/whoami") {
-		t.Fatalf("expected /whoami hint in reply: %q", payload.Text)
-	}
 	if !strings.Contains(payload.Text, "allowedUsers") {
 		t.Fatalf("expected allowedUsers hint in reply: %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "999") {
+		t.Fatalf("expected user ID in reply: %q", payload.Text)
 	}
 }


### PR DESCRIPTION
## Summary\n- include Telegram user ID (and username) in unauthorized reply\n- update unauthorized test to assert user ID + allowedUsers hint\n\nFixes #176