### PR TITLE
telegram: add allowedChats allowlist

### DIFF
--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -142,6 +142,7 @@ func (m *Manager) registerConfiguredChannels() error {
 		if err != nil {
 			return fmt.Errorf("failed to init telegram bot: %w", err)
 		}
+		bot.setAllowedChats(m.cfg.Telegram.AllowedChats)
 
 		bot.ConfigureMode(m.cfg.Telegram.Mode)
 		bot.ConfigurePolling(

--- a/internal/channels/telegram_allowed_chats_test.go
+++ b/internal/channels/telegram_allowed_chats_test.go
@@ -1,0 +1,71 @@
+package channels
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type allowlistHandler struct {
+	called bool
+}
+
+func (h *allowlistHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	h.called = true
+	return "", nil
+}
+
+func TestTelegramAllowedChatsEmptyAllowsDM(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	handler := &allowlistHandler{}
+	bot.SetHandler(handler)
+
+	msg := &TelegramMessage{
+		Text: "hello",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55, Type: "private"},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if !handler.called {
+		t.Fatalf("expected handler called for allowed DM")
+	}
+}
+
+func TestTelegramAllowedChatsRejectsUnknownChat(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+	bot.setAllowedChats([]int64{999})
+
+	var payload sendMessagePayload
+	bot.httpClient = captureHTTPClient(t, &payload)
+
+	handler := &allowlistHandler{}
+	bot.SetHandler(handler)
+
+	msg := &TelegramMessage{
+		Text: "hello",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55, Type: "private"},
+	}
+
+	bot.handleIncomingMessage(msg)
+
+	if handler.called {
+		t.Fatalf("expected handler not called for disallowed chat")
+	}
+	if payload.Text != "" {
+		t.Fatalf("expected no reply for disallowed chat, got %q", payload.Text)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type TelegramConfig struct {
 	Enabled      bool    `yaml:"enabled"`
 	BotToken     string  `yaml:"botToken,omitempty"`
 	AllowedUsers []int64 `yaml:"allowedUsers,omitempty"`
+	AllowedChats []int64 `yaml:"allowedChats,omitempty"`
 	AdminID      int64   `yaml:"adminID,omitempty"`
 
 	// Mode controls how FractalBot receives Telegram updates.


### PR DESCRIPTION
## Summary\n- add channels.telegram.allowedChats config to gate chat IDs\n- enforce allowedChats in Telegram handler (empty = allow all)\n- add tests for allow/deny behavior\n\nFixes #190