### PR TITLE
fix: normalize default-agent conversational marker replies (#272)

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -31,6 +31,8 @@ const (
 	maxOhMyCodeMonitorLines         = 200
 
 	runtimeToolsDisabledMessage = "⚠️ runtime tools are disabled. Set agents.runtime.enabled and agents.runtime.allowedTools."
+	markerHeartbeatOK           = "HEARTBEAT_OK"
+	markerNoReply               = "NO_REPLY"
 )
 
 // Manager is a minimal stub for agent lifecycle management.
@@ -126,6 +128,10 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 		if err != nil {
 			return "", err
 		}
+		out = normalizeUserReply(out)
+		if out == "" {
+			return "", nil
+		}
 		if channel == "telegram" {
 			return channels.TruncateTelegramReply(out), nil
 		}
@@ -137,6 +143,10 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 		out, err := m.assignOhMyCode(ctx, text, agentName, data)
 		if err != nil {
 			return "", err
+		}
+		out = normalizeUserReply(out)
+		if out == "" {
+			return "", nil
 		}
 		if channel == "telegram" {
 			return channels.TruncateTelegramReply(out), nil
@@ -451,4 +461,12 @@ func defaultPromptContextValue(value string) string {
 		return "(unknown)"
 	}
 	return value
+}
+
+func normalizeUserReply(reply string) string {
+	trimmed := strings.TrimSpace(reply)
+	if trimmed == markerHeartbeatOK || trimmed == markerNoReply {
+		return ""
+	}
+	return reply
 }

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -8,8 +8,31 @@ import (
 	"testing"
 
 	"github.com/fractalmind-ai/fractalbot/internal/config"
+	agentruntime "github.com/fractalmind-ai/fractalbot/internal/runtime"
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 )
+
+type runtimeStub struct {
+	reply string
+	err   error
+	tasks []agentruntime.Task
+}
+
+func (r *runtimeStub) Start(ctx context.Context) error {
+	_ = ctx
+	return nil
+}
+
+func (r *runtimeStub) Stop(ctx context.Context) error {
+	_ = ctx
+	return nil
+}
+
+func (r *runtimeStub) HandleTask(ctx context.Context, task agentruntime.Task) (string, error) {
+	_ = ctx
+	r.tasks = append(r.tasks, task)
+	return r.reply, r.err
+}
 
 func TestValidateOhMyCodeAgentDefaultOnly(t *testing.T) {
 	manager := NewManager(&config.AgentsConfig{
@@ -141,6 +164,64 @@ func TestHandleIncomingToolDisabledWhenRuntimeOff(t *testing.T) {
 		if !strings.Contains(out, "agents.runtime.allowedTools") {
 			t.Fatalf("expected allowedTools config hint for %q, got %q", input, out)
 		}
+	}
+}
+
+func TestHandleIncomingNormalizesHeartbeatAndNoReplyMarkers(t *testing.T) {
+	tests := []struct {
+		name    string
+		channel string
+		reply   string
+	}{
+		{name: "heartbeat-slack", channel: "slack", reply: markerHeartbeatOK},
+		{name: "heartbeat-telegram-whitespace", channel: "telegram", reply: "  HEARTBEAT_OK  \n"},
+		{name: "no-reply-slack", channel: "slack", reply: markerNoReply},
+		{name: "no-reply-telegram-whitespace", channel: "telegram", reply: "\nNO_REPLY\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := &runtimeStub{reply: tc.reply}
+			manager := NewManager(&config.AgentsConfig{})
+			manager.runtime = rt
+
+			out, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+				Data: map[string]interface{}{
+					"channel": tc.channel,
+					"text":    "hello",
+					"agent":   "qa-1",
+				},
+			})
+			if err != nil {
+				t.Fatalf("HandleIncoming: %v", err)
+			}
+			if out != "" {
+				t.Fatalf("expected empty normalized reply, got %q", out)
+			}
+			if len(rt.tasks) != 1 {
+				t.Fatalf("expected one runtime task, got %d", len(rt.tasks))
+			}
+		})
+	}
+}
+
+func TestHandleIncomingKeepsNonMarkerRuntimeReply(t *testing.T) {
+	rt := &runtimeStub{reply: "runtime: received task"}
+	manager := NewManager(&config.AgentsConfig{})
+	manager.runtime = rt
+
+	out, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "slack",
+			"text":    "hello",
+			"agent":   "qa-1",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming: %v", err)
+	}
+	if out != "runtime: received task" {
+		t.Fatalf("expected runtime reply preserved, got %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements issue #272 (phase2.5 default-agent conversational replies) with minimal scoped changes.

Closes #272.

### What this PR changes
- Keeps normal oh-my-code conversational path concise (no monitor dump behavior remains unchanged).
- Adds reply normalization in `internal/agent/manager.go` so literal runtime markers are not sent to users:
  - `HEARTBEAT_OK` -> empty reply
  - `NO_REPLY` -> empty reply
- Applies normalization before channel-specific formatting in both runtime and oh-my-code paths.
- Adds/updates unit tests in `internal/agent/manager_test.go`:
  - Existing `TestAssignOhMyCodeReturnsAckWithoutMonitor` continues proving no `/monitor` append on normal assign path.
  - New marker normalization tests for both Slack and Telegram message paths.

### Acceptance mapping
1. **No monitor dump in normal oh-my-code replies**: covered by existing assign-no-monitor test and unchanged assign flow.
2. **`/monitor` and `/doctor` diagnostics remain explicit**: no lifecycle command path changes in this PR.
3. **Normalize `HEARTBEAT_OK`/`NO_REPLY` to empty reply**: implemented and unit-tested.
4. **Unit tests added/adjusted in `internal/agent/manager_test.go`**: done.

## Test evidence
```bash
go test ./internal/agent
go test ./...
```

Results:
- `go test ./internal/agent` ✅
- `go test ./...` ✅
