### PR TITLE
telegram: ignore non-private chats

### DIFF
--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -627,6 +627,9 @@ func (b *TelegramBot) handleUpdate(update telegramUpdate) {
 }
 
 func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
+	if message.Chat != nil && strings.TrimSpace(message.Chat.Type) != "" && message.Chat.Type != "private" {
+		return
+	}
 	if !b.userManager.Authorize(message.From.ID) {
 		log.Printf("🚫 Unauthorized Telegram user: %d", message.From.ID)
 		if isTelegramWhoamiCommand(message.Text) {
@@ -1096,7 +1099,8 @@ type TelegramUser struct {
 
 // TelegramChat represents a Telegram chat.
 type TelegramChat struct {
-	ID int64 `json:"id"`
+	ID   int64  `json:"id"`
+	Type string `json:"type"`
 }
 
 func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent string) *protocol.Message {
@@ -1108,6 +1112,7 @@ func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent
 			"text":     text,
 			"agent":    agent,
 			"chat_id":  msg.Chat.ID,
+			"chatType": msg.Chat.Type,
 			"user_id":  msg.From.ID,
 			"username": msg.From.UserName,
 		},

--- a/internal/channels/telegram_dm_only_test.go
+++ b/internal/channels/telegram_dm_only_test.go
@@ -1,0 +1,45 @@
+package channels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type captureHandler struct {
+	called bool
+}
+
+func (c *captureHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	c.called = true
+	return "ok", nil
+}
+
+func TestTelegramGroupChatIgnored(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	handler := &captureHandler{}
+	bot.SetHandler(handler)
+
+	msg := &TelegramMessage{
+		Text: "hello",
+		From: &TelegramUser{ID: 123, UserName: "tester"},
+		Chat: &TelegramChat{ID: 55, Type: "group"},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if handler.called {
+		t.Fatalf("expected handler not called for group chat")
+	}
+	if payload.Text != "" {
+		t.Fatalf("expected no reply for group chat, got %q", payload.Text)
+	}
+}


### PR DESCRIPTION
## Summary\n- ignore non-private Telegram chats (DM-only)\n- include chatType in protocol message data\n- add test to ensure group chats are ignored\n\nFixes #188