### PR TITLE
feat: add CLI message send via gateway API

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -1,17 +1,27 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
 	"io"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
+	"time"
 
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/fractalmind-ai/fractalbot/internal/gateway"
 )
+
+var messageSendFn = sendMessageViaGatewayAPI
 
 func main() {
 	os.Exit(Run(os.Args[1:], os.Stderr))
@@ -48,6 +58,11 @@ func runWithContext(ctx context.Context, args []string, out io.Writer) int {
 		return 1
 	}
 
+	remaining := fs.Args()
+	if len(remaining) > 0 {
+		return runCommand(ctx, cfg, remaining, out, logger)
+	}
+
 	if cfg.Gateway == nil {
 		cfg.Gateway = &config.GatewayConfig{Bind: "127.0.0.1", Port: 18789}
 	}
@@ -75,4 +90,140 @@ func runWithContext(ctx context.Context, args []string, out io.Writer) int {
 	}
 
 	return 0
+}
+
+func runCommand(ctx context.Context, cfg *config.Config, args []string, out io.Writer, logger *log.Logger) int {
+	switch strings.ToLower(strings.TrimSpace(args[0])) {
+	case "message":
+		return runMessageCommand(ctx, cfg, args[1:], out, logger)
+	default:
+		logger.Printf("unknown command: %s", args[0])
+		return 1
+	}
+}
+
+func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, out io.Writer, logger *log.Logger) int {
+	if len(args) == 0 {
+		logger.Printf("message command requires a subcommand (send)")
+		return 1
+	}
+
+	subcmd := strings.ToLower(strings.TrimSpace(args[0]))
+	if subcmd != "send" {
+		logger.Printf("unknown message subcommand: %s", args[0])
+		return 1
+	}
+
+	sendFS := flag.NewFlagSet("message send", flag.ContinueOnError)
+	sendFS.SetOutput(out)
+	channel := sendFS.String("channel", "telegram", "target channel (e.g. telegram, slack, feishu, discord)")
+	to := sendFS.String("to", "", "target chat ID")
+	text := sendFS.String("text", "", "message text")
+
+	if err := sendFS.Parse(args[1:]); err != nil {
+		return 1
+	}
+
+	toValue := strings.TrimSpace(*to)
+	if toValue == "" {
+		logger.Printf("--to is required")
+		return 1
+	}
+
+	chatID, err := strconv.ParseInt(toValue, 10, 64)
+	if err != nil {
+		logger.Printf("invalid --to chat_id: %s", toValue)
+		return 1
+	}
+
+	messageText := strings.TrimSpace(*text)
+	if messageText == "" {
+		logger.Printf("--text is required")
+		return 1
+	}
+
+	channelName := strings.ToLower(strings.TrimSpace(*channel))
+	if channelName == "" {
+		logger.Printf("--channel is required")
+		return 1
+	}
+
+	if err := messageSendFn(ctx, cfg, channelName, chatID, messageText); err != nil {
+		logger.Printf("failed to send message: %v", err)
+		return 1
+	}
+
+	fmt.Fprintf(out, "✅ Message sent via %s to %d\n", channelName, chatID)
+	return 0
+}
+
+func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+	type requestPayload struct {
+		Channel string `json:"channel"`
+		To      int64  `json:"to"`
+		Text    string `json:"text"`
+	}
+
+	type responsePayload struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+
+	requestBody, err := json.Marshal(requestPayload{
+		Channel: channel,
+		To:      to,
+		Text:    text,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+
+	endpoint := gatewaySendEndpoint(cfg)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(requestBody))
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("request %s failed: %w", endpoint, err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+		message := strings.TrimSpace(string(body))
+		var parsed responsePayload
+		if len(body) > 0 && json.Unmarshal(body, &parsed) == nil && strings.TrimSpace(parsed.Error) != "" {
+			message = parsed.Error
+		}
+		if message == "" {
+			message = http.StatusText(response.StatusCode)
+		}
+		return fmt.Errorf("gateway API error (%d): %s", response.StatusCode, message)
+	}
+
+	return nil
+}
+
+func gatewaySendEndpoint(cfg *config.Config) string {
+	bind := "127.0.0.1"
+	port := 18789
+
+	if cfg != nil && cfg.Gateway != nil {
+		if trimmedBind := strings.TrimSpace(cfg.Gateway.Bind); trimmedBind != "" {
+			bind = trimmedBind
+		}
+		if cfg.Gateway.Port > 0 {
+			port = cfg.Gateway.Port
+		}
+	}
+
+	if bind == "0.0.0.0" || bind == "::" {
+		bind = "127.0.0.1"
+	}
+
+	return fmt.Sprintf("http://%s/api/v1/message/send", net.JoinHostPort(bind, strconv.Itoa(port)))
 }

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
 )
 
 func TestRunMissingConfig(t *testing.T) {
@@ -42,4 +45,161 @@ func TestRunMinimalConfigExitsOnCancel(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
 	}
+}
+
+func TestRunMessageSend(t *testing.T) {
+	configPath := writeMinimalConfig(t)
+	original := messageSendFn
+	t.Cleanup(func() { messageSendFn = original })
+
+	t.Run("success", func(t *testing.T) {
+		called := false
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+			_ = ctx
+			_ = cfg
+			called = true
+			if channel != "telegram" {
+				t.Fatalf("channel=%q", channel)
+			}
+			if to != 5088760910 {
+				t.Fatalf("to=%d", to)
+			}
+			if text != "hello from cli" {
+				t.Fatalf("text=%q", text)
+			}
+			return nil
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"message", "send",
+			"--channel", "telegram",
+			"--to", "5088760910",
+			"--text", "hello from cli",
+		}, &buf)
+
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
+		}
+		if !called {
+			t.Fatalf("expected message send function to be called")
+		}
+		if !strings.Contains(buf.String(), "Message sent via telegram to 5088760910") {
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+	})
+
+	t.Run("validation errors", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			args          []string
+			expectedError string
+		}{
+			{
+				name:          "missing to",
+				args:          []string{"--channel", "telegram", "--text", "hello"},
+				expectedError: "--to is required",
+			},
+			{
+				name:          "invalid to",
+				args:          []string{"--channel", "telegram", "--to", "not-number", "--text", "hello"},
+				expectedError: "invalid --to chat_id",
+			},
+			{
+				name:          "missing text",
+				args:          []string{"--channel", "telegram", "--to", "5088760910"},
+				expectedError: "--text is required",
+			},
+		}
+
+		for _, testCase := range cases {
+			t.Run(testCase.name, func(t *testing.T) {
+				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+					_ = ctx
+					_ = cfg
+					_ = channel
+					_ = to
+					_ = text
+					t.Fatalf("messageSendFn should not be called for validation error")
+					return nil
+				}
+
+				var buf bytes.Buffer
+				args := append([]string{"--config", configPath, "message", "send"}, testCase.args...)
+				code := runWithContext(context.Background(), args, &buf)
+				if code == 0 {
+					t.Fatalf("expected non-zero exit code for %s", testCase.name)
+				}
+				if !strings.Contains(buf.String(), testCase.expectedError) {
+					t.Fatalf("expected output to contain %q, got %q", testCase.expectedError, buf.String())
+				}
+			})
+		}
+	})
+
+	t.Run("unknown subcommand", func(t *testing.T) {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+			_ = ctx
+			_ = cfg
+			_ = channel
+			_ = to
+			_ = text
+			t.Fatalf("messageSendFn should not be called")
+			return nil
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"message", "ping",
+		}, &buf)
+		if code == 0 {
+			t.Fatalf("expected non-zero exit code")
+		}
+		if !strings.Contains(buf.String(), "unknown message subcommand") {
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+	})
+
+	t.Run("send failure", func(t *testing.T) {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+			_ = ctx
+			_ = cfg
+			_ = channel
+			_ = to
+			_ = text
+			return fmt.Errorf("gateway down")
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"message", "send",
+			"--channel", "telegram",
+			"--to", "5088760910",
+			"--text", "hello",
+		}, &buf)
+
+		if code == 0 {
+			t.Fatalf("expected non-zero exit code")
+		}
+		if !strings.Contains(buf.String(), "failed to send message") {
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+	})
+}
+
+func writeMinimalConfig(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	configContents := []byte("gateway:\n  bind: 127.0.0.1\n  port: 18789\n")
+
+	if err := os.WriteFile(configPath, configContents, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	return configPath
 }


### PR DESCRIPTION
## Summary
- add `fractalbot message send --channel <name> --to <chat_id> --text "..."`
- implement CLI path to call gateway HTTP API: `POST /api/v1/message/send`
- parse gateway bind/port from config and build API endpoint automatically
- add CLI tests for success, validation failures, unknown subcommand, and gateway error propagation

## Dependency
- Base branch: `feat/issue-269-http-outbound-api` (PR #275)

## Test Evidence
- `XDG_CONFIG_HOME=$(mktemp -d) GOTELEMETRY=off go test ./cmd/fractalbot`

## Risk & Rollback
### Risks
- CLI send now requires a running gateway process at configured bind/port.
- Misconfigured gateway address will fail fast with explicit HTTP/API errors.

### Rollback
- Revert commit `19aee70` to remove CLI message-send command path.
