### PR TITLE
feat: add HTTP outbound message send API

### DIFF
--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -70,6 +72,7 @@ func (s *Server) Start(ctx context.Context) error {
 
 	// Status endpoint
 	mux.HandleFunc("/status", s.handleStatus)
+	mux.HandleFunc("/api/v1/message/send", s.handleMessageSend)
 
 	if s.startTime.IsZero() {
 		s.startTime = time.Now()
@@ -243,6 +246,81 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+type messageSendRequest struct {
+	Channel string `json:"channel"`
+	To      int64  `json:"to"`
+	Text    string `json:"text"`
+}
+
+type messageSendResponse struct {
+	Status  string `json:"status"`
+	Channel string `json:"channel,omitempty"`
+	To      int64  `json:"to,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, messageSendResponse{Status: "error", Error: "method not allowed"})
+		return
+	}
+
+	var request messageSendRequest
+	decoder := json.NewDecoder(io.LimitReader(r.Body, 64*1024))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "invalid JSON payload"})
+		return
+	}
+
+	request.Channel = strings.ToLower(strings.TrimSpace(request.Channel))
+	request.Text = strings.TrimSpace(request.Text)
+
+	if request.Channel == "" {
+		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "channel is required"})
+		return
+	}
+	if request.To == 0 {
+		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "to is required"})
+		return
+	}
+	if request.Text == "" {
+		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "text is required"})
+		return
+	}
+
+	if s.agentManager == nil || s.agentManager.ChannelManager == nil {
+		writeJSON(w, http.StatusServiceUnavailable, messageSendResponse{Status: "error", Error: "channel manager unavailable"})
+		return
+	}
+
+	channel := s.agentManager.ChannelManager.Get(request.Channel)
+	if channel == nil {
+		writeJSON(w, http.StatusNotFound, messageSendResponse{Status: "error", Error: fmt.Sprintf("channel %q not found", request.Channel)})
+		return
+	}
+
+	if err := channel.SendMessage(r.Context(), request.To, request.Text); err != nil {
+		writeJSON(w, http.StatusBadGateway, messageSendResponse{Status: "error", Error: err.Error()})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, messageSendResponse{
+		Status:  "ok",
+		Channel: request.Channel,
+		To:      request.To,
+	})
+}
+
+func writeJSON(w http.ResponseWriter, statusCode int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Printf("failed to encode JSON response (status=%s): %v", strconv.Itoa(statusCode), err)
+	}
 }
 
 func (s *Server) activeClients() int {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -396,3 +396,122 @@ func TestStatusDoesNotExposeSecrets(t *testing.T) {
 		t.Fatalf("status response leaked secrets: %s", text)
 	}
 }
+
+type fakeSendChannel struct {
+	name     string
+	running  bool
+	lastChat int64
+	lastText string
+	sendErr  error
+}
+
+func (f *fakeSendChannel) Name() string { return f.name }
+
+func (f *fakeSendChannel) Start(ctx context.Context) error {
+	_ = ctx
+	f.running = true
+	return nil
+}
+
+func (f *fakeSendChannel) Stop() error {
+	f.running = false
+	return nil
+}
+
+func (f *fakeSendChannel) SendMessage(ctx context.Context, chatID int64, text string) error {
+	_ = ctx
+	f.lastChat = chatID
+	f.lastText = text
+	return f.sendErr
+}
+
+func (f *fakeSendChannel) IsRunning() bool { return f.running }
+
+func TestMessageSendAPI(t *testing.T) {
+	cfg := &config.Config{
+		Gateway:  &config.GatewayConfig{Bind: "127.0.0.1", Port: 0},
+		Channels: &config.ChannelsConfig{Telegram: &config.TelegramConfig{Enabled: true}},
+		Agents:   &config.AgentsConfig{},
+	}
+
+	server, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	fake := &fakeSendChannel{name: "telegram"}
+	if err := server.agentManager.ChannelManager.Register(fake); err != nil {
+		t.Fatalf("register fake channel: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/message/send", server.handleMessageSend)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	t.Run("success", func(t *testing.T) {
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"telegram","to":12345,"text":"hello from api"}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d body=%s", resp.StatusCode, string(body))
+		}
+
+		if fake.lastChat != 12345 {
+			t.Fatalf("expected lastChat=12345 got %d", fake.lastChat)
+		}
+		if fake.lastText != "hello from api" {
+			t.Fatalf("expected text captured, got %q", fake.lastText)
+		}
+
+		var payload messageSendResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if payload.Status != "ok" || payload.Channel != "telegram" || payload.To != 12345 {
+			t.Fatalf("unexpected response payload: %#v", payload)
+		}
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"telegram","to":0,"text":""}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 400, got %d body=%s", resp.StatusCode, string(body))
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"slack","to":1,"text":"hello"}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusNotFound {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 404, got %d body=%s", resp.StatusCode, string(body))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- add gateway outbound endpoint: `POST /api/v1/message/send`
- validate request fields (`channel`, `to`, `text`) with structured JSON errors
- route outbound send to `ChannelManager.Get(channel).SendMessage(...)`
- add endpoint tests for success, bad request, and channel not found

## Test Evidence
- `XDG_CONFIG_HOME=$(mktemp -d) GOTELEMETRY=off go test ./internal/gateway`

## Risk & Rollback
### Risks
- Endpoint relies on configured/registered channels; unavailable channels return explicit errors.
- Non-telegram channels may return channel-specific send errors from current implementations.

### Rollback
- Revert commit `8de13fe` to remove outbound API endpoint and handlers.
