### PR TITLE
runtime: add memory.list tool

### DIFF
--- a/internal/runtime/memory_list_tool.go
+++ b/internal/runtime/memory_list_tool.go
@@ -1,0 +1,200 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+const (
+	memoryListDefaultLimit   = 20
+	memoryListMaxLimit       = 200
+	memoryListMaxOutputBytes = 64 * 1024
+)
+
+// MemoryListTool lists memory files under the configured source root.
+type MemoryListTool struct {
+	cfg     *config.MemoryConfig
+	sandbox PathSandbox
+}
+
+// NewMemoryListTool creates a new memory.list tool.
+func NewMemoryListTool(cfg *config.MemoryConfig, sandbox PathSandbox) (Tool, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("memory config is required")
+	}
+	return &MemoryListTool{cfg: cfg, sandbox: sandbox}, nil
+}
+
+// Name returns the tool name.
+func (t *MemoryListTool) Name() string {
+	return "memory.list"
+}
+
+// Execute lists memory files in a stable, safe order.
+func (t *MemoryListTool) Execute(ctx context.Context, req ToolRequest) (string, error) {
+	_ = ctx
+	limit, err := parseMemoryListLimit(req.Args)
+	if err != nil {
+		return "", err
+	}
+	root := strings.TrimSpace(t.cfg.SourceRoot)
+	if root == "" {
+		root = "."
+	}
+	safeRoot, err := t.sandbox.ValidatePath(root)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(safeRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to access source root")
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("source root is not a directory")
+	}
+	items, err := collectMemoryList(safeRoot)
+	if err != nil {
+		return "", fmt.Errorf("failed to list memory files")
+	}
+	if len(items) == 0 {
+		return "no memory files", nil
+	}
+	paths := orderMemoryList(items)
+	if len(paths) > limit {
+		paths = paths[:limit]
+	}
+	out := strings.Join(paths, "\n")
+	if len(out) > memoryListMaxOutputBytes {
+		out = truncateToBytes(out, memoryListMaxOutputBytes)
+	}
+	return out, nil
+}
+
+type memoryListItem struct {
+	path    string
+	modTime time.Time
+	daily   bool
+	isRoot  bool
+}
+
+func parseMemoryListLimit(args string) (int, error) {
+	trimmed := strings.TrimSpace(args)
+	if trimmed == "" {
+		return memoryListDefaultLimit, nil
+	}
+	parsed, err := strconv.Atoi(trimmed)
+	if err != nil || parsed <= 0 {
+		return 0, fmt.Errorf("invalid limit")
+	}
+	if parsed > memoryListMaxLimit {
+		parsed = memoryListMaxLimit
+	}
+	return parsed, nil
+}
+
+func collectMemoryList(root string) ([]memoryListItem, error) {
+	var items []memoryListItem
+
+	memoryFile := filepath.Join(root, "MEMORY.md")
+	if info, err := os.Stat(memoryFile); err == nil && !info.IsDir() {
+		items = append(items, memoryListItem{
+			path:    "MEMORY.md",
+			modTime: info.ModTime(),
+			isRoot:  true,
+		})
+	}
+
+	memoryDir := filepath.Join(root, "memory")
+	if info, err := os.Stat(memoryDir); err == nil && info.IsDir() {
+		err := filepath.WalkDir(memoryDir, func(path string, entry os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				if entry.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if entry.IsDir() {
+				return nil
+			}
+			if filepath.Ext(entry.Name()) != ".md" {
+				return nil
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
+			items = append(items, memoryListItem{
+				path:    filepath.ToSlash(rel),
+				modTime: info.ModTime(),
+				daily:   isDailyMemoryPath(rel),
+			})
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return items, nil
+}
+
+func isDailyMemoryPath(path string) bool {
+	normalized := filepath.ToSlash(path)
+	return strings.Contains(normalized, "/daily/")
+}
+
+func orderMemoryList(items []memoryListItem) []string {
+	var rootFile string
+	var daily []memoryListItem
+	var other []memoryListItem
+
+	for _, item := range items {
+		if item.isRoot {
+			rootFile = item.path
+			continue
+		}
+		if item.daily {
+			daily = append(daily, item)
+			continue
+		}
+		other = append(other, item)
+	}
+
+	sort.Slice(daily, func(i, j int) bool {
+		if daily[i].modTime.Equal(daily[j].modTime) {
+			return daily[i].path < daily[j].path
+		}
+		return daily[i].modTime.After(daily[j].modTime)
+	})
+	paths := make([]string, 0, len(items))
+	if rootFile != "" {
+		paths = append(paths, rootFile)
+	}
+	for _, item := range daily {
+		paths = append(paths, item.path)
+	}
+	if len(other) > 0 {
+		sort.Slice(other, func(i, j int) bool {
+			return other[i].path < other[j].path
+		})
+		for _, item := range other {
+			paths = append(paths, item.path)
+		}
+	}
+	return paths
+}

--- a/internal/runtime/memory_list_tool_test.go
+++ b/internal/runtime/memory_list_tool_test.go
@@ -1,0 +1,100 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+func TestMemoryListToolHappyPath(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "MEMORY.md"), []byte("root"), 0644); err != nil {
+		t.Fatalf("write MEMORY.md: %v", err)
+	}
+	dailyDir := filepath.Join(root, "memory", "daily")
+	if err := os.MkdirAll(dailyDir, 0755); err != nil {
+		t.Fatalf("mkdir daily: %v", err)
+	}
+	older := filepath.Join(dailyDir, "2026-01-01.md")
+	newer := filepath.Join(dailyDir, "2026-01-02.md")
+	if err := os.WriteFile(older, []byte("old"), 0644); err != nil {
+		t.Fatalf("write older: %v", err)
+	}
+	if err := os.WriteFile(newer, []byte("new"), 0644); err != nil {
+		t.Fatalf("write newer: %v", err)
+	}
+	oldTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	newTime := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	if err := os.Chtimes(older, oldTime, oldTime); err != nil {
+		t.Fatalf("chtimes older: %v", err)
+	}
+	if err := os.Chtimes(newer, newTime, newTime); err != nil {
+		t.Fatalf("chtimes newer: %v", err)
+	}
+	other := filepath.Join(root, "memory", "notes.md")
+	if err := os.WriteFile(other, []byte("notes"), 0644); err != nil {
+		t.Fatalf("write notes: %v", err)
+	}
+
+	tool, err := NewMemoryListTool(&config.MemoryConfig{SourceRoot: root}, PathSandbox{Roots: []string{root}})
+	if err != nil {
+		t.Fatalf("NewMemoryListTool: %v", err)
+	}
+	out, err := tool.Execute(context.Background(), ToolRequest{})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	expected := []string{
+		"MEMORY.md",
+		"memory/daily/2026-01-02.md",
+		"memory/daily/2026-01-01.md",
+		"memory/notes.md",
+	}
+	if strings.Join(expected, "\n") != out {
+		t.Fatalf("unexpected output: %q", out)
+	}
+}
+
+func TestMemoryListToolLimitClamp(t *testing.T) {
+	root := t.TempDir()
+	memoryDir := filepath.Join(root, "memory")
+	if err := os.MkdirAll(memoryDir, 0755); err != nil {
+		t.Fatalf("mkdir memory: %v", err)
+	}
+	for i := 0; i < memoryListMaxLimit+10; i++ {
+		path := filepath.Join(memoryDir, fmt.Sprintf("file-%03d.md", i))
+		if err := os.WriteFile(path, []byte("x"), 0644); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+	tool, err := NewMemoryListTool(&config.MemoryConfig{SourceRoot: root}, PathSandbox{Roots: []string{root}})
+	if err != nil {
+		t.Fatalf("NewMemoryListTool: %v", err)
+	}
+	out, err := tool.Execute(context.Background(), ToolRequest{Args: "500"})
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	lines := strings.Split(out, "\n")
+	if len(lines) != memoryListMaxLimit {
+		t.Fatalf("expected %d lines, got %d", memoryListMaxLimit, len(lines))
+	}
+}
+
+func TestMemoryListToolTraversalDenied(t *testing.T) {
+	root := t.TempDir()
+	tool, err := NewMemoryListTool(&config.MemoryConfig{SourceRoot: "../outside"}, PathSandbox{Roots: []string{root}})
+	if err != nil {
+		t.Fatalf("NewMemoryListTool: %v", err)
+	}
+	_, err = tool.Execute(context.Background(), ToolRequest{})
+	if err == nil {
+		t.Fatal("expected traversal to be rejected")
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -111,6 +111,13 @@ func NewRuntime(cfg *config.RuntimeConfig, memoryCfg *config.MemoryConfig) (Agen
 		if err := registry.Register(getTool); err != nil {
 			return nil, err
 		}
+		listTool, err := NewMemoryListTool(memoryCfg, sandbox)
+		if err != nil {
+			return nil, err
+		}
+		if err := registry.Register(listTool); err != nil {
+			return nil, err
+		}
 	}
 
 	maxChars := defaultMaxReplyChars


### PR DESCRIPTION
## Summary\n- add memory.list tool to enumerate memory files under agents.memory.sourceRoot\n- register memory.list when memory is enabled\n- add tests for ordering, limit clamp, and traversal rejection\n\nFixes #186