### PR TITLE
docs: update Telegram config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,14 @@ gateway:
 channels:
   telegram:
     enabled: true
+    # DM-only; non-private chats are ignored.
     botToken: "your_bot_token"
     adminID: 1234567890
     allowedUsers:
       - 1234567890
+    # Optional: restrict to specific chat IDs
+    # allowedChats:
+    #   - 1234567890
 
     # Recommended: long polling (local/dev friendly)
     mode: "polling"
@@ -153,6 +157,9 @@ agents:
     allowedTools:
       - "echo"
       - "version"
+      # - "memory.search"
+      # - "memory.get"
+      # - "memory.list"
     # Optional: cap runtime replies
     maxReplyChars: 2000
 ```
@@ -170,12 +177,15 @@ Tool invocation prefixes (case-insensitive tool names; args preserve newlines):
 
 Security model:
 - `agents.runtime.allowedTools` must include the tool name (including `tools.list` if you want to use it).
+- Remember to allowlist `memory.get` and `memory.list` before using them.
 - `agents.runtime.sandboxRoots` must be non-empty for file and command tools; empty means deny all.
 
 Example chat commands (copy/paste):
 - `tool echo hello\nworld`
 - `/tool@fractalbot tools.list`
 - `tool file.read ./workspace/MEMORY.md`
+- `tool memory.list`
+- `tool memory.get\nMEMORY.md\n1\n20`
 
 Phase 3 memory uses a native ONNX Runtime (ORT) library; see `docs/ort-distribution.md` for the distribution strategy and security notes.
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -14,6 +14,7 @@ channels:
   # Telegram channel configuration
   telegram:
     enabled: true
+    # Telegram is DM-only; non-private chats are ignored.
     # Get from @BotFather on Telegram
     botToken: "your_bot_token_here"
     # Admin Telegram User ID (required for /adduser, /removeuser, /listusers)
@@ -21,6 +22,9 @@ channels:
     # List of Telegram User IDs allowed to interact (admin will be auto-added)
     allowedUsers:
       - 1234567890
+    # Optional: restrict to specific chat IDs (DM-only; non-private chats ignored)
+    # allowedChats:
+    #   - 1234567890
 
     # Mode controls how FractalBot receives Telegram updates.
     # - polling: long polling via getUpdates (recommended for local/dev)
@@ -120,6 +124,9 @@ agents:
     allowedTools:
       - "echo"
       - "version"
+      # - "memory.search"
+      # - "memory.get"
+      # - "memory.list"
     # Optional: cap runtime replies
     maxReplyChars: 2000
     # Tool file sandbox roots (empty = deny all file access)


### PR DESCRIPTION
## Summary\n- document Telegram DM-only behavior and allowedChats in config example\n- include memory tools in runtime allowedTools examples\n- add memory.get/memory.list usage notes in README\n\nFixes #192