### PR TITLE
Fix #284 channel startup isolation + Slack reconnect; add graceful restart signal (#285)

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -23,16 +23,57 @@ import (
 
 var messageSendFn = sendMessageViaGatewayAPI
 
+const exitCodeRestartRequested = 75
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
+
 func main() {
 	os.Exit(Run(os.Args[1:], os.Stderr))
 }
 
 // Run executes the fractalbot CLI.
 func Run(args []string, out io.Writer) int {
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
+	ctx, stop, observedSignal := newShutdownContext(context.Background())
+	code := runWithContext(ctx, args, out)
+	stop()
 
-	return runWithContext(ctx, args, out)
+	sig, ok := <-observedSignal
+	return exitCodeForShutdown(code, sig, ok)
+}
+
+func exitCodeForShutdown(code int, sig os.Signal, hasSignal bool) int {
+	if code == 0 && hasSignal && sig == syscall.SIGHUP {
+		return exitCodeRestartRequested
+	}
+	return code
+}
+
+func newShutdownContext(parent context.Context) (context.Context, func(), <-chan os.Signal) {
+	ctx, cancel := context.WithCancel(parent)
+	sigCh := make(chan os.Signal, 1)
+	observed := make(chan os.Signal, 1)
+	signal.Notify(sigCh, shutdownSignals...)
+
+	go func() {
+		defer close(observed)
+		select {
+		case <-ctx.Done():
+			return
+		case <-parent.Done():
+			cancel()
+			return
+		case sig := <-sigCh:
+			observed <- sig
+			cancel()
+			return
+		}
+	}()
+
+	cleanup := func() {
+		signal.Stop(sigCh)
+		cancel()
+	}
+	return ctx, cleanup, observed
 }
 
 func runWithContext(ctx context.Context, args []string, out io.Writer) int {

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -202,4 +203,31 @@ func writeMinimalConfig(t *testing.T) string {
 	}
 
 	return configPath
+}
+
+func TestShutdownSignalsIncludeSIGHUP(t *testing.T) {
+	if !containsSignal(shutdownSignals, syscall.SIGHUP) {
+		t.Fatalf("expected shutdown signals to include SIGHUP")
+	}
+}
+
+func TestExitCodeForShutdown(t *testing.T) {
+	if got := exitCodeForShutdown(0, syscall.SIGHUP, true); got != exitCodeRestartRequested {
+		t.Fatalf("expected restart code %d, got %d", exitCodeRestartRequested, got)
+	}
+	if got := exitCodeForShutdown(0, syscall.SIGTERM, true); got != 0 {
+		t.Fatalf("expected normal exit code for SIGTERM, got %d", got)
+	}
+	if got := exitCodeForShutdown(1, syscall.SIGHUP, true); got != 1 {
+		t.Fatalf("expected existing failure code to be preserved, got %d", got)
+	}
+}
+
+func containsSignal(signals []os.Signal, target os.Signal) bool {
+	for _, sig := range signals {
+		if sig == target {
+			return true
+		}
+	}
+	return false
 }

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ After=network.target
 [Service]
 ExecStart=${bin_dir}/fractalbot --config ${config_path}
 WorkingDirectory=${data_dir}
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 [Install]

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 )
@@ -17,6 +19,9 @@ type Manager struct {
 	handler   IncomingMessageHandler
 
 	channels map[string]Channel
+
+	startMu      sync.Mutex
+	startCancels map[string]context.CancelFunc
 }
 
 // NewManager creates a new channel manager.
@@ -25,6 +30,8 @@ func NewManager(cfg *config.ChannelsConfig, agentsCfg *config.AgentsConfig) *Man
 		cfg:       cfg,
 		agentsCfg: agentsCfg,
 		channels:  make(map[string]Channel),
+
+		startCancels: make(map[string]context.CancelFunc),
 	}
 }
 
@@ -88,9 +95,13 @@ func (m *Manager) Start(ctx context.Context) error {
 		if channel.IsRunning() {
 			continue
 		}
-		if err := channel.Start(ctx); err != nil {
-			return fmt.Errorf("failed to start %s: %w", channel.Name(), err)
+		name := channel.Name()
+		if m.hasInFlightStart(name) {
+			continue
 		}
+		channelCtx, cancel := context.WithCancel(ctx)
+		m.trackInFlightStart(name, cancel)
+		go m.startChannel(name, channel, channelCtx)
 	}
 
 	return nil
@@ -98,6 +109,8 @@ func (m *Manager) Start(ctx context.Context) error {
 
 // Stop stops configured channels.
 func (m *Manager) Stop() error {
+	m.cancelInFlightStarts()
+
 	var errs []error
 	for _, channel := range m.List() {
 		if !channel.IsRunning() {
@@ -113,6 +126,45 @@ func (m *Manager) Stop() error {
 	}
 
 	return nil
+}
+
+func (m *Manager) startChannel(name string, channel Channel, ctx context.Context) {
+	defer m.clearInFlightStart(name)
+	if err := channel.Start(ctx); err != nil {
+		log.Printf("channel %s failed to start: %v", name, err)
+	}
+}
+
+func (m *Manager) hasInFlightStart(name string) bool {
+	m.startMu.Lock()
+	defer m.startMu.Unlock()
+	_, ok := m.startCancels[name]
+	return ok
+}
+
+func (m *Manager) trackInFlightStart(name string, cancel context.CancelFunc) {
+	m.startMu.Lock()
+	m.startCancels[name] = cancel
+	m.startMu.Unlock()
+}
+
+func (m *Manager) clearInFlightStart(name string) {
+	m.startMu.Lock()
+	delete(m.startCancels, name)
+	m.startMu.Unlock()
+}
+
+func (m *Manager) cancelInFlightStarts() {
+	m.startMu.Lock()
+	cancels := make([]context.CancelFunc, 0, len(m.startCancels))
+	for name, cancel := range m.startCancels {
+		cancels = append(cancels, cancel)
+		delete(m.startCancels, name)
+	}
+	m.startMu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
 }
 
 func (m *Manager) registerConfiguredChannels() error {

--- a/internal/channels/manager_test.go
+++ b/internal/channels/manager_test.go
@@ -2,7 +2,9 @@ package channels
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 )
 
 type fakeChannel struct {
@@ -21,8 +23,11 @@ func (f *fakeChannel) Name() string { return f.name }
 func (f *fakeChannel) Start(ctx context.Context) error {
 	_ = ctx
 	f.started++
+	if f.startErr != nil {
+		return f.startErr
+	}
 	f.running = true
-	return f.startErr
+	return nil
 }
 
 func (f *fakeChannel) Stop() error {
@@ -51,6 +56,9 @@ func TestManagerStartStop(t *testing.T) {
 	if err := manager.Start(context.Background()); err != nil {
 		t.Fatalf("start: %v", err)
 	}
+	waitForCondition(t, time.Second, func() bool {
+		return fake.running && fake.started == 1
+	})
 	if !fake.running || fake.started != 1 {
 		t.Fatalf("expected channel started, running=%v started=%d", fake.running, fake.started)
 	}
@@ -73,4 +81,108 @@ func TestManagerRegisterDuplicate(t *testing.T) {
 	if err := manager.Register(fake); err == nil {
 		t.Fatalf("expected duplicate register error")
 	}
+}
+
+func TestManagerStartBestEffortWhenOneChannelFails(t *testing.T) {
+	manager := NewManager(nil, nil)
+	good := &fakeChannel{name: "good"}
+	bad := &fakeChannel{name: "bad", startErr: errors.New("boom")}
+
+	if err := manager.Register(good); err != nil {
+		t.Fatalf("register good: %v", err)
+	}
+	if err := manager.Register(bad); err != nil {
+		t.Fatalf("register bad: %v", err)
+	}
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start should be best-effort, got error: %v", err)
+	}
+
+	waitForCondition(t, time.Second, func() bool {
+		return good.started == 1 && bad.started == 1
+	})
+
+	if !good.running {
+		t.Fatalf("expected good channel to start")
+	}
+	if bad.running {
+		t.Fatalf("expected bad channel not running")
+	}
+}
+
+func TestManagerStartDoesNotBlockOnSlowChannel(t *testing.T) {
+	manager := NewManager(nil, nil)
+	blockCtxObserved := make(chan struct{})
+	quick := &fakeChannel{name: "quick"}
+	blocking := &blockingStartChannel{
+		name:           "blocking",
+		started:        make(chan struct{}),
+		blockCtxSignal: blockCtxObserved,
+	}
+
+	if err := manager.Register(quick); err != nil {
+		t.Fatalf("register quick: %v", err)
+	}
+	if err := manager.Register(blocking); err != nil {
+		t.Fatalf("register blocking: %v", err)
+	}
+
+	startedAt := time.Now()
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > 200*time.Millisecond {
+		t.Fatalf("manager start blocked for %s", elapsed)
+	}
+
+	waitForCondition(t, time.Second, func() bool { return quick.started == 1 })
+
+	if err := manager.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+
+	select {
+	case <-blockCtxObserved:
+	case <-time.After(time.Second):
+		t.Fatalf("expected blocking start context cancellation on stop")
+	}
+}
+
+type blockingStartChannel struct {
+	name           string
+	started        chan struct{}
+	blockCtxSignal chan struct{}
+}
+
+func (b *blockingStartChannel) Name() string { return b.name }
+
+func (b *blockingStartChannel) Start(ctx context.Context) error {
+	close(b.started)
+	<-ctx.Done()
+	close(b.blockCtxSignal)
+	return ctx.Err()
+}
+
+func (b *blockingStartChannel) Stop() error { return nil }
+
+func (b *blockingStartChannel) SendMessage(ctx context.Context, chatID int64, text string) error {
+	_ = ctx
+	_ = chatID
+	_ = text
+	return nil
+}
+
+func (b *blockingStartChannel) IsRunning() bool { return false }
+
+func waitForCondition(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("condition not met before timeout (%s)", timeout)
 }

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -16,6 +16,11 @@ import (
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 )
 
+const (
+	defaultSlackReconnectBackoffMin = 1 * time.Second
+	defaultSlackReconnectBackoffMax = 1 * time.Minute
+)
+
 // SlackBot implements a minimal Slack channel skeleton.
 type SlackBot struct {
 	botToken string
@@ -34,6 +39,10 @@ type SlackBot struct {
 	startFn       func(ctx context.Context) error
 	stopFn        func() error
 	sendMessageFn func(ctx context.Context, channelID, text string) error
+
+	socketClientFactoryFn func(apiClient *slack.Client) *socketmode.Client
+	runSocketModeFn       func(ctx context.Context, socketClient *socketmode.Client) error
+	waitReconnectFn       func(ctx context.Context, backoff time.Duration) bool
 
 	runningMu sync.RWMutex
 	running   bool
@@ -156,50 +165,118 @@ func (b *SlackBot) initClients() {
 		return
 	}
 	b.apiClient = slack.New(b.botToken, slack.OptionAppLevelToken(b.appToken))
-	b.socketClient = socketmode.New(b.apiClient)
-	if b.ackFn == nil {
-		b.ackFn = b.socketClient.Ack
+	if b.socketClientFactoryFn == nil {
+		b.socketClientFactoryFn = func(apiClient *slack.Client) *socketmode.Client {
+			return socketmode.New(apiClient)
+		}
+	}
+	if b.runSocketModeFn == nil {
+		b.runSocketModeFn = func(ctx context.Context, socketClient *socketmode.Client) error {
+			return socketClient.RunContext(ctx)
+		}
+	}
+	if b.waitReconnectFn == nil {
+		b.waitReconnectFn = waitForReconnect
 	}
 	b.sendMessageFn = b.sendText
 	b.startFn = b.startSocketMode
 }
 
 func (b *SlackBot) startSocketMode(ctx context.Context) error {
-	if b.socketClient == nil {
-		return errors.New("slack socket mode client not initialized")
+	if b.apiClient == nil {
+		return errors.New("slack api client not initialized")
 	}
-
-	go b.consumeSocketEvents(ctx)
-
-	go func() {
-		if err := b.socketClient.RunContext(ctx); err != nil {
-			log.Printf("slack socket mode error: %v", err)
-		}
-	}()
+	if b.socketClientFactoryFn == nil {
+		return errors.New("slack socket mode client factory not configured")
+	}
+	if b.runSocketModeFn == nil {
+		return errors.New("slack socket mode runner not configured")
+	}
+	if b.waitReconnectFn == nil {
+		b.waitReconnectFn = waitForReconnect
+	}
+	go b.runSocketModeLoop(ctx)
 	return nil
 }
 
-func (b *SlackBot) consumeSocketEvents(ctx context.Context) {
+func (b *SlackBot) runSocketModeLoop(ctx context.Context) {
+	backoff := defaultSlackReconnectBackoffMin
+	for {
+		err := b.runSocketModeSession(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			b.markError()
+			log.Printf("slack socket mode error: %v (retry in %s)", err, backoff)
+		} else {
+			log.Printf("slack socket mode disconnected (retry in %s)", backoff)
+		}
+		if !b.waitReconnectFn(ctx, backoff) {
+			return
+		}
+		backoff = nextSlackReconnectBackoff(backoff)
+	}
+}
+
+func (b *SlackBot) runSocketModeSession(ctx context.Context) error {
+	socketClient, err := b.newSocketClient()
+	if err != nil {
+		return err
+	}
+	b.socketClient = socketClient
+
+	ackFn := b.ack
+	if b.ackFn == nil {
+		ackFn = socketClient.Ack
+	}
+
+	sessionCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	go b.consumeSocketEvents(sessionCtx, socketClient, ackFn)
+	return b.runSocketModeFn(sessionCtx, socketClient)
+}
+
+func (b *SlackBot) newSocketClient() (*socketmode.Client, error) {
+	if b.socketClientFactoryFn == nil {
+		return nil, errors.New("slack socket mode client factory not configured")
+	}
+	socketClient := b.socketClientFactoryFn(b.apiClient)
+	if socketClient == nil {
+		return nil, errors.New("slack socket mode client not initialized")
+	}
+	return socketClient, nil
+}
+
+func (b *SlackBot) consumeSocketEvents(ctx context.Context, socketClient *socketmode.Client, ackFn func(req socketmode.Request, payload ...interface{})) {
+	if socketClient == nil {
+		return
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case event, ok := <-b.socketClient.Events:
+		case event, ok := <-socketClient.Events:
 			if !ok {
 				return
 			}
-			b.handleSocketEvent(ctx, event)
+			b.handleSocketEventWithAck(ctx, event, ackFn)
 		}
 	}
 }
 
 func (b *SlackBot) handleSocketEvent(ctx context.Context, event socketmode.Event) {
+	b.handleSocketEventWithAck(ctx, event, b.ack)
+}
+
+func (b *SlackBot) handleSocketEventWithAck(ctx context.Context, event socketmode.Event, ackFn func(req socketmode.Request, payload ...interface{})) {
 	if event.Type == socketmode.EventTypeSlashCommand {
-		b.handleSlashCommandEvent(ctx, event)
+		b.handleSlashCommandEventWithAck(ctx, event, ackFn)
 		return
 	}
-	if event.Request != nil {
-		b.ack(*event.Request)
+	if event.Request != nil && ackFn != nil {
+		ackFn(*event.Request)
 	}
 
 	if event.Type != socketmode.EventTypeEventsAPI {
@@ -213,12 +290,18 @@ func (b *SlackBot) handleSocketEvent(ctx context.Context, event socketmode.Event
 }
 
 func (b *SlackBot) handleSlashCommandEvent(ctx context.Context, event socketmode.Event) {
+	b.handleSlashCommandEventWithAck(ctx, event, b.ack)
+}
+
+func (b *SlackBot) handleSlashCommandEventWithAck(ctx context.Context, event socketmode.Event, ackFn func(req socketmode.Request, payload ...interface{})) {
 	if event.Request == nil {
 		return
 	}
 	cmd, ok := event.Data.(slack.SlashCommand)
 	if !ok {
-		b.ack(*event.Request, map[string]string{"text": "❌ Invalid slash command payload."})
+		if ackFn != nil {
+			ackFn(*event.Request, map[string]string{"text": "❌ Invalid slash command payload."})
+		}
 		return
 	}
 	text := strings.TrimSpace(cmd.Command)
@@ -232,7 +315,34 @@ func (b *SlackBot) handleSlashCommandEvent(ctx context.Context, event socketmode
 		channelType: "slash",
 	}
 	replyText := b.slashCommandReply(ctx, msg)
-	b.ack(*event.Request, map[string]string{"text": replyText})
+	if ackFn != nil {
+		ackFn(*event.Request, map[string]string{"text": replyText})
+	}
+}
+
+func nextSlackReconnectBackoff(current time.Duration) time.Duration {
+	if current < defaultSlackReconnectBackoffMin {
+		return defaultSlackReconnectBackoffMin
+	}
+	next := current * 2
+	if next > defaultSlackReconnectBackoffMax {
+		return defaultSlackReconnectBackoffMax
+	}
+	return next
+}
+
+func waitForReconnect(ctx context.Context, backoff time.Duration) bool {
+	if backoff <= 0 {
+		return true
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func (b *SlackBot) handleEventsAPIEvent(ctx context.Context, event slackevents.EventsAPIEvent) {

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -2,9 +2,12 @@ package channels
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -978,5 +981,81 @@ func TestSlackAgentWithMentionRoutes(t *testing.T) {
 	}
 	if data["text"] != "hello" {
 		t.Fatalf("expected task text, got %v", data["text"])
+	}
+}
+
+func TestNextSlackReconnectBackoff(t *testing.T) {
+	if got := nextSlackReconnectBackoff(0); got != defaultSlackReconnectBackoffMin {
+		t.Fatalf("backoff(0)=%s", got)
+	}
+	if got := nextSlackReconnectBackoff(defaultSlackReconnectBackoffMin); got != 2*defaultSlackReconnectBackoffMin {
+		t.Fatalf("backoff(min)=%s", got)
+	}
+	if got := nextSlackReconnectBackoff(defaultSlackReconnectBackoffMax); got != defaultSlackReconnectBackoffMax {
+		t.Fatalf("backoff(max)=%s", got)
+	}
+}
+
+func TestSlackSocketModeReconnectsWithBackoff(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+	bot.initClients()
+
+	bot.socketClientFactoryFn = func(apiClient *slack.Client) *socketmode.Client {
+		_ = apiClient
+		return &socketmode.Client{}
+	}
+	bot.runSocketModeFn = func(ctx context.Context, socketClient *socketmode.Client) error {
+		_ = ctx
+		_ = socketClient
+		return errors.New("socket closed")
+	}
+
+	var (
+		mu     sync.Mutex
+		waited []time.Duration
+		done   = make(chan struct{})
+	)
+	bot.waitReconnectFn = func(ctx context.Context, backoff time.Duration) bool {
+		_ = ctx
+		mu.Lock()
+		waited = append(waited, backoff)
+		shouldStop := len(waited) >= 3
+		mu.Unlock()
+		if shouldStop {
+			close(done)
+			return false
+		}
+		return true
+	}
+
+	if err := bot.startSocketMode(context.Background()); err != nil {
+		t.Fatalf("startSocketMode: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for reconnect attempts")
+	}
+
+	mu.Lock()
+	got := append([]time.Duration(nil), waited...)
+	mu.Unlock()
+
+	want := []time.Duration{
+		defaultSlackReconnectBackoffMin,
+		2 * defaultSlackReconnectBackoffMin,
+		4 * defaultSlackReconnectBackoffMin,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("waited=%v want=%v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("waited=%v want=%v", got, want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- make channel startup best-effort in `channels.Manager`: each channel start runs with its own child context + goroutine, and one failing channel no longer blocks others
- add Slack socket-mode reconnect loop with exponential backoff
- add graceful restart signal support (`SIGHUP`) and return restart exit code after graceful shutdown
- update installer-generated systemd unit to `Restart=always`

## Why
- resolves P0 cascade where Slack socket-mode failure could block service startup or impact other channels
- allows explicit graceful restart signaling at code level for service managers

## Testing
- `go test ./...`

## QA Request
Please verify:
1. when Slack startup fails, other channels still start and remain available
2. Slack reconnects automatically after simulated socket disconnects
3. sending `SIGHUP` performs graceful shutdown and process exits with restart code (`75`)
4. systemd unit generated by installer uses `Restart=always`