### PR TITLE
feat: change SendMessage target from int64 to string

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -171,12 +171,6 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 		return 1
 	}
 
-	chatID, err := strconv.ParseInt(toValue, 10, 64)
-	if err != nil {
-		logger.Printf("invalid --to chat_id: %s", toValue)
-		return 1
-	}
-
 	messageText := strings.TrimSpace(*text)
 	if messageText == "" {
 		logger.Printf("--text is required")
@@ -189,19 +183,19 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 		return 1
 	}
 
-	if err := messageSendFn(ctx, cfg, channelName, chatID, messageText); err != nil {
+	if err := messageSendFn(ctx, cfg, channelName, toValue, messageText); err != nil {
 		logger.Printf("failed to send message: %v", err)
 		return 1
 	}
 
-	fmt.Fprintf(out, "✅ Message sent via %s to %d\n", channelName, chatID)
+	fmt.Fprintf(out, "✅ Message sent via %s to %s\n", channelName, toValue)
 	return 0
 }
 
-func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
 	type requestPayload struct {
 		Channel string `json:"channel"`
-		To      int64  `json:"to"`
+		To      string `json:"to"`
 		Text    string `json:"text"`
 	}
 

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -55,15 +55,15 @@ func TestRunMessageSend(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		called := false
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
 			_ = ctx
 			_ = cfg
 			called = true
 			if channel != "telegram" {
 				t.Fatalf("channel=%q", channel)
 			}
-			if to != 5088760910 {
-				t.Fatalf("to=%d", to)
+			if to != "5088760910" {
+				t.Fatalf("to=%s", to)
 			}
 			if text != "hello from cli" {
 				t.Fatalf("text=%q", text)
@@ -103,11 +103,6 @@ func TestRunMessageSend(t *testing.T) {
 				expectedError: "--to is required",
 			},
 			{
-				name:          "invalid to",
-				args:          []string{"--channel", "telegram", "--to", "not-number", "--text", "hello"},
-				expectedError: "invalid --to chat_id",
-			},
-			{
 				name:          "missing text",
 				args:          []string{"--channel", "telegram", "--to", "5088760910"},
 				expectedError: "--text is required",
@@ -116,7 +111,7 @@ func TestRunMessageSend(t *testing.T) {
 
 		for _, testCase := range cases {
 			t.Run(testCase.name, func(t *testing.T) {
-				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
 					_ = ctx
 					_ = cfg
 					_ = channel
@@ -140,7 +135,7 @@ func TestRunMessageSend(t *testing.T) {
 	})
 
 	t.Run("unknown subcommand", func(t *testing.T) {
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
 			_ = ctx
 			_ = cfg
 			_ = channel
@@ -164,7 +159,7 @@ func TestRunMessageSend(t *testing.T) {
 	})
 
 	t.Run("send failure", func(t *testing.T) {
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to int64, text string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
 			_ = ctx
 			_ = cfg
 			_ = channel

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -10,7 +10,7 @@ type Channel interface {
 	Name() string
 	Start(ctx context.Context) error
 	Stop() error
-	SendMessage(ctx context.Context, chatID int64, text string) error
+	SendMessage(ctx context.Context, target string, text string) error
 	IsRunning() bool
 }
 

--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -136,11 +136,19 @@ func (b *DiscordBot) Stop() error {
 	return nil
 }
 
-func (b *DiscordBot) SendMessage(ctx context.Context, chatID int64, text string) error {
-	_ = ctx
-	_ = chatID
-	_ = text
-	return errors.New("discord SendMessage requires a string channel ID")
+func (b *DiscordBot) SendMessage(ctx context.Context, target string, text string) error {
+	if b.sendMessageFn == nil {
+		return errors.New("discord sender not configured")
+	}
+	if strings.TrimSpace(target) == "" {
+		return errors.New("discord channel ID is required")
+	}
+	if err := b.sendMessageFn(ctx, target, text); err != nil {
+		b.markError()
+		return err
+	}
+	b.markActivity()
+	return nil
 }
 
 func (b *DiscordBot) initClients() error {

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -155,11 +155,19 @@ func (b *FeishuBot) Stop() error {
 	return nil
 }
 
-func (b *FeishuBot) SendMessage(ctx context.Context, chatID int64, text string) error {
-	_ = ctx
-	_ = chatID
-	_ = text
-	return errors.New("feishu SendMessage requires a string receive_id")
+func (b *FeishuBot) SendMessage(ctx context.Context, target string, text string) error {
+	if b.sendMessageFn == nil {
+		return errors.New("feishu sender not configured")
+	}
+	if strings.TrimSpace(target) == "" {
+		return errors.New("feishu receive_id is required")
+	}
+	if err := b.sendMessageFn(ctx, "open_id", target, text); err != nil {
+		b.markError()
+		return err
+	}
+	b.markActivity()
+	return nil
 }
 
 func (b *FeishuBot) initClients() {

--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -226,13 +226,16 @@ func (b *IMessageBot) Stop() error {
 	return nil
 }
 
-func (b *IMessageBot) SendMessage(ctx context.Context, chatID int64, text string) error {
-	_ = chatID
+func (b *IMessageBot) SendMessage(ctx context.Context, target string, text string) error {
+	recipient := strings.TrimSpace(target)
+	if recipient == "" {
+		recipient = b.recipient
+	}
 	message := strings.TrimSpace(text)
 	if message == "" {
 		message = b.defaultMessage
 	}
-	return b.send(ctx, b.recipient, message)
+	return b.send(ctx, recipient, message)
 }
 
 // Send sends a message to the configured recipient using osascript.

--- a/internal/channels/imessage_test.go
+++ b/internal/channels/imessage_test.go
@@ -59,7 +59,7 @@ func TestIMessageBotSendMessageUsesAppleScript(t *testing.T) {
 		return []byte("ok"), nil
 	}
 
-	if err := bot.SendMessage(context.Background(), 0, "hello from test"); err != nil {
+	if err := bot.SendMessage(context.Background(), "", "hello from test"); err != nil {
 		t.Fatalf("SendMessage: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func TestIMessageBotSendMessageFallsBackToConfiguredMessage(t *testing.T) {
 		return nil, nil
 	}
 
-	if err := bot.SendMessage(context.Background(), 0, ""); err != nil {
+	if err := bot.SendMessage(context.Background(), "", ""); err != nil {
 		t.Fatalf("SendMessage: %v", err)
 	}
 	if !strings.Contains(script, `send "configured default"`) {

--- a/internal/channels/manager_test.go
+++ b/internal/channels/manager_test.go
@@ -14,7 +14,7 @@ type fakeChannel struct {
 	running  bool
 	startErr error
 	stopErr  error
-	lastChat int64
+	lastChat string
 	lastText string
 }
 
@@ -36,9 +36,9 @@ func (f *fakeChannel) Stop() error {
 	return f.stopErr
 }
 
-func (f *fakeChannel) SendMessage(ctx context.Context, chatID int64, text string) error {
+func (f *fakeChannel) SendMessage(ctx context.Context, target string, text string) error {
 	_ = ctx
-	f.lastChat = chatID
+	f.lastChat = target
 	f.lastText = text
 	return nil
 }
@@ -166,9 +166,9 @@ func (b *blockingStartChannel) Start(ctx context.Context) error {
 
 func (b *blockingStartChannel) Stop() error { return nil }
 
-func (b *blockingStartChannel) SendMessage(ctx context.Context, chatID int64, text string) error {
+func (b *blockingStartChannel) SendMessage(ctx context.Context, target string, text string) error {
 	_ = ctx
-	_ = chatID
+	_ = target
 	_ = text
 	return nil
 }

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -150,11 +150,19 @@ func (b *SlackBot) Stop() error {
 	return nil
 }
 
-func (b *SlackBot) SendMessage(ctx context.Context, chatID int64, text string) error {
-	_ = ctx
-	_ = chatID
-	_ = text
-	return errors.New("slack SendMessage requires a string channel ID")
+func (b *SlackBot) SendMessage(ctx context.Context, target string, text string) error {
+	if b.sendMessageFn == nil {
+		return errors.New("slack sender not configured")
+	}
+	if strings.TrimSpace(target) == "" {
+		return errors.New("slack channel ID is required")
+	}
+	if err := b.sendMessageFn(ctx, target, text); err != nil {
+		b.markError()
+		return err
+	}
+	b.markActivity()
+	return nil
 }
 
 func (b *SlackBot) initClients() {
@@ -275,7 +283,7 @@ func (b *SlackBot) handleSocketEventWithAck(ctx context.Context, event socketmod
 		b.handleSlashCommandEventWithAck(ctx, event, ackFn)
 		return
 	}
-	if event.Request != nil && ackFn != nil {
+	if event.Request != nil && ackFn != nil && event.Request.EnvelopeID != "" {
 		ackFn(*event.Request)
 	}
 
@@ -462,6 +470,7 @@ func (b *SlackBot) handleMessageEvent(ctx context.Context, msg *slackInboundMess
 		_ = b.reply(ctx, msg, fmt.Sprintf("❌ Unauthorized. Ask an admin to add your Slack user ID to channels.slack.allowedUsers.\nUser ID: %s", msg.userID))
 		return
 	}
+	log.Printf("slack: authorized user=%s, routing message", msg.userID)
 
 	if handled, cmdErr := b.handleCommand(ctx, msg); handled {
 		if cmdErr != nil {
@@ -858,6 +867,9 @@ func slackMessageFromEvent(event *slackevents.MessageEvent) *slackInboundMessage
 		return nil
 	}
 	if event.SubType != "" {
+		return nil
+	}
+	if event.BotID != "" {
 		return nil
 	}
 	if strings.TrimSpace(event.User) == "" || strings.TrimSpace(event.Channel) == "" {

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -642,7 +642,7 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 		log.Printf("🚫 Unauthorized Telegram user: %d", message.From.ID)
 		if isTelegramWhoamiCommand(message.Text) {
 			reply := formatTelegramWhoamiReply(message, b.adminID)
-			_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
+			_ = b.sendToChat(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
 			return
 		}
 		username := strings.TrimSpace(message.From.UserName)
@@ -656,7 +656,7 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 			message.From.ID,
 			username,
 		)
-		_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(hint))
+		_ = b.sendToChat(b.ctx, message.Chat.ID, TruncateTelegramReply(hint))
 		return
 	}
 
@@ -668,7 +668,7 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 			} else if isAgentAllowlistError(cmdErr) {
 				reply = fmt.Sprintf("%s\nTip: use /agents to see allowed agents.", reply)
 			}
-			_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
+			_ = b.sendToChat(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
 		}
 		return
 	}
@@ -681,7 +681,7 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 		} else if isAgentAllowlistError(err) {
 			reply = fmt.Sprintf("%s\nTip: use /agents to see allowed agents.", reply)
 		}
-		_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
+		_ = b.sendToChat(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
 		return
 	}
 
@@ -701,7 +701,7 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 			} else if isAgentAllowlistError(err) {
 				reply = fmt.Sprintf("%s\nTip: use /agents to see allowed agents.", reply)
 			}
-			_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
+			_ = b.sendToChat(b.ctx, message.Chat.ID, TruncateTelegramReply(reply))
 			return
 		}
 	}
@@ -715,14 +715,14 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 			replyText = "❌ Something went wrong. Please try again."
 		}
 		if strings.TrimSpace(replyText) != "" {
-			_ = b.SendMessage(b.ctx, message.Chat.ID, TruncateTelegramReply(replyText))
+			_ = b.sendToChat(b.ctx, message.Chat.ID, TruncateTelegramReply(replyText))
 		}
 		return
 	}
 
 	if selection.Task != "" {
 		reply := fmt.Sprintf("echo: %s", selection.Task)
-		_ = b.SendMessage(b.ctx, message.Chat.ID, reply)
+		_ = b.sendToChat(b.ctx, message.Chat.ID, reply)
 	}
 }
 
@@ -761,14 +761,14 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 
 	switch command {
 	case "/help", "/start":
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, b.helpText())
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, b.helpText())
 
 	case "/ping":
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, "pong")
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, "pong")
 
 	case "/whoami":
 		reply := formatTelegramWhoamiReply(msg, b.adminID)
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, TruncateTelegramReply(reply))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, TruncateTelegramReply(reply))
 
 	case "/agents":
 		names := b.agentAllowlist.Names()
@@ -777,7 +777,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 			names = filterOutAgentName(names, defaultName)
 		}
 		if len(names) == 0 && defaultName == "" {
-			return true, b.SendMessage(b.ctx, msg.Chat.ID, noAgentsConfiguredMessage)
+			return true, b.sendToChat(b.ctx, msg.Chat.ID, noAgentsConfiguredMessage)
 		}
 		var sb strings.Builder
 		sb.WriteString("Allowed agents:\n")
@@ -787,7 +787,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		for _, name := range names {
 			sb.WriteString(fmt.Sprintf("  - %s\n", name))
 		}
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, strings.TrimSpace(sb.String()))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, strings.TrimSpace(sb.String()))
 
 	case "/monitor":
 		agentName, lines, err := parseMonitorArgs(parts)
@@ -808,7 +808,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		if strings.TrimSpace(out) == "" {
 			out = "No output from agent-monitor."
 		}
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
 
 	case "/startagent":
 		if err := requireAdmin(); err != nil {
@@ -832,7 +832,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		if strings.TrimSpace(out) == "" {
 			out = fmt.Sprintf("✅ Started agent %s", agentName)
 		}
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
 
 	case "/stopagent":
 		if err := requireAdmin(); err != nil {
@@ -856,7 +856,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		if strings.TrimSpace(out) == "" {
 			out = fmt.Sprintf("✅ Stopped agent %s", agentName)
 		}
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
 
 	case "/doctor":
 		if err := requireAdmin(); err != nil {
@@ -873,7 +873,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		if strings.TrimSpace(out) == "" {
 			out = "✅ agent-manager doctor completed"
 		}
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, TruncateTelegramReply(out))
 
 	case "/adduser":
 		if err := requireAdmin(); err != nil {
@@ -887,7 +887,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 			return true, fmt.Errorf("invalid user id")
 		}
 		b.userManager.AddUser(userID)
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, fmt.Sprintf("✅ Added user %d", userID))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, fmt.Sprintf("✅ Added user %d", userID))
 
 	case "/removeuser":
 		if err := requireAdmin(); err != nil {
@@ -901,7 +901,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 			return true, fmt.Errorf("invalid user id")
 		}
 		b.userManager.RemoveUser(userID)
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, fmt.Sprintf("✅ Removed user %d", userID))
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, fmt.Sprintf("✅ Removed user %d", userID))
 
 	case "/listusers":
 		if err := requireAdmin(); err != nil {
@@ -909,7 +909,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 		}
 		users := b.userManager.GetAllowedUsers()
 		response := fmt.Sprintf("✅ Authorized users:\n%s", formatUserList(users))
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, response)
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, response)
 
 	case "/status":
 		uptime := time.Since(b.startTime).Truncate(time.Second)
@@ -925,7 +925,7 @@ func (b *TelegramBot) handleCommand(msg *TelegramMessage) (bool, error) {
 			b.pollingOffsetFile,
 			uptime,
 		)
-		return true, b.SendMessage(b.ctx, msg.Chat.ID, status)
+		return true, b.sendToChat(b.ctx, msg.Chat.ID, status)
 
 	default:
 		return true, fmt.Errorf("unknown command: %s", command)
@@ -1151,7 +1151,16 @@ func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent
 }
 
 // SendMessage sends a message to Telegram.
-func (b *TelegramBot) SendMessage(ctx context.Context, chatID int64, text string) error {
+func (b *TelegramBot) SendMessage(ctx context.Context, target string, text string) error {
+	chatID, err := strconv.ParseInt(strings.TrimSpace(target), 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid telegram chat ID %q: %w", target, err)
+	}
+	return b.sendToChat(ctx, chatID, text)
+}
+
+// sendToChat is the internal implementation for sending a Telegram message.
+func (b *TelegramBot) sendToChat(ctx context.Context, chatID int64, text string) error {
 	apiURL := fmt.Sprintf("https://api.telegram.org/bot%s/sendMessage", b.botToken)
 
 	payload := map[string]interface{}{

--- a/internal/channels/telegram_telemetry_test.go
+++ b/internal/channels/telegram_telemetry_test.go
@@ -33,7 +33,7 @@ func TestTelegramTelemetry(t *testing.T) {
 			return nil, errors.New("send failed")
 		}),
 	}
-	if err := bot.SendMessage(context.Background(), 1, "hi"); err == nil {
+	if err := bot.SendMessage(context.Background(), "1", "hi"); err == nil {
 		t.Fatalf("expected send error")
 	}
 	if bot.LastError().IsZero() {

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -250,14 +250,14 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 
 type messageSendRequest struct {
 	Channel string `json:"channel"`
-	To      int64  `json:"to"`
+	To      string `json:"to"`
 	Text    string `json:"text"`
 }
 
 type messageSendResponse struct {
 	Status  string `json:"status"`
 	Channel string `json:"channel,omitempty"`
-	To      int64  `json:"to,omitempty"`
+	To      string `json:"to,omitempty"`
 	Error   string `json:"error,omitempty"`
 }
 
@@ -283,7 +283,7 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "channel is required"})
 		return
 	}
-	if request.To == 0 {
+	if request.To == "" {
 		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "to is required"})
 		return
 	}

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -281,9 +281,9 @@ func (f *fakeTelemetryChannel) Stop() error {
 	return nil
 }
 
-func (f *fakeTelemetryChannel) SendMessage(ctx context.Context, chatID int64, text string) error {
+func (f *fakeTelemetryChannel) SendMessage(ctx context.Context, target string, text string) error {
 	_ = ctx
-	_ = chatID
+	_ = target
 	_ = text
 	return nil
 }
@@ -400,7 +400,7 @@ func TestStatusDoesNotExposeSecrets(t *testing.T) {
 type fakeSendChannel struct {
 	name     string
 	running  bool
-	lastChat int64
+	lastChat string
 	lastText string
 	sendErr  error
 }
@@ -418,9 +418,9 @@ func (f *fakeSendChannel) Stop() error {
 	return nil
 }
 
-func (f *fakeSendChannel) SendMessage(ctx context.Context, chatID int64, text string) error {
+func (f *fakeSendChannel) SendMessage(ctx context.Context, target string, text string) error {
 	_ = ctx
-	f.lastChat = chatID
+	f.lastChat = target
 	f.lastText = text
 	return f.sendErr
 }
@@ -453,7 +453,7 @@ func TestMessageSendAPI(t *testing.T) {
 		resp, err := http.Post(
 			ts.URL+"/api/v1/message/send",
 			"application/json",
-			strings.NewReader(`{"channel":"telegram","to":12345,"text":"hello from api"}`),
+			strings.NewReader(`{"channel":"telegram","to":"12345","text":"hello from api"}`),
 		)
 		if err != nil {
 			t.Fatalf("post failed: %v", err)
@@ -465,8 +465,8 @@ func TestMessageSendAPI(t *testing.T) {
 			t.Fatalf("unexpected status %d body=%s", resp.StatusCode, string(body))
 		}
 
-		if fake.lastChat != 12345 {
-			t.Fatalf("expected lastChat=12345 got %d", fake.lastChat)
+		if fake.lastChat != "12345" {
+			t.Fatalf("expected lastChat=12345 got %s", fake.lastChat)
 		}
 		if fake.lastText != "hello from api" {
 			t.Fatalf("expected text captured, got %q", fake.lastText)
@@ -476,7 +476,7 @@ func TestMessageSendAPI(t *testing.T) {
 		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
 			t.Fatalf("decode response: %v", err)
 		}
-		if payload.Status != "ok" || payload.Channel != "telegram" || payload.To != 12345 {
+		if payload.Status != "ok" || payload.Channel != "telegram" || payload.To != "12345" {
 			t.Fatalf("unexpected response payload: %#v", payload)
 		}
 	})
@@ -485,7 +485,7 @@ func TestMessageSendAPI(t *testing.T) {
 		resp, err := http.Post(
 			ts.URL+"/api/v1/message/send",
 			"application/json",
-			strings.NewReader(`{"channel":"telegram","to":0,"text":""}`),
+			strings.NewReader(`{"channel":"telegram","to":"","text":""}`),
 		)
 		if err != nil {
 			t.Fatalf("post failed: %v", err)
@@ -502,7 +502,7 @@ func TestMessageSendAPI(t *testing.T) {
 		resp, err := http.Post(
 			ts.URL+"/api/v1/message/send",
 			"application/json",
-			strings.NewReader(`{"channel":"slack","to":1,"text":"hello"}`),
+			strings.NewReader(`{"channel":"slack","to":"1","text":"hello"}`),
 		)
 		if err != nil {
 			t.Fatalf("post failed: %v", err)


### PR DESCRIPTION
## Summary

- Change `Channel.SendMessage` signature from `int64 chatID` to `string target` to support Slack/Discord/Feishu string-based IDs
- Refactor Telegram internals: extract `sendToChat(int64)` private helper while public `SendMessage` parses string→int64
- Implement working `SendMessage` for Slack (via `sendText`), Discord, Feishu, and iMessage channels
- Update Gateway API and CLI to use string `To` field, removing `strconv.ParseInt` restriction
- Fix Slack empty EnvelopeID ack crash and bot self-message loop

## Motivation

Slack uses string user/channel IDs (e.g. `U08C93FU222`, `D0ACSGK4JE8`), Discord uses snowflake strings, and Feishu uses `open_id` strings. The previous `int64` interface made it impossible to send messages via these channels from either the CLI or HTTP API.

## Changes

| File | Change |
|------|--------|
| `internal/channels/channel.go` | Interface: `SendMessage(ctx, target string, text)` |
| `internal/channels/telegram.go` | Extract `sendToChat(int64)`, update ~20 internal call sites |
| `internal/channels/slack.go` | Working `SendMessage` + empty envelope & self-message fixes |
| `internal/channels/discord.go` | Working `SendMessage` via `sendMessageFn` |
| `internal/channels/feishu.go` | Working `SendMessage` with `open_id` default |
| `internal/channels/imessage.go` | Updated signature, target as recipient override |
| `internal/gateway/server.go` | `To` field: `int64` → `string` |
| `cmd/fractalbot/main.go` | Remove `ParseInt`, string throughout |
| 5 test files | Updated signatures, assertions, JSON payloads |

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] CLI: `./fractalbot message send --channel slack --to U08C93FU222 --text "test"` → success
- [x] HTTP API: `POST /api/v1/message/send {"channel":"slack","to":"U08C93FU222","text":"test"}` → `{"status":"ok"}`
- [x] Telegram backward compat: `--to "5088760910"` still works
- [x] End-to-end: Slack DM → fractalbot → agent-manager → main session → reply via API