### PR TITLE
fix: preserve Telegram routing context and use-fractalbot hint for main agent (#279)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ agents:
     allowedAgents:
       - "qa-1"
       - "coder-a"
+    # FractalBot injects inbound routing context into assign prompts:
+    # channel/chat_id/user_id/username + resolved selected_agent.
+    # For Telegram outbound intent, the prompt directs the agent to
+    # prefer use-fractalbot and default recipient to current chat_id if omitted.
+    # Keep skill path/name consistent in the agent workspace:
+    # .claude/skills/use-fractalbot/SKILL.md
 
   # Optional: in-process runtime (Phase 3 skeleton)
   runtime:
@@ -193,6 +199,8 @@ Example chat commands (copy/paste):
 Phase 3 memory uses a native ONNX Runtime (ORT) library; see `docs/ort-distribution.md` for the distribution strategy and security notes.
 
 Telegram supports `/agent <name> <task...>` to route tasks to a specific agent; if omitted, `defaultAgent` is used. When `allowedAgents` is set, only those names are accepted. Use `/agents` to see allowed agents; if you target a disallowed agent, the bot will suggest `/agents`.
+For Telegram-routed assignments, FractalBot includes routing context (`channel`, `chat_id`, `user_id`, `username`, `selected_agent`) in the assign prompt and explicitly hints outbound-send intent through `use-fractalbot`. If no Telegram recipient is provided, the prompt contract defaults target to current `chat_id`.
+Operator note: make sure `use-fractalbot` appears in the agent's effective available skills list and points to `.claude/skills/use-fractalbot/SKILL.md`.
 Additional lifecycle commands:
 - `/agents` (list allowed agent names)
 - `/monitor <name> [lines]` (show recent agent output; lines capped to 200)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -106,6 +106,12 @@ agents:
     allowedAgents:
       - "qa-1"
       - "coder-a"
+    # Inbound channel context (channel/chat_id/user_id/username + selected_agent) is
+    # injected into assign prompts. For Telegram outbound intent, FractalBot instructs
+    # the agent to prefer the use-fractalbot skill and default recipient to current chat_id
+    # when omitted.
+    # Keep skill naming/path consistent in your agent workspace:
+    #   use-fractalbot -> .claude/skills/use-fractalbot/SKILL.md
     # How long to wait for agent-manager output
     assignTimeoutSeconds: 90
     # Telegram lifecycle commands:

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -134,7 +134,7 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 
 	if m.isOhMyCodeEnabled() {
 		agentName, _ := data["agent"].(string)
-		out, err := m.assignOhMyCode(ctx, text, agentName)
+		out, err := m.assignOhMyCode(ctx, text, agentName, data)
 		if err != nil {
 			return "", err
 		}
@@ -215,7 +215,7 @@ func (m *Manager) isOhMyCodeEnabled() bool {
 	return strings.TrimSpace(m.config.OhMyCode.Workspace) != ""
 }
 
-func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride string) (string, error) {
+func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride string, inboundData map[string]interface{}) (string, error) {
 	workspace, script, err := m.resolveOhMyCodeWorkspaceAndScript()
 	if err != nil {
 		return "", err
@@ -246,7 +246,8 @@ func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride st
 		defer cancel()
 	}
 
-	if _, err := runOhMyCodeAgentManager(assignCtx, workspace, script, buildOhMyCodeTaskPrompt(userText), "assign", name); err != nil {
+	prompt := buildOhMyCodeTaskPrompt(userText, name, inboundData)
+	if _, err := runOhMyCodeAgentManager(assignCtx, workspace, script, prompt, "assign", name); err != nil {
 		return "", err
 	}
 
@@ -407,6 +408,47 @@ func runOhMyCodeAgentManager(ctx context.Context, workspace, script, stdin strin
 	return outText, nil
 }
 
-func buildOhMyCodeTaskPrompt(userText string) string {
-	return fmt.Sprintf("User message:\n%s\n", strings.TrimSpace(userText))
+func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[string]interface{}) string {
+	channel := promptContextValue(inboundData, "channel")
+	chatID := promptContextValue(inboundData, "chat_id")
+	userID := promptContextValue(inboundData, "user_id")
+	username := promptContextValue(inboundData, "username")
+
+	var sb strings.Builder
+	sb.WriteString("Inbound routing context:\n")
+	sb.WriteString(fmt.Sprintf("- channel: %s\n", defaultPromptContextValue(channel)))
+	sb.WriteString(fmt.Sprintf("- chat_id: %s\n", defaultPromptContextValue(chatID)))
+	sb.WriteString(fmt.Sprintf("- user_id: %s\n", defaultPromptContextValue(userID)))
+	sb.WriteString(fmt.Sprintf("- username: %s\n", defaultPromptContextValue(username)))
+	sb.WriteString(fmt.Sprintf("- selected_agent: %s\n", defaultPromptContextValue(strings.TrimSpace(selectedAgent))))
+	sb.WriteString("\n")
+	sb.WriteString("Routing instructions:\n")
+	sb.WriteString("- selected_agent is the final routing target after default/allowlist resolution.\n")
+	sb.WriteString("- For outbound messaging intent, prefer `use-fractalbot` skill.\n")
+	sb.WriteString("- Effective available skills:\n")
+	sb.WriteString("  - use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)\n")
+	sb.WriteString("- If channel=telegram and recipient is omitted, default to current chat_id.\n")
+	sb.WriteString("\n")
+	sb.WriteString("User message:\n")
+	sb.WriteString(strings.TrimSpace(userText))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func promptContextValue(inboundData map[string]interface{}, key string) string {
+	if len(inboundData) == 0 {
+		return ""
+	}
+	value, ok := inboundData[key]
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func defaultPromptContextValue(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "(unknown)"
+	}
+	return value
 }

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -65,16 +65,49 @@ func TestValidateOhMyCodeAgentInvalidName(t *testing.T) {
 	}
 }
 
-func TestBuildOhMyCodeTaskPrompt(t *testing.T) {
-	out := buildOhMyCodeTaskPrompt("hello world")
-	if !strings.HasPrefix(out, "User message:\n") {
-		t.Fatalf("expected user message prefix, got %q", out)
+func TestBuildOhMyCodeTaskPromptIncludesTelegramContextAndSkillHint(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("hello world", "main", map[string]interface{}{
+		"channel":  "telegram",
+		"chat_id":  int64(99),
+		"user_id":  int64(123),
+		"username": "alice",
+	})
+
+	expectedParts := []string{
+		"Inbound routing context:",
+		"- channel: telegram",
+		"- chat_id: 99",
+		"- user_id: 123",
+		"- username: alice",
+		"- selected_agent: main",
+		"prefer `use-fractalbot` skill",
+		"use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)",
+		"default to current chat_id",
+		"User message:\nhello world",
 	}
-	if strings.Contains(out, "Telegram") {
-		t.Fatalf("did not expect channel-specific wording, got %q", out)
+	for _, part := range expectedParts {
+		if !strings.Contains(out, part) {
+			t.Fatalf("expected %q in prompt, got %q", part, out)
+		}
 	}
-	if !strings.Contains(out, "hello world") {
-		t.Fatalf("expected message content, got %q", out)
+}
+
+func TestBuildOhMyCodeTaskPromptIncludesResolvedTargetContract(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("send a message", "qa-1", nil)
+
+	expectedParts := []string{
+		"- channel: (unknown)",
+		"- chat_id: (unknown)",
+		"- user_id: (unknown)",
+		"- username: (unknown)",
+		"- selected_agent: qa-1",
+		"selected_agent is the final routing target after default/allowlist resolution",
+		"default to current chat_id",
+	}
+	for _, part := range expectedParts {
+		if !strings.Contains(out, part) {
+			t.Fatalf("expected %q in prompt, got %q", part, out)
+		}
 	}
 }
 
@@ -148,7 +181,7 @@ sys.exit(1)
 		},
 	})
 
-	out, err := manager.assignOhMyCode(context.Background(), "hello world", "")
+	out, err := manager.assignOhMyCode(context.Background(), "hello world", "", nil)
 	if err != nil {
 		t.Fatalf("assignOhMyCode: %v", err)
 	}
@@ -197,7 +230,7 @@ sys.exit(1)
 		},
 	})
 
-	out, err := manager.assignOhMyCode(context.Background(), "hello world", "")
+	out, err := manager.assignOhMyCode(context.Background(), "hello world", "", nil)
 	if err == nil {
 		t.Fatal("expected assign failure")
 	}
@@ -206,5 +239,72 @@ sys.exit(1)
 	}
 	if !strings.Contains(err.Error(), "assign failed") {
 		t.Fatalf("expected assign failure error, got %v", err)
+	}
+}
+
+func TestAssignOhMyCodePromptUsesResolvedDefaultAgent(t *testing.T) {
+	workspace := t.TempDir()
+	scriptPath := filepath.Join(workspace, "agent_manager_prompt_capture.py")
+	promptPath := filepath.Join(workspace, "prompt.log")
+
+	script := `import pathlib
+import sys
+
+base = pathlib.Path(sys.argv[0]).parent
+prompt = sys.stdin.read()
+(base / "prompt.log").write_text(prompt, encoding="utf-8")
+
+if len(sys.argv) >= 2 and sys.argv[1] == "assign":
+    print("assign ok")
+    sys.exit(0)
+
+print("unexpected command", file=sys.stderr)
+sys.exit(1)
+`
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	manager := NewManager(&config.AgentsConfig{
+		OhMyCode: &config.OhMyCodeConfig{
+			Enabled:            true,
+			Workspace:          workspace,
+			AgentManagerScript: scriptPath,
+			DefaultAgent:       "qa-1",
+		},
+	})
+
+	out, err := manager.assignOhMyCode(context.Background(), "send hello", "", map[string]interface{}{
+		"channel":  "telegram",
+		"chat_id":  int64(321),
+		"user_id":  int64(456),
+		"username": "bob",
+	})
+	if err != nil {
+		t.Fatalf("assignOhMyCode: %v", err)
+	}
+	if out != ohMyCodeAssignAckMessage {
+		t.Fatalf("expected %q, got %q", ohMyCodeAssignAckMessage, out)
+	}
+
+	promptRaw, err := os.ReadFile(promptPath)
+	if err != nil {
+		t.Fatalf("read prompt log: %v", err)
+	}
+	prompt := string(promptRaw)
+
+	expectedParts := []string{
+		"- selected_agent: qa-1",
+		"- channel: telegram",
+		"- chat_id: 321",
+		"- user_id: 456",
+		"- username: bob",
+		"default to current chat_id",
+	}
+	for _, part := range expectedParts {
+		if !strings.Contains(prompt, part) {
+			t.Fatalf("expected %q in prompt, got %q", part, prompt)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #279 by preserving inbound routing context when Telegram messages are assigned to the default oh-my-code agent, and by adding explicit outbound-routing guidance for `use-fractalbot`.

### What changed
- `internal/agent/manager.go`
  - `assignOhMyCode` now receives inbound message metadata and builds a structured assign prompt.
  - Prompt now includes: `channel`, `chat_id`, `user_id`, `username`, and resolved `selected_agent`.
  - Prompt includes explicit routing instructions:
    - prefer `use-fractalbot` for outbound messaging intent
    - if channel is Telegram and recipient is omitted, default to current `chat_id`
  - Prompt now contains an explicit effective skills entry:
    - `use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)`
- `internal/agent/manager_test.go`
  - Added regression tests for Telegram metadata presence, `use-fractalbot` hint, and default-target contract in prompt.
  - Added assign-path test to verify resolved default agent appears in generated prompt.
- `README.md` and `config.example.yaml`
  - Documented new prompt behavior and operator expectation for skill path/name consistency.

### Behavior checks
- Keeps existing concise assign ack behavior (`处理中…`) unchanged.
- No additional secret material is introduced to logs/prompts; only inbound routing metadata is included.

## Test evidence
```bash
go test ./internal/agent
go test ./...
```

Results:
- `go test ./internal/agent` ✅
- `go test ./...` ✅
