### PR TITLE
runtime: add loop mode

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ type MemoryConfig struct {
 // RuntimeConfig enables the in-process agent runtime.
 type RuntimeConfig struct {
 	Enabled       bool     `yaml:"enabled,omitempty"`
+	Mode          string   `yaml:"mode,omitempty"`
 	AllowedTools  []string `yaml:"allowedTools,omitempty"`
 	MaxReplyChars int      `yaml:"maxReplyChars,omitempty"`
 	// SandboxRoots restricts tool file access to these roots. Empty means deny all.
@@ -235,6 +236,9 @@ func validateConfig(cfg *Config) error {
 	if err := validateMemoryConfig(cfg); err != nil {
 		return err
 	}
+	if err := validateRuntimeConfig(cfg); err != nil {
+		return err
+	}
 	if err := validateOhMyCodeConfig(cfg); err != nil {
 		return err
 	}
@@ -253,6 +257,22 @@ func validateMemoryConfig(cfg *Config) error {
 		return fmt.Errorf("agents.memory.modelId: %w", err)
 	}
 	return nil
+}
+
+func validateRuntimeConfig(cfg *Config) error {
+	if cfg == nil || cfg.Agents == nil || cfg.Agents.Runtime == nil {
+		return nil
+	}
+	mode := strings.TrimSpace(cfg.Agents.Runtime.Mode)
+	if mode == "" {
+		return nil
+	}
+	switch mode {
+	case "basic", "loop":
+		return nil
+	default:
+		return fmt.Errorf("agents.runtime.mode: must be \"basic\" or \"loop\"")
+	}
 }
 
 func validateOhMyCodeConfig(cfg *Config) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -119,6 +119,32 @@ func TestLoadConfigAcceptsValidOhMyCodeAgents(t *testing.T) {
 	}
 }
 
+func TestLoadConfigRejectsInvalidRuntimeMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("agents:\n  runtime:\n    mode: \"weird\"\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected error for invalid runtime mode")
+	}
+	if !strings.Contains(err.Error(), "agents.runtime.mode") {
+		t.Fatalf("expected error to mention agents.runtime.mode, got %v", err)
+	}
+}
+
+func TestLoadConfigAcceptsLoopRuntimeMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("agents:\n  runtime:\n    mode: \"loop\"\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestLoadConfigRejectsOhMyCodeEnabledWithoutWorkspace(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	content := []byte("agents:\n  ohMyCode:\n    enabled: true\n")

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -50,6 +50,42 @@ func TestRuntimeAllowlistedToolAllowed(t *testing.T) {
 	}
 }
 
+func TestRuntimeLoopModeSelectsLoopRuntime(t *testing.T) {
+	rt, err := NewRuntime(&config.RuntimeConfig{
+		Enabled:      true,
+		Mode:         "loop",
+		AllowedTools: []string{"echo"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	if _, ok := rt.(*LoopRuntime); !ok {
+		t.Fatalf("expected LoopRuntime, got %T", rt)
+	}
+}
+
+func TestRuntimeLoopModeToolInvocation(t *testing.T) {
+	rt, err := NewRuntime(&config.RuntimeConfig{
+		Enabled:      true,
+		Mode:         "loop",
+		AllowedTools: []string{"echo"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("NewRuntime: %v", err)
+	}
+	reply, err := rt.HandleTask(context.Background(), Task{
+		Agent:   "qa-1",
+		Text:    "tool echo hi",
+		Channel: "telegram",
+	})
+	if err != nil {
+		t.Fatalf("HandleTask: %v", err)
+	}
+	if reply != "hi" {
+		t.Fatalf("expected echo reply, got %q", reply)
+	}
+}
+
 func TestRuntimeToolOutputTruncation(t *testing.T) {
 	rt, err := NewRuntime(&config.RuntimeConfig{
 		Enabled:       true,

--- a/internal/runtime/tool_command_planner.go
+++ b/internal/runtime/tool_command_planner.go
@@ -1,0 +1,27 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ToolCommandPlanner turns tool-prefixed messages into tool calls.
+type ToolCommandPlanner struct{}
+
+// NextStep decides the next tool call or reply.
+func (p *ToolCommandPlanner) NextStep(ctx context.Context, req PlannerRequest) (PlannerResponse, error) {
+	_ = ctx
+	if req.LastToolResult != nil {
+		if strings.TrimSpace(req.LastToolResult.Err) != "" {
+			return PlannerResponse{Reply: fmt.Sprintf("❌ %s", req.LastToolResult.Err)}, nil
+		}
+		return PlannerResponse{Reply: strings.TrimSpace(req.LastToolResult.Output)}, nil
+	}
+
+	name, args, ok := parseToolInvocation(req.Task.Text)
+	if !ok || name == "" {
+		return PlannerResponse{Reply: "usage: tool <name> <args...> (see tools.list)"}, nil
+	}
+	return PlannerResponse{ToolCall: &ToolCall{Name: name, Args: args}}, nil
+}


### PR DESCRIPTION
## Summary\n- add agents.runtime.mode config validation (basic|loop)\n- introduce ToolCommandPlanner and wire LoopRuntime selection in loop mode\n- add tests for mode validation, runtime selection, and loop tool invocation\n\nFixes #200