### PR TITLE
docs: consolidate implemented scope for issue #269

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -15,6 +15,9 @@
 - **#72** Slack DM-only skeleton + /whoami onboarding
 - **#73** Discord DM-only skeleton + /whoami onboarding
 - **#74** Phase 3 runtime skeleton (default-deny tools)
+- **#275** HTTP outbound message send API (`POST /api/v1/message/send`)
+- **#276** CLI `fractalbot message send` via gateway API
+- **#277** concise assign acknowledgement (`处理中…`) for plain conversation flow
 
 ---
 
@@ -40,6 +43,23 @@
 - Safer error messaging and reply truncation
 - One-click local install script (XDG-friendly)
 - Phase 3 runtime skeleton with default-deny tool registry (echo/version)
+- Outbound single-target send path (HTTP API + CLI send command)
+- Concise default assign acknowledgement instead of raw monitor dump
+
+---
+
+## Issue #269 Snapshot (Partial Delivery)
+
+Implemented:
+- Natural default-agent chat now replies with concise acknowledgement (`处理中…`) after assign (#277)
+- Outbound single-target message send API is available (`POST /api/v1/message/send`) (#275)
+- CLI command for send is available (`fractalbot message send --channel --to --text`) (#276)
+
+Still pending for full #269 scope:
+- Channel-agnostic target model (`--to` currently numeric `int64`)
+- Origin-channel/thread routing memory when target is omitted
+- Proactive notify mode and multi-target broadcast/fan-out
+- Broadcast safety controls (policy/rate-limit/audit trail)
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -69,7 +69,8 @@
 ### Phase 2.5: Messaging UX & Routing Control Plane 🆕 (IN PROGRESS)
 
 #### Conversational Reply Experience
-- [ ] Default-agent conversational mode for plain messages (no raw monitor dump)
+- [x] Default-agent conversational mode for plain messages (no raw monitor dump)
+- [x] Direct assign acknowledgement uses concise `"处理中…"` reply (#277)
 - [ ] Separate user-facing replies from operator diagnostics (`/monitor`, `/doctor`)
 - [ ] Reply normalization (silent/heartbeat filtering + concise fallback behavior)
 - [ ] Friendly progress/error responses (actionable next-step hints)
@@ -78,8 +79,10 @@
 **Estimated**: 1-2 weeks
 
 #### Outbound Messaging API + CLI
-- [ ] Unified outbound message API (provider-agnostic)
-- [ ] CLI surface for send/proactive notify/broadcast
+- [x] Unified outbound message API (single-target send: `POST /api/v1/message/send`) (#275)
+- [x] CLI surface for send (`fractalbot message send`) (#276)
+- [ ] CLI/API surface for proactive notify
+- [ ] CLI/API surface for multi-target broadcast
 - [ ] Default "reply to originating channel" behavior when target is omitted
 - [ ] Multi-target fan-out (broadcast) with delivery receipts
 

--- a/docs/issue-269-implementation-status.md
+++ b/docs/issue-269-implementation-status.md
@@ -1,0 +1,30 @@
+# Issue #269 Implementation Status
+
+Issue: <https://github.com/fractalmind-ai/fractalbot/issues/269>
+
+## Implemented (merged)
+
+1. PR #275: HTTP outbound single-target send API
+   - Endpoint: `POST /api/v1/message/send`
+   - Payload: `channel`, `to`, `text`
+2. PR #276: CLI send command
+   - Command: `fractalbot message send --channel <name> --to <id> --text "<message>"`
+   - Behavior: calls gateway API endpoint above
+3. PR #277: concise default assign acknowledgement
+   - Behavior: after successful assign, reply with `处理中…`
+   - Purpose: avoid dumping raw monitor output into direct conversation replies
+
+## Current Boundary
+
+- Outbound target is still numeric (`to int64`) across CLI/API/channel interface.
+- Slack/Discord outbound adapters are not yet using a channel-agnostic target string.
+- Multi-target fan-out/broadcast is not implemented.
+- Omitted-target reply routing (reuse last origin channel/thread) is not implemented.
+- Routing memory, rate limit, duplicate suppression, and outbound audit trail are not implemented yet.
+
+## Follow-up Work Needed To Close #269
+
+1. Introduce channel-agnostic target model (string target + per-channel parsing/validation).
+2. Add routing memory for default reply target when explicit target is absent.
+3. Add proactive `notify` and `broadcast` modes with multi-target fan-out.
+4. Add policy guardrails: allowlist, rate limit, duplicate suppression, audit logs.


### PR DESCRIPTION
## Summary
- add a dedicated implementation status doc for #269 with implemented scope and current boundaries
- update `ROADMAP.md` to mark delivered sub-items (concise assign ack, single-target outbound API, CLI send)
- update `PROGRESS.md` with a partial-delivery snapshot and explicit remaining work

## Why
Issue #269 was reopened. This PR consolidates what is already shipped vs what is still pending, so review and next-step planning can be done from one place.

## Scope
- Docs only (no runtime behavior changes)

## References
- #269
- #275
- #276
- #277
