### PR TITLE
fix: simplify direct-message assign reply to concise ack

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -22,8 +22,8 @@ const (
 	defaultOhMyCodeAgentManagerScript = ".claude/skills/agent-manager/scripts/main.py"
 	defaultOhMyCodeDefaultAgent       = "qa-1"
 	defaultOhMyCodeAssignTimeout      = 90 * time.Second
+	ohMyCodeAssignAckMessage          = "处理中…"
 
-	defaultOhMyCodeMonitorDelay   = 1 * time.Second
 	defaultOhMyCodeMonitorTimeout = 15 * time.Second
 	defaultOhMyCodeMonitorLines   = 60
 
@@ -246,29 +246,11 @@ func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride st
 		defer cancel()
 	}
 
-	assignOut, err := runOhMyCodeAgentManager(assignCtx, workspace, script, buildOhMyCodeTaskPrompt(userText), "assign", name)
-	if err != nil {
+	if _, err := runOhMyCodeAgentManager(assignCtx, workspace, script, buildOhMyCodeTaskPrompt(userText), "assign", name); err != nil {
 		return "", err
 	}
 
-	if defaultOhMyCodeMonitorDelay > 0 {
-		time.Sleep(defaultOhMyCodeMonitorDelay)
-	}
-
-	monitorCtx, cancel := context.WithTimeout(ctx, defaultOhMyCodeMonitorTimeout)
-	defer cancel()
-
-	monitorOut, monitorErr := runOhMyCodeAgentManager(monitorCtx, workspace, script, "", "monitor", name, "--lines", strconv.Itoa(defaultOhMyCodeMonitorLines))
-	if monitorErr != nil {
-		return assignOut, nil
-	}
-
-	snapshot := extractMonitorSnapshot(monitorOut)
-	if strings.TrimSpace(snapshot) == "" {
-		return assignOut, nil
-	}
-
-	return strings.TrimSpace(assignOut) + "\n\n" + snapshot, nil
+	return ohMyCodeAssignAckMessage, nil
 }
 
 // MonitorAgent returns the latest agent-manager monitor output.
@@ -427,28 +409,4 @@ func runOhMyCodeAgentManager(ctx context.Context, workspace, script, stdin strin
 
 func buildOhMyCodeTaskPrompt(userText string) string {
 	return fmt.Sprintf("User message:\n%s\n", strings.TrimSpace(userText))
-}
-
-func extractMonitorSnapshot(monitorOutput string) string {
-	lines := strings.Split(monitorOutput, "\n")
-	firstSep := -1
-	secondSep := -1
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "====") {
-			if firstSep == -1 {
-				firstSep = i
-				continue
-			}
-			secondSep = i
-			break
-		}
-	}
-
-	if firstSep == -1 || secondSep == -1 || secondSep <= firstSep {
-		return strings.TrimSpace(monitorOutput)
-	}
-
-	snapshot := strings.Join(lines[firstSep+1:secondSep], "\n")
-	return strings.TrimSpace(snapshot)
 }

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -2,6 +2,8 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -106,5 +108,103 @@ func TestHandleIncomingToolDisabledWhenRuntimeOff(t *testing.T) {
 		if !strings.Contains(out, "agents.runtime.allowedTools") {
 			t.Fatalf("expected allowedTools config hint for %q, got %q", input, out)
 		}
+	}
+}
+
+func TestAssignOhMyCodeReturnsAckWithoutMonitor(t *testing.T) {
+	workspace := t.TempDir()
+	scriptPath := filepath.Join(workspace, "agent_manager_stub.py")
+	logPath := filepath.Join(workspace, "calls.log")
+
+	script := `import pathlib
+import sys
+
+log_path = pathlib.Path(sys.argv[0]).with_name("calls.log")
+with log_path.open("a", encoding="utf-8") as f:
+    f.write(" ".join(sys.argv[1:]) + "\n")
+
+if len(sys.argv) >= 2 and sys.argv[1] == "assign":
+    print("assign ok")
+    sys.exit(0)
+
+if len(sys.argv) >= 2 and sys.argv[1] == "monitor":
+    print("monitor should not run")
+    sys.exit(0)
+
+print("unknown command", file=sys.stderr)
+sys.exit(1)
+`
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	manager := NewManager(&config.AgentsConfig{
+		OhMyCode: &config.OhMyCodeConfig{
+			Enabled:            true,
+			Workspace:          workspace,
+			AgentManagerScript: scriptPath,
+			DefaultAgent:       "qa-1",
+		},
+	})
+
+	out, err := manager.assignOhMyCode(context.Background(), "hello world", "")
+	if err != nil {
+		t.Fatalf("assignOhMyCode: %v", err)
+	}
+	if out != ohMyCodeAssignAckMessage {
+		t.Fatalf("expected %q, got %q", ohMyCodeAssignAckMessage, out)
+	}
+
+	logRaw, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read calls log: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(logRaw)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected only one agent-manager call, got %d (%q)", len(lines), lines)
+	}
+	if lines[0] != "assign qa-1" {
+		t.Fatalf("expected assign call, got %q", lines[0])
+	}
+}
+
+func TestAssignOhMyCodePreservesAssignFailure(t *testing.T) {
+	workspace := t.TempDir()
+	scriptPath := filepath.Join(workspace, "agent_manager_fail.py")
+
+	script := `import sys
+
+if len(sys.argv) >= 2 and sys.argv[1] == "assign":
+    print("assign failed", file=sys.stderr)
+    sys.exit(2)
+
+print("unexpected command", file=sys.stderr)
+sys.exit(1)
+`
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	manager := NewManager(&config.AgentsConfig{
+		OhMyCode: &config.OhMyCodeConfig{
+			Enabled:            true,
+			Workspace:          workspace,
+			AgentManagerScript: scriptPath,
+			DefaultAgent:       "qa-1",
+		},
+	})
+
+	out, err := manager.assignOhMyCode(context.Background(), "hello world", "")
+	if err == nil {
+		t.Fatal("expected assign failure")
+	}
+	if out != "" {
+		t.Fatalf("expected empty output on failure, got %q", out)
+	}
+	if !strings.Contains(err.Error(), "assign failed") {
+		t.Fatalf("expected assign failure error, got %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- remove post-assign monitor fetch from `assignOhMyCode()`
- return concise ack `处理中…` immediately after successful assign
- preserve assign failure path (still returns original error)
- add tests to verify:
  - assign success returns ack and does not invoke monitor
  - assign failure still surfaces error message

## Linked Issue
- Closes #269

## Test Evidence
- `XDG_CONFIG_HOME=$(mktemp -d) GOTELEMETRY=off go test ./internal/agent`
- `XDG_CONFIG_HOME=$(mktemp -d) GOTELEMETRY=off go test ./...`

## Risk & Rollback
### Risk
- Users no longer receive immediate tmux snapshot in direct reply; they only receive acknowledgment while agent continues asynchronously.

### Rollback
- Revert commit `86961ee` to restore previous monitor-after-assign behavior.
