### PR TITLE
telegram: allow /whoami before allowlist

### DIFF
--- a/internal/channels/telegram_unauthorized_test.go
+++ b/internal/channels/telegram_unauthorized_test.go
@@ -47,3 +47,37 @@ func TestTelegramUnauthorizedHint(t *testing.T) {
 		t.Fatalf("expected user ID in reply: %q", payload.Text)
 	}
 }
+
+func TestTelegramUnauthorizedWhoamiAllowed(t *testing.T) {
+	bot, err := NewTelegramBot("token", nil, 123, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	handler := &fakeIncomingHandler{}
+	bot.SetHandler(handler)
+
+	msg := &TelegramMessage{
+		Text: "/whoami@mybot",
+		From: &TelegramUser{ID: 999, UserName: "intruder"},
+		Chat: &TelegramChat{ID: 55},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if handler.called {
+		t.Fatalf("expected handler not called for unauthorized user")
+	}
+	if strings.Contains(payload.Text, "Unauthorized") {
+		t.Fatalf("expected whoami reply, got %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "User ID: 999") {
+		t.Fatalf("expected user ID in reply: %q", payload.Text)
+	}
+	if !strings.Contains(payload.Text, "Is admin: false") {
+		t.Fatalf("expected admin false in reply: %q", payload.Text)
+	}
+}


### PR DESCRIPTION
## Summary\n- allow /whoami to respond before allowlist checks\n- add unauthorized whoami test coverage\n\nFixes #178