### PR TITLE
channels: add /to agent alias

### DIFF
--- a/internal/channels/agent_selection.go
+++ b/internal/channels/agent_selection.go
@@ -40,7 +40,7 @@ func NewAgentAllowlist(names []string) AgentAllowlist {
 }
 
 // ParseAgentSelection extracts a target agent and task from chat text.
-// Supported syntax: /agent <name> <task...>
+// Supported syntax: /agent <name> <task...> or /to <name> <task...>
 func ParseAgentSelection(text string) (AgentSelection, error) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
@@ -53,12 +53,12 @@ func ParseAgentSelection(text string) (AgentSelection, error) {
 	}
 
 	first := fields[0]
-	if strings.HasPrefix(first, "/agent") {
+	if strings.HasPrefix(first, "/agent") || strings.HasPrefix(first, "/to") {
 		command := first
 		if idx := strings.IndexByte(command, '@'); idx != -1 {
 			command = command[:idx]
 		}
-		if command != "/agent" {
+		if command != "/agent" && command != "/to" {
 			return AgentSelection{Task: trimmed}, nil
 		}
 		if len(fields) < 3 {

--- a/internal/channels/agent_selection_test.go
+++ b/internal/channels/agent_selection_test.go
@@ -29,6 +29,20 @@ func TestParseAgentSelection(t *testing.T) {
 			specified:   true,
 		},
 		{
+			name:        "to command",
+			input:       "/to coder-a do the thing",
+			expectAgent: "coder-a",
+			expectTask:  "do the thing",
+			specified:   true,
+		},
+		{
+			name:        "to command with bot",
+			input:       "/to@bot coder_b run",
+			expectAgent: "coder_b",
+			expectTask:  "run",
+			specified:   true,
+		},
+		{
 			name:       "plain text",
 			input:      "hello world",
 			expectTask: "hello world",
@@ -37,6 +51,11 @@ func TestParseAgentSelection(t *testing.T) {
 		{
 			name:      "missing task",
 			input:     "/agent coder",
+			expectErr: true,
+		},
+		{
+			name:      "missing task to",
+			input:     "/to coder",
 			expectErr: true,
 		},
 	}

--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -301,7 +301,7 @@ func (b *DiscordBot) handleCommand(ctx context.Context, msg *discordInboundMessa
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command == "/agent" {
+	if command == "/agent" || command == "/to" {
 		return false, nil
 	}
 	if command != "/tools" && (command == "/tool" || strings.HasPrefix(command, "/tool:")) {
@@ -419,7 +419,7 @@ func isDiscordSafeCommand(text string) bool {
 
 func isIncompleteDiscordAgentCommand(text string) bool {
 	trimmed := strings.TrimSpace(text)
-	if trimmed == "" || !strings.HasPrefix(trimmed, "/agent") {
+	if trimmed == "" || (!strings.HasPrefix(trimmed, "/agent") && !strings.HasPrefix(trimmed, "/to")) {
 		return false
 	}
 	fields := strings.Fields(trimmed)
@@ -430,7 +430,7 @@ func isIncompleteDiscordAgentCommand(text string) bool {
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command != "/agent" {
+	if command != "/agent" && command != "/to" {
 		return false
 	}
 	return len(fields) < 3

--- a/internal/channels/discord_test.go
+++ b/internal/channels/discord_test.go
@@ -332,7 +332,16 @@ func TestDiscordIncompleteAgentUsageBypassesAllowlist(t *testing.T) {
 		t.Fatalf("NewDiscordBot: %v", err)
 	}
 
-	tests := []string{"/agent", "/agent qa-1", "/agent@bot", "/agent@bot qa-1"}
+	tests := []string{
+		"/agent",
+		"/agent qa-1",
+		"/agent@bot",
+		"/agent@bot qa-1",
+		"/to",
+		"/to qa-1",
+		"/to@bot",
+		"/to@bot qa-1",
+	}
 	for _, input := range tests {
 		var sent discordSendCapture
 		bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -333,7 +333,7 @@ func (b *FeishuBot) handleCommand(ctx context.Context, msg *feishuInboundMessage
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command == "/agent" {
+	if command == "/agent" || command == "/to" {
 		return false, nil
 	}
 
@@ -509,7 +509,7 @@ func derefString(value *string) string {
 
 func isIncompleteFeishuAgentCommand(text string) bool {
 	trimmed := strings.TrimSpace(text)
-	if trimmed == "" || !strings.HasPrefix(trimmed, "/agent") {
+	if trimmed == "" || (!strings.HasPrefix(trimmed, "/agent") && !strings.HasPrefix(trimmed, "/to")) {
 		return false
 	}
 	fields := strings.Fields(trimmed)
@@ -520,7 +520,7 @@ func isIncompleteFeishuAgentCommand(text string) bool {
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command != "/agent" {
+	if command != "/agent" && command != "/to" {
 		return false
 	}
 	return len(fields) < 3

--- a/internal/channels/feishu_test.go
+++ b/internal/channels/feishu_test.go
@@ -311,13 +311,16 @@ func TestFeishuAgentCommandUsageHint(t *testing.T) {
 		return nil
 	}
 
-	bot.handleMessageEvent(context.Background(), buildFeishuEvent("/agent   ", "p2p", "ou_allowed", "u1", "chat1"))
+	for _, input := range []string{"/agent   ", "/to   "} {
+		sent = feishuSendCapture{}
+		bot.handleMessageEvent(context.Background(), buildFeishuEvent(input, "p2p", "ou_allowed", "u1", "chat1"))
 
-	if !strings.Contains(sent.text, "usage: /agent <name> <task>") {
-		t.Fatalf("expected usage hint, got %q", sent.text)
-	}
-	if !strings.Contains(sent.text, "Tip: use /agents") {
-		t.Fatalf("expected /agents tip, got %q", sent.text)
+		if !strings.Contains(sent.text, "usage: /agent <name> <task>") {
+			t.Fatalf("expected usage hint for %q, got %q", input, sent.text)
+		}
+		if !strings.Contains(sent.text, "Tip: use /agents") {
+			t.Fatalf("expected /agents tip for %q, got %q", input, sent.text)
+		}
 	}
 }
 

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -325,7 +325,7 @@ func (b *SlackBot) handleCommand(ctx context.Context, msg *slackInboundMessage) 
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command == "/agent" {
+	if command == "/agent" || command == "/to" {
 		return false, nil
 	}
 	if command != "/tools" && (command == "/tool" || strings.HasPrefix(command, "/tool:")) {
@@ -443,7 +443,7 @@ func isSlackSafeCommand(text string) bool {
 
 func isIncompleteSlackAgentCommand(text string) bool {
 	trimmed := strings.TrimSpace(text)
-	if trimmed == "" || !strings.HasPrefix(trimmed, "/agent") {
+	if trimmed == "" || (!strings.HasPrefix(trimmed, "/agent") && !strings.HasPrefix(trimmed, "/to")) {
 		return false
 	}
 	fields := strings.Fields(trimmed)
@@ -454,7 +454,7 @@ func isIncompleteSlackAgentCommand(text string) bool {
 	if idx := strings.IndexByte(command, '@'); idx != -1 {
 		command = command[:idx]
 	}
-	if command != "/agent" {
+	if command != "/agent" && command != "/to" {
 		return false
 	}
 	return len(fields) < 3

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -379,7 +379,16 @@ func TestSlackIncompleteAgentUsageBypassesAllowlist(t *testing.T) {
 		t.Fatalf("NewSlackBot: %v", err)
 	}
 
-	tests := []string{"/agent", "/agent qa-1", "/agent@bot", "/agent@bot qa-1"}
+	tests := []string{
+		"/agent",
+		"/agent qa-1",
+		"/agent@bot",
+		"/agent@bot qa-1",
+		"/to",
+		"/to qa-1",
+		"/to@bot",
+		"/to@bot qa-1",
+	}
 	for _, input := range tests {
 		var sent slackSendCapture
 		bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -745,7 +745,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		command = command[:idx]
 	}
 	command = strings.ToLower(command)
-	if command == "/agent" || isRuntimeToolCommand(command) {
+	if command == "/agent" || command == "/to" || isRuntimeToolCommand(command) {
 		return false, nil
 	}
 

--- a/internal/channels/telegram_agents_test.go
+++ b/internal/channels/telegram_agents_test.go
@@ -107,19 +107,22 @@ func TestTelegramAgentSelectionErrorIncludesHint(t *testing.T) {
 	var payload sendMessagePayload
 	bot.httpClient = captureHTTPClient(t, &payload)
 
-	msg := &TelegramMessage{
-		Text: "/agent hacker do stuff",
-		From: &TelegramUser{ID: 123},
-		Chat: &TelegramChat{ID: 99},
-	}
+	for _, input := range []string{"/agent hacker do stuff", "/to hacker do stuff"} {
+		payload.Text = ""
+		msg := &TelegramMessage{
+			Text: input,
+			From: &TelegramUser{ID: 123},
+			Chat: &TelegramChat{ID: 99},
+		}
 
-	bot.handleIncomingMessage(msg)
+		bot.handleIncomingMessage(msg)
 
-	if !strings.Contains(payload.Text, "agents.ohMyCode.allowedAgents") {
-		t.Fatalf("expected allowedAgents hint, got %q", payload.Text)
-	}
-	if !strings.Contains(payload.Text, "/agents") {
-		t.Fatalf("expected /agents hint, got %q", payload.Text)
+		if !strings.Contains(payload.Text, "agents.ohMyCode.allowedAgents") {
+			t.Fatalf("expected allowedAgents hint for %q, got %q", input, payload.Text)
+		}
+		if !strings.Contains(payload.Text, "/agents") {
+			t.Fatalf("expected /agents hint for %q, got %q", input, payload.Text)
+		}
 	}
 }
 
@@ -132,21 +135,24 @@ func TestTelegramAgentNotAllowedDefaultOnly(t *testing.T) {
 	var payload sendMessagePayload
 	bot.httpClient = captureHTTPClient(t, &payload)
 
-	msg := &TelegramMessage{
-		Text: "/agent hacker do stuff",
-		From: &TelegramUser{ID: 123},
-		Chat: &TelegramChat{ID: 99},
-	}
+	for _, input := range []string{"/agent hacker do stuff", "/to hacker do stuff"} {
+		payload.Text = ""
+		msg := &TelegramMessage{
+			Text: input,
+			From: &TelegramUser{ID: 123},
+			Chat: &TelegramChat{ID: 99},
+		}
 
-	bot.handleIncomingMessage(msg)
+		bot.handleIncomingMessage(msg)
 
-	if !strings.Contains(payload.Text, "Only the default agent is enabled") {
-		t.Fatalf("expected default-only hint, got %q", payload.Text)
-	}
-	if !strings.Contains(payload.Text, "agents.ohMyCode.allowedAgents") {
-		t.Fatalf("expected allowedAgents hint, got %q", payload.Text)
-	}
-	if !strings.Contains(payload.Text, "/agents") {
-		t.Fatalf("expected /agents hint, got %q", payload.Text)
+		if !strings.Contains(payload.Text, "Only the default agent is enabled") {
+			t.Fatalf("expected default-only hint for %q, got %q", input, payload.Text)
+		}
+		if !strings.Contains(payload.Text, "agents.ohMyCode.allowedAgents") {
+			t.Fatalf("expected allowedAgents hint for %q, got %q", input, payload.Text)
+		}
+		if !strings.Contains(payload.Text, "/agents") {
+			t.Fatalf("expected /agents hint for %q, got %q", input, payload.Text)
+		}
 	}
 }


### PR DESCRIPTION
## Summary\n- add /to as alias for /agent across channels and parsing\n- include /to in incomplete-command usage hints\n- add tests for /to parsing and allowlist behavior\n\nFixes #205