### PR TITLE
feat(imessage): add inbound polling and handler routing

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -157,7 +157,7 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 
 	sendFS := flag.NewFlagSet("message send", flag.ContinueOnError)
 	sendFS.SetOutput(out)
-	channel := sendFS.String("channel", "telegram", "target channel (e.g. telegram, slack, feishu, discord)")
+	channel := sendFS.String("channel", "telegram", "target channel (e.g. telegram, slack, feishu, discord, imessage)")
 	to := sendFS.String("to", "", "target chat ID")
 	text := sendFS.String("text", "", "message text")
 

--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -1,0 +1,585 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+const (
+	defaultIMessageService          = "E:iMessage"
+	defaultIMessagePollingInterval  = 5 * time.Second
+	minIMessagePollingInterval      = 1 * time.Second
+	defaultIMessagePollingLimit     = 20
+	maxIMessagePollingLimit         = 100
+	defaultIMessageDatabasePath     = "~/Library/Messages/chat.db"
+	defaultIMessageStartCheckPeriod = 500 * time.Millisecond
+	defaultIMessageStartRetries     = 5
+)
+
+var currentGOOS = runtime.GOOS
+
+type iMessageSQLiteRow struct {
+	MessageID int64   `json:"message_id"`
+	Sender    string  `json:"sender"`
+	Text      string  `json:"text"`
+	Date      float64 `json:"date"`
+}
+
+// IMessageInbound represents a single inbound iMessage entry.
+type IMessageInbound struct {
+	MessageID    int64
+	Sender       string
+	Text         string
+	Timestamp    time.Time
+	RawTimestamp int64
+}
+
+// IMessageBot implements native macOS iMessage send/polling.
+type IMessageBot struct {
+	recipient      string
+	defaultMessage string
+	service        string
+
+	handler IncomingMessageHandler
+
+	pollingEnabled  bool
+	pollingInterval time.Duration
+	pollingLimit    int
+	databasePath    string
+
+	lastSeenMu        sync.Mutex
+	lastSeenMessageID int64
+
+	execFn             func(ctx context.Context, name string, args ...string) ([]byte, error)
+	readMessagesFn     func(ctx context.Context, sinceMessageID int64, limit int) ([]IMessageInbound, error)
+	checkPermissionsFn func(ctx context.Context) error
+	isMessagesRunning  func(ctx context.Context) (bool, error)
+	startMessagesApp   func(ctx context.Context) error
+	sleepFn            func(d time.Duration)
+
+	runningMu sync.RWMutex
+	running   bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	telemetryMu  sync.RWMutex
+	lastActivity time.Time
+	lastError    time.Time
+}
+
+func NewIMessageBot(recipient, defaultMessage, service string) (*IMessageBot, error) {
+	if currentGOOS != "darwin" {
+		return nil, errors.New("imessage channel is only supported on darwin")
+	}
+
+	trimmedRecipient := strings.TrimSpace(recipient)
+	if trimmedRecipient == "" {
+		return nil, errors.New("imessage recipient is required")
+	}
+
+	trimmedService := strings.TrimSpace(service)
+	if trimmedService == "" {
+		trimmedService = defaultIMessageService
+	}
+
+	bot := &IMessageBot{
+		recipient:       trimmedRecipient,
+		defaultMessage:  strings.TrimSpace(defaultMessage),
+		service:         trimmedService,
+		ctx:             context.Background(),
+		pollingEnabled:  false,
+		pollingInterval: defaultIMessagePollingInterval,
+		pollingLimit:    defaultIMessagePollingLimit,
+		databasePath:    defaultIMessageDatabasePath,
+		sleepFn:         time.Sleep,
+	}
+
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	}
+	bot.readMessagesFn = bot.readMessagesFromSQLite
+	bot.checkPermissionsFn = bot.checkStartupPermissions
+	bot.isMessagesRunning = bot.defaultIsMessagesRunning
+	bot.startMessagesApp = bot.defaultStartMessagesApp
+
+	return bot, nil
+}
+
+func (b *IMessageBot) Name() string {
+	return "imessage"
+}
+
+func (b *IMessageBot) SetHandler(handler IncomingMessageHandler) {
+	b.handler = handler
+}
+
+// ConfigurePolling configures inbound iMessage polling behavior.
+func (b *IMessageBot) ConfigurePolling(enabled bool, intervalSeconds int, limit int, databasePath string) {
+	b.pollingEnabled = enabled
+
+	if intervalSeconds > 0 {
+		b.pollingInterval = time.Duration(intervalSeconds) * time.Second
+	} else {
+		b.pollingInterval = defaultIMessagePollingInterval
+	}
+	if b.pollingInterval < minIMessagePollingInterval {
+		b.pollingInterval = minIMessagePollingInterval
+	}
+
+	if limit > 0 {
+		b.pollingLimit = limit
+	} else {
+		b.pollingLimit = defaultIMessagePollingLimit
+	}
+	if b.pollingLimit > maxIMessagePollingLimit {
+		b.pollingLimit = maxIMessagePollingLimit
+	}
+
+	if trimmed := strings.TrimSpace(databasePath); trimmed != "" {
+		b.databasePath = trimmed
+	}
+}
+
+func (b *IMessageBot) IsRunning() bool {
+	b.runningMu.RLock()
+	defer b.runningMu.RUnlock()
+	return b.running
+}
+
+func (b *IMessageBot) setRunning(running bool) {
+	b.runningMu.Lock()
+	b.running = running
+	b.runningMu.Unlock()
+}
+
+// LastActivity reports the last successful send or inbound handling time.
+func (b *IMessageBot) LastActivity() time.Time {
+	b.telemetryMu.RLock()
+	defer b.telemetryMu.RUnlock()
+	return b.lastActivity
+}
+
+// LastError reports the last channel error time.
+func (b *IMessageBot) LastError() time.Time {
+	b.telemetryMu.RLock()
+	defer b.telemetryMu.RUnlock()
+	return b.lastError
+}
+
+func (b *IMessageBot) markActivity() {
+	b.telemetryMu.Lock()
+	b.lastActivity = time.Now().UTC()
+	b.telemetryMu.Unlock()
+}
+
+func (b *IMessageBot) markError() {
+	b.telemetryMu.Lock()
+	b.lastError = time.Now().UTC()
+	b.telemetryMu.Unlock()
+}
+
+func (b *IMessageBot) Start(ctx context.Context) error {
+	if currentGOOS != "darwin" {
+		return errors.New("imessage channel is only supported on darwin")
+	}
+
+	b.ctx, b.cancel = context.WithCancel(ctx)
+
+	if b.pollingEnabled {
+		if err := b.checkPermissionsFn(b.ctx); err != nil {
+			b.markError()
+			return err
+		}
+		if err := b.ensureMessagesRunning(b.ctx); err != nil {
+			b.markError()
+			return err
+		}
+
+		b.wg.Add(1)
+		go b.pollLoop(b.ctx)
+	}
+
+	b.setRunning(true)
+	return nil
+}
+
+func (b *IMessageBot) Stop() error {
+	if b.cancel != nil {
+		b.cancel()
+	}
+	b.wg.Wait()
+	b.setRunning(false)
+	return nil
+}
+
+func (b *IMessageBot) SendMessage(ctx context.Context, chatID int64, text string) error {
+	_ = chatID
+	message := strings.TrimSpace(text)
+	if message == "" {
+		message = b.defaultMessage
+	}
+	return b.send(ctx, b.recipient, message)
+}
+
+// Send sends a message to the configured recipient using osascript.
+func (b *IMessageBot) Send(text string) error {
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return b.send(ctx, b.recipient, text)
+}
+
+// PollMessages reads new inbound messages from Messages database.
+func (b *IMessageBot) PollMessages(ctx context.Context) ([]IMessageInbound, error) {
+	since := b.getLastSeenMessageID()
+	msgs, err := b.readMessagesFn(ctx, since, b.pollingLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	maxSeen := since
+	for _, msg := range msgs {
+		if msg.MessageID > maxSeen {
+			maxSeen = msg.MessageID
+		}
+	}
+	if maxSeen > since {
+		b.setLastSeenMessageID(maxSeen)
+	}
+
+	return msgs, nil
+}
+
+func (b *IMessageBot) pollLoop(ctx context.Context) {
+	defer b.wg.Done()
+
+	b.pollOnce(ctx)
+	ticker := time.NewTicker(b.pollingInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.pollOnce(ctx)
+		}
+	}
+}
+
+func (b *IMessageBot) pollOnce(ctx context.Context) {
+	if b.handler == nil {
+		return
+	}
+
+	msgs, err := b.PollMessages(ctx)
+	if err != nil {
+		b.markError()
+		log.Printf("imessage polling failed: %v", err)
+		return
+	}
+
+	for _, inbound := range msgs {
+		if strings.TrimSpace(inbound.Text) == "" {
+			continue
+		}
+		reply, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(inbound))
+		if err != nil {
+			b.markError()
+			log.Printf("imessage inbound handler failed: %v", err)
+			continue
+		}
+
+		b.markActivity()
+
+		trimmedReply := strings.TrimSpace(reply)
+		if trimmedReply != "" && strings.TrimSpace(inbound.Sender) != "" {
+			if err := b.send(ctx, inbound.Sender, trimmedReply); err != nil {
+				log.Printf("imessage reply send failed: %v", err)
+			}
+		}
+	}
+}
+
+func (b *IMessageBot) toProtocolMessage(inbound IMessageInbound) *protocol.Message {
+	return &protocol.Message{
+		Kind:   protocol.MessageKindChannel,
+		Action: protocol.ActionCreate,
+		Data: map[string]interface{}{
+			"channel":     "imessage",
+			"text":        inbound.Text,
+			"agent":       "",
+			"sender":      inbound.Sender,
+			"message_id":  inbound.MessageID,
+			"timestamp":   inbound.Timestamp.UTC().Format(time.RFC3339),
+			"chatType":    "dm",
+			"raw_message": inbound.RawTimestamp,
+		},
+	}
+}
+
+func (b *IMessageBot) readMessagesFromSQLite(ctx context.Context, sinceMessageID int64, limit int) ([]IMessageInbound, error) {
+	if b.execFn == nil {
+		return nil, errors.New("imessage executor not configured")
+	}
+	if limit <= 0 {
+		limit = defaultIMessagePollingLimit
+	}
+	if limit > maxIMessagePollingLimit {
+		limit = maxIMessagePollingLimit
+	}
+	if sinceMessageID < 0 {
+		sinceMessageID = 0
+	}
+
+	dbPath, err := expandHomePath(b.databasePath)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf(`SELECT
+    m.ROWID AS message_id,
+    COALESCE(h.id, '') AS sender,
+    COALESCE(m.text, '') AS text,
+    m.date AS date
+FROM message m
+LEFT JOIN handle h ON m.handle_id = h.ROWID
+WHERE m.is_from_me = 0
+  AND m.ROWID > %d
+ORDER BY m.ROWID ASC
+LIMIT %d;`, sinceMessageID, limit)
+
+	output, execErr := b.execFn(ctx, "sqlite3", "-json", dbPath, query)
+	if execErr != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return nil, fmt.Errorf("imessage sqlite polling failed: %w: %s", execErr, trimmedOutput)
+		}
+		return nil, fmt.Errorf("imessage sqlite polling failed: %w", execErr)
+	}
+
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" || trimmed == "[]" {
+		return nil, nil
+	}
+
+	var rows []iMessageSQLiteRow
+	if err := json.Unmarshal([]byte(trimmed), &rows); err != nil {
+		return nil, fmt.Errorf("parse sqlite messages: %w", err)
+	}
+
+	messages := make([]IMessageInbound, 0, len(rows))
+	for _, row := range rows {
+		text := strings.TrimSpace(row.Text)
+		if text == "" {
+			continue
+		}
+		rawTimestamp := int64(row.Date)
+		messages = append(messages, IMessageInbound{
+			MessageID:    row.MessageID,
+			Sender:       strings.TrimSpace(row.Sender),
+			Text:         text,
+			Timestamp:    appleTimestampToTime(rawTimestamp),
+			RawTimestamp: rawTimestamp,
+		})
+	}
+
+	return messages, nil
+}
+
+func (b *IMessageBot) checkStartupPermissions(ctx context.Context) error {
+	if b.execFn == nil {
+		return errors.New("imessage executor not configured")
+	}
+
+	dbPath, err := expandHomePath(b.databasePath)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(dbPath); err != nil {
+		return fmt.Errorf("imessage database not accessible (%s): %w", dbPath, err)
+	}
+
+	output, err := b.execFn(ctx, "sqlite3", dbPath, "SELECT 1;")
+	if err != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return fmt.Errorf("imessage database permission check failed: %w: %s", err, trimmedOutput)
+		}
+		return fmt.Errorf("imessage database permission check failed: %w", err)
+	}
+
+	// Verify AppleScript access to Messages application.
+	output, err = b.execFn(ctx, "osascript", "-e", `tell application "Messages" to get name`)
+	if err != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return fmt.Errorf("imessage app permission check failed: %w: %s", err, trimmedOutput)
+		}
+		return fmt.Errorf("imessage app permission check failed: %w", err)
+	}
+
+	return nil
+}
+
+func (b *IMessageBot) defaultIsMessagesRunning(ctx context.Context) (bool, error) {
+	if b.execFn == nil {
+		return false, errors.New("imessage executor not configured")
+	}
+	output, err := b.execFn(ctx, "osascript", "-e", `tell application "System Events" to (name of processes) contains "Messages"`)
+	if err != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return false, fmt.Errorf("check Messages process failed: %w: %s", err, trimmedOutput)
+		}
+		return false, fmt.Errorf("check Messages process failed: %w", err)
+	}
+	return strings.EqualFold(strings.TrimSpace(string(output)), "true"), nil
+}
+
+func (b *IMessageBot) defaultStartMessagesApp(ctx context.Context) error {
+	if b.execFn == nil {
+		return errors.New("imessage executor not configured")
+	}
+	if _, err := b.execFn(ctx, "open", "-a", "Messages"); err != nil {
+		return fmt.Errorf("start Messages app: %w", err)
+	}
+
+	for i := 0; i < defaultIMessageStartRetries; i++ {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+		running, err := b.isMessagesRunning(ctx)
+		if err == nil && running {
+			return nil
+		}
+		b.sleepFn(defaultIMessageStartCheckPeriod)
+	}
+
+	return errors.New("messages app did not start in time")
+}
+
+func (b *IMessageBot) ensureMessagesRunning(ctx context.Context) error {
+	running, err := b.isMessagesRunning(ctx)
+	if err != nil {
+		return err
+	}
+	if running {
+		return nil
+	}
+	log.Printf("imessage: Messages app not running, attempting to start")
+	return b.startMessagesApp(ctx)
+}
+
+func (b *IMessageBot) getLastSeenMessageID() int64 {
+	b.lastSeenMu.Lock()
+	defer b.lastSeenMu.Unlock()
+	return b.lastSeenMessageID
+}
+
+func (b *IMessageBot) setLastSeenMessageID(value int64) {
+	b.lastSeenMu.Lock()
+	b.lastSeenMessageID = value
+	b.lastSeenMu.Unlock()
+}
+
+func (b *IMessageBot) send(ctx context.Context, recipient, text string) error {
+	if currentGOOS != "darwin" {
+		return errors.New("imessage channel is only supported on darwin")
+	}
+
+	trimmedRecipient := strings.TrimSpace(recipient)
+	if trimmedRecipient == "" {
+		return errors.New("imessage recipient is required")
+	}
+
+	trimmedText := strings.TrimSpace(text)
+	if trimmedText == "" {
+		return errors.New("imessage text is required")
+	}
+
+	if b.execFn == nil {
+		return errors.New("imessage executor not configured")
+	}
+
+	script := buildIMessageScript(trimmedRecipient, trimmedText, b.service)
+	output, err := b.execFn(ctx, "osascript", "-e", script)
+	if err != nil {
+		b.markError()
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return fmt.Errorf("imessage osascript failed: %w: %s", err, trimmedOutput)
+		}
+		return fmt.Errorf("imessage osascript failed: %w", err)
+	}
+
+	b.markActivity()
+	return nil
+}
+
+func buildIMessageScript(recipient, text, service string) string {
+	return fmt.Sprintf(`tell application "Messages"
+	send "%s" to buddy "%s" of service "%s"
+end tell`, escapeAppleScriptString(text), escapeAppleScriptString(recipient), escapeAppleScriptString(service))
+}
+
+func escapeAppleScriptString(value string) string {
+	replacer := strings.NewReplacer(
+		`\\`, `\\\\`,
+		`"`, `\"`,
+		"\n", `\n`,
+		"\r", ``,
+	)
+	return replacer.Replace(value)
+}
+
+func expandHomePath(path string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", errors.New("imessage database path is required")
+	}
+	if trimmed == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(trimmed, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home dir: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(trimmed, "~/")), nil
+	}
+	return trimmed, nil
+}
+
+func appleTimestampToTime(raw int64) time.Time {
+	if raw == 0 {
+		return time.Time{}
+	}
+	base := time.Date(2001, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Apple Messages commonly stores nanoseconds since 2001-01-01.
+	if raw > 9_000_000_000_000 {
+		return base.Add(time.Duration(raw))
+	}
+	return base.Add(time.Duration(raw) * time.Second)
+}

--- a/internal/channels/imessage_test.go
+++ b/internal/channels/imessage_test.go
@@ -1,0 +1,268 @@
+package channels
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type fakeIMessageHandler struct {
+	reply string
+	err   error
+	calls int
+	msgs  []*protocol.Message
+}
+
+func (f *fakeIMessageHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	_ = ctx
+	f.calls++
+	f.msgs = append(f.msgs, msg)
+	return f.reply, f.err
+}
+
+func TestNewIMessageBotRejectsNonDarwin(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "linux"
+	defer func() { currentGOOS = originalGOOS }()
+
+	_, err := NewIMessageBot("recipient@example.com", "hello", "")
+	if err == nil {
+		t.Fatalf("expected non-darwin error")
+	}
+	if !strings.Contains(err.Error(), "darwin") {
+		t.Fatalf("expected darwin error, got %v", err)
+	}
+}
+
+func TestIMessageBotSendMessageUsesAppleScript(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "fallback", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	var called bool
+	var commandName string
+	var commandArgs []string
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		called = true
+		commandName = name
+		commandArgs = append([]string{}, args...)
+		return []byte("ok"), nil
+	}
+
+	if err := bot.SendMessage(context.Background(), 0, "hello from test"); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+
+	if !called {
+		t.Fatalf("expected osascript to be called")
+	}
+	if commandName != "osascript" {
+		t.Fatalf("command=%q want osascript", commandName)
+	}
+	if len(commandArgs) != 2 || commandArgs[0] != "-e" {
+		t.Fatalf("unexpected args: %v", commandArgs)
+	}
+	if !strings.Contains(commandArgs[1], `send "hello from test" to buddy "recipient@example.com" of service "E:iMessage"`) {
+		t.Fatalf("unexpected script: %s", commandArgs[1])
+	}
+	if bot.LastActivity().IsZero() {
+		t.Fatalf("expected last activity to be set")
+	}
+}
+
+func TestIMessageBotSendMessageFallsBackToConfiguredMessage(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "configured default", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	var script string
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		_ = name
+		if len(args) == 2 {
+			script = args[1]
+		}
+		return nil, nil
+	}
+
+	if err := bot.SendMessage(context.Background(), 0, ""); err != nil {
+		t.Fatalf("SendMessage: %v", err)
+	}
+	if !strings.Contains(script, `send "configured default"`) {
+		t.Fatalf("expected configured default message in script, got: %s", script)
+	}
+}
+
+func TestIMessageBotPollMessagesFromSQLite(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.ConfigurePolling(true, 5, 10, "/tmp/chat.db")
+
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != "sqlite3" {
+			t.Fatalf("command=%q want sqlite3", name)
+		}
+		if len(args) < 3 {
+			t.Fatalf("unexpected sqlite args: %v", args)
+		}
+		if !strings.Contains(args[2], "FROM message") {
+			t.Fatalf("unexpected query: %s", args[2])
+		}
+		return []byte(`[{"message_id":11,"sender":"+123","text":"hello","date":785000000000000000}]`), nil
+	}
+
+	msgs, err := bot.PollMessages(context.Background())
+	if err != nil {
+		t.Fatalf("PollMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs)=%d want 1", len(msgs))
+	}
+	if msgs[0].MessageID != 11 || msgs[0].Sender != "+123" || msgs[0].Text != "hello" {
+		t.Fatalf("unexpected message: %+v", msgs[0])
+	}
+	if bot.getLastSeenMessageID() != 11 {
+		t.Fatalf("lastSeenMessageID=%d want 11", bot.getLastSeenMessageID())
+	}
+}
+
+func TestIMessageBotPollOnceRoutesInboundAndReplies(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	handler := &fakeIMessageHandler{reply: "ack"}
+	bot.SetHandler(handler)
+
+	bot.readMessagesFn = func(ctx context.Context, sinceMessageID int64, limit int) ([]IMessageInbound, error) {
+		_ = ctx
+		_ = sinceMessageID
+		_ = limit
+		return []IMessageInbound{
+			{
+				MessageID: 1,
+				Sender:    "+123",
+				Text:      "ping",
+				Timestamp: time.Now().UTC(),
+			},
+		}, nil
+	}
+
+	var replySent bool
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name == "osascript" && len(args) == 2 && strings.Contains(args[1], `send "ack" to buddy "+123"`) {
+			replySent = true
+		}
+		return nil, nil
+	}
+
+	bot.pollOnce(context.Background())
+
+	if handler.calls != 1 {
+		t.Fatalf("handler calls=%d want 1", handler.calls)
+	}
+	if !replySent {
+		t.Fatalf("expected reply to be sent to inbound sender")
+	}
+	if bot.LastActivity().IsZero() {
+		t.Fatalf("expected last activity to be set")
+	}
+}
+
+func TestIMessageBotStartChecksPermissionsAndStartsMessages(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.ConfigurePolling(true, 60, 10, "/tmp/chat.db")
+
+	var permissionChecked bool
+	bot.checkPermissionsFn = func(ctx context.Context) error {
+		_ = ctx
+		permissionChecked = true
+		return nil
+	}
+
+	running := false
+	bot.isMessagesRunning = func(ctx context.Context) (bool, error) {
+		_ = ctx
+		return running, nil
+	}
+
+	var startCalled bool
+	bot.startMessagesApp = func(ctx context.Context) error {
+		_ = ctx
+		startCalled = true
+		running = true
+		return nil
+	}
+
+	if err := bot.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !permissionChecked {
+		t.Fatalf("expected permission check")
+	}
+	if !startCalled {
+		t.Fatalf("expected Messages app start")
+	}
+	if err := bot.Stop(); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+}
+
+func TestIMessageBotStartFailsPermissionCheck(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.ConfigurePolling(true, 60, 10, "/tmp/chat.db")
+	bot.checkPermissionsFn = func(ctx context.Context) error {
+		_ = ctx
+		return errors.New("permission denied")
+	}
+
+	err = bot.Start(context.Background())
+	if err == nil {
+		t.Fatalf("expected start error")
+	}
+	if !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -320,6 +320,34 @@ func (m *Manager) registerConfiguredChannels() error {
 		}
 	}
 
+	if m.cfg.IMessage != nil && m.cfg.IMessage.Enabled {
+		if m.Get("imessage") != nil {
+			return nil
+		}
+		if strings.TrimSpace(m.cfg.IMessage.Recipient) == "" {
+			return errors.New("channels.imessage.recipient is required when imessage is enabled")
+		}
+
+		bot, err := NewIMessageBot(
+			m.cfg.IMessage.Recipient,
+			m.cfg.IMessage.Message,
+			m.cfg.IMessage.Service,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to init imessage bot: %w", err)
+		}
+		bot.ConfigurePolling(
+			m.cfg.IMessage.PollingEnabled,
+			m.cfg.IMessage.PollingIntervalSeconds,
+			m.cfg.IMessage.PollingLimit,
+			m.cfg.IMessage.DatabasePath,
+		)
+
+		if err := m.Register(bot); err != nil {
+			return fmt.Errorf("failed to register imessage bot: %w", err)
+		}
+	}
+
 	return nil
 }
 

--- a/internal/channels/manager_imessage_test.go
+++ b/internal/channels/manager_imessage_test.go
@@ -1,0 +1,55 @@
+package channels
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+func TestManagerRegistersIMessageChannel(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	manager := NewManager(&config.ChannelsConfig{
+		IMessage: &config.IMessageConfig{
+			Enabled:   true,
+			Recipient: "recipient@example.com",
+			Message:   "hello",
+		},
+	}, nil)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = manager.Stop() }()
+
+	waitForCondition(t, time.Second, func() bool {
+		channel := manager.Get("imessage")
+		return channel != nil && channel.IsRunning()
+	})
+}
+
+func TestManagerRejectsIMessageOnNonDarwin(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "linux"
+	defer func() { currentGOOS = originalGOOS }()
+
+	manager := NewManager(&config.ChannelsConfig{
+		IMessage: &config.IMessageConfig{
+			Enabled:   true,
+			Recipient: "recipient@example.com",
+		},
+	}, nil)
+
+	err := manager.Start(context.Background())
+	if err == nil {
+		t.Fatalf("expected non-darwin start error")
+	}
+	if !strings.Contains(err.Error(), "darwin") {
+		t.Fatalf("expected darwin error, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type ChannelsConfig struct {
 	Feishu   *FeishuConfig   `yaml:"feishu,omitempty"`
 	Slack    *SlackConfig    `yaml:"slack,omitempty"`
 	Discord  *DiscordConfig  `yaml:"discord,omitempty"`
+	IMessage *IMessageConfig `yaml:"imessage,omitempty"`
 }
 
 // TelegramConfig contains Telegram channel settings.
@@ -98,6 +99,25 @@ type DiscordConfig struct {
 	Enabled      bool     `yaml:"enabled,omitempty"`
 	Token        string   `yaml:"token,omitempty"`
 	AllowedUsers []string `yaml:"allowedUsers,omitempty"`
+}
+
+// IMessageConfig contains iMessage channel settings.
+type IMessageConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+	// Recipient is the default iMessage target (email/phone/Apple ID handle).
+	Recipient string `yaml:"recipient,omitempty"`
+	// Message is the fallback text used when API/CLI send text is empty.
+	Message string `yaml:"message,omitempty"`
+	// Service defaults to "E:iMessage" when empty.
+	Service string `yaml:"service,omitempty"`
+	// PollingEnabled controls whether inbound iMessage polling is enabled.
+	PollingEnabled bool `yaml:"pollingEnabled,omitempty"`
+	// PollingIntervalSeconds sets polling interval. Default: 5.
+	PollingIntervalSeconds int `yaml:"pollingIntervalSeconds,omitempty"`
+	// PollingLimit caps number of messages fetched per poll. Default: 20.
+	PollingLimit int `yaml:"pollingLimit,omitempty"`
+	// DatabasePath overrides Messages DB path. Default: ~/Library/Messages/chat.db.
+	DatabasePath string `yaml:"databasePath,omitempty"`
 }
 
 // OhMyCodeConfig contains integration settings for the oh-my-code workspace.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -229,3 +229,37 @@ func TestLoadConfigAcceptsOhMyCodeAbsoluteWorkspaceWithRelativeScript(t *testing
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestLoadConfigAcceptsIMessagePollingConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`channels:
+  imessage:
+    enabled: true
+    recipient: "recipient@example.com"
+    service: "E:iMessage"
+    pollingEnabled: true
+    pollingIntervalSeconds: 10
+    pollingLimit: 25
+    databasePath: "~/Library/Messages/chat.db"
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Channels == nil || cfg.Channels.IMessage == nil {
+		t.Fatalf("expected channels.imessage config")
+	}
+	if !cfg.Channels.IMessage.PollingEnabled {
+		t.Fatalf("expected pollingEnabled=true")
+	}
+	if cfg.Channels.IMessage.PollingIntervalSeconds != 10 {
+		t.Fatalf("pollingIntervalSeconds=%d want 10", cfg.Channels.IMessage.PollingIntervalSeconds)
+	}
+	if cfg.Channels.IMessage.PollingLimit != 25 {
+		t.Fatalf("pollingLimit=%d want 25", cfg.Channels.IMessage.PollingLimit)
+	}
+}


### PR DESCRIPTION
## Summary
Implements KR2 groundwork for iMessage inbound handling:
- polling recent inbound messages from `~/Library/Messages/chat.db`
- parsing sender/content/timestamp
- routing inbound messages to the FractalBot channel handler
- startup checks for Messages access + app-running handling

Related: #287

## What changed
- Added iMessage inbound polling and routing in `internal/channels/imessage.go`:
  - `PollMessages()` using `sqlite3` against Messages DB
  - inbound parsing to `{message_id, sender, text, timestamp}`
  - protocol routing via `HandleIncoming(...)`
  - optional auto-reply to sender when handler returns response text
  - startup permission checks (DB + Messages app AppleScript check)
  - app-not-running handling (attempt `open -a Messages`)
  - polling rate controls (interval/limit)
- Added iMessage polling config fields:
  - `channels.imessage.pollingEnabled`
  - `channels.imessage.pollingIntervalSeconds`
  - `channels.imessage.pollingLimit`
  - `channels.imessage.databasePath`
- Wired config into channel manager (`ConfigurePolling(...)`).
- Added/updated tests:
  - `internal/channels/imessage_test.go`
  - `internal/channels/manager_imessage_test.go`
  - `internal/config/config_test.go`

## Validation
```bash
go test ./internal/channels ./internal/config ./cmd/fractalbot
```

Passed:
- `ok github.com/fractalmind-ai/fractalbot/internal/channels`
- `ok github.com/fractalmind-ai/fractalbot/internal/config`
- `ok github.com/fractalmind-ai/fractalbot/cmd/fractalbot`

## Notes
- Polling is configurable and disabled by default; enable with `channels.imessage.pollingEnabled: true`.
- Live end-to-end behavior still depends on local macOS privacy permissions (Messages + Full Disk Access for `chat.db`).
