### PR TITLE
telegram: allow plain tool invocations without default agent

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -1021,7 +1021,9 @@ func isTelegramToolInvocation(text string) bool {
 		return false
 	}
 	lower := strings.ToLower(trimmed)
-	return hasTelegramToolPrefix(lower, "/tools") || hasTelegramToolPrefix(lower, "/tool")
+	return hasTelegramToolPrefix(lower, "/tools") ||
+		hasTelegramToolPrefix(lower, "/tool") ||
+		hasTelegramToolPrefix(lower, "tool")
 }
 
 func isTelegramWhoamiCommand(text string) bool {

--- a/internal/channels/telegram_handler_reply_test.go
+++ b/internal/channels/telegram_handler_reply_test.go
@@ -132,7 +132,7 @@ func TestTelegramToolsBypassAgentSelection(t *testing.T) {
 	const sentinel = "runtime ok"
 	bot.SetHandler(&fakeReplyHandler{reply: sentinel})
 
-	tests := []string{"/tools", "/tool: echo hi"}
+	tests := []string{"/tools", "/tool: echo hi", "tool: echo hi", "tool tools.list"}
 	for _, text := range tests {
 		payload.Text = ""
 		msg := &TelegramMessage{


### PR DESCRIPTION
## Summary\n- treat plain tool invocations as tool commands for agent-selection bypass\n- extend Telegram tool-bypass tests to include plain tool forms\n\nFixes #180