### PR TITLE
slack/discord: include user id in unauthorized hint

### DIFF
--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -219,7 +219,7 @@ func (b *DiscordBot) handleMessageEvent(ctx context.Context, msg *discordInbound
 	}
 
 	if !b.allowlist.Allowed(msg.userID) {
-		_ = b.reply(ctx, msg, "❌ Unauthorized. Ask an admin to add your Discord user ID to channels.discord.allowedUsers.\nTip: use /whoami to get your user ID.")
+		_ = b.reply(ctx, msg, fmt.Sprintf("❌ Unauthorized. Ask an admin to add your Discord user ID to channels.discord.allowedUsers.\nUser ID: %s", msg.userID))
 		return
 	}
 

--- a/internal/channels/discord_test.go
+++ b/internal/channels/discord_test.go
@@ -98,6 +98,12 @@ func TestDiscordUnauthorized(t *testing.T) {
 	if !strings.Contains(sent.text, "Unauthorized") {
 		t.Fatalf("expected unauthorized reply, got %q", sent.text)
 	}
+	if !strings.Contains(sent.text, "999") {
+		t.Fatalf("expected user ID in reply, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "channels.discord.allowedUsers") {
+		t.Fatalf("expected allowedUsers hint in reply, got %q", sent.text)
+	}
 }
 
 func TestDiscordWhoamiAllowedWithoutAllowlist(t *testing.T) {

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -243,7 +243,7 @@ func (b *SlackBot) handleMessageEvent(ctx context.Context, msg *slackInboundMess
 	}
 
 	if !b.allowlist.Allowed(msg.userID) {
-		_ = b.reply(ctx, msg, "❌ Unauthorized. Ask an admin to add your Slack user ID to channels.slack.allowedUsers.\nTip: use /whoami to get your user ID.")
+		_ = b.reply(ctx, msg, fmt.Sprintf("❌ Unauthorized. Ask an admin to add your Slack user ID to channels.slack.allowedUsers.\nUser ID: %s", msg.userID))
 		return
 	}
 

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -98,6 +98,12 @@ func TestSlackUnauthorized(t *testing.T) {
 	if !strings.Contains(sent.text, "Unauthorized") {
 		t.Fatalf("expected unauthorized reply, got %q", sent.text)
 	}
+	if !strings.Contains(sent.text, "U999") {
+		t.Fatalf("expected user ID in reply, got %q", sent.text)
+	}
+	if !strings.Contains(sent.text, "channels.slack.allowedUsers") {
+		t.Fatalf("expected allowedUsers hint in reply, got %q", sent.text)
+	}
 }
 
 func TestSlackSocketModeDMEvent(t *testing.T) {


### PR DESCRIPTION
## Summary\n- include user ID in Slack + Discord unauthorized replies\n- update tests to assert user ID + allowedUsers hints\n\nFixes #204