### PR TITLE
feat(slack): auto-fetch last 5 messages as conversation context

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -441,6 +441,30 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 	sb.WriteString("  - use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)\n")
 	sb.WriteString("- If channel=telegram and recipient is omitted, default to current chat_id.\n")
 	sb.WriteString("\n")
+
+	// Insert recent conversation context if available.
+	recentMessages := extractRecentMessages(inboundData)
+	if len(recentMessages) > 0 {
+		wrapTag := trustLevel != "full" && trustLevel != ""
+		if wrapTag {
+			sb.WriteString("<conversation_context>\n")
+		}
+		sb.WriteString("Recent conversation in this channel (last 5 messages, oldest first):\n")
+		for _, msg := range recentMessages {
+			user, _ := msg["user"].(string)
+			text, _ := msg["text"].(string)
+			if user == "" {
+				user = "(unknown)"
+			}
+			sb.WriteString(fmt.Sprintf("[%s] %s\n", user, text))
+		}
+		sb.WriteString("\nNote: Only the 5 most recent messages are shown. To fetch more conversation history, use the `use-fractalbot` skill.\n")
+		if wrapTag {
+			sb.WriteString("</conversation_context>\n")
+		}
+		sb.WriteString("\n")
+	}
+
 	sb.WriteString("User message:\n")
 	if trustLevel == "full" || trustLevel == "" {
 		sb.WriteString(strings.TrimSpace(userText))
@@ -466,6 +490,21 @@ func promptContextValue(inboundData map[string]interface{}, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func extractRecentMessages(inboundData map[string]interface{}) []map[string]interface{} {
+	if len(inboundData) == 0 {
+		return nil
+	}
+	raw, ok := inboundData["recent_messages"]
+	if !ok {
+		return nil
+	}
+	msgs, ok := raw.([]map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return msgs
 }
 
 func defaultPromptContextValue(value string) string {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -427,3 +427,86 @@ sys.exit(1)
 		}
 	}
 }
+
+func TestBuildPromptWithRecentMessages(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("hello", "main", map[string]interface{}{
+		"channel":     "slack",
+		"chat_id":     "C123",
+		"user_id":     "U123",
+		"trust_level": "full",
+		"recent_messages": []map[string]interface{}{
+			{"user": "U111", "text": "first message"},
+			{"user": "U222", "text": "second message"},
+		},
+	})
+
+	expectedParts := []string{
+		"Recent conversation in this channel (last 5 messages, oldest first):",
+		"[U111] first message",
+		"[U222] second message",
+		"use the `use-fractalbot` skill",
+	}
+	for _, part := range expectedParts {
+		if !strings.Contains(out, part) {
+			t.Fatalf("expected %q in prompt, got %q", part, out)
+		}
+	}
+	// trust_level=full should NOT have <conversation_context> tags
+	if strings.Contains(out, "<conversation_context>") {
+		t.Fatalf("expected no <conversation_context> tags for trust_level=full, got %q", out)
+	}
+	// History block should appear before "User message:"
+	histIdx := strings.Index(out, "Recent conversation")
+	msgIdx := strings.Index(out, "User message:")
+	if histIdx >= msgIdx {
+		t.Fatalf("expected recent conversation before User message, hist=%d msg=%d", histIdx, msgIdx)
+	}
+}
+
+func TestBuildPromptWithRecentMessagesChannelTrust(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("hello", "main", map[string]interface{}{
+		"channel":     "slack",
+		"chat_id":     "C456",
+		"user_id":     "U999",
+		"trust_level": "channel",
+		"recent_messages": []map[string]interface{}{
+			{"user": "U333", "text": "channel msg"},
+		},
+	})
+
+	if !strings.Contains(out, "<conversation_context>") {
+		t.Fatalf("expected <conversation_context> tag for trust_level=channel, got %q", out)
+	}
+	if !strings.Contains(out, "</conversation_context>") {
+		t.Fatalf("expected </conversation_context> tag for trust_level=channel, got %q", out)
+	}
+	if !strings.Contains(out, "[U333] channel msg") {
+		t.Fatalf("expected message in history, got %q", out)
+	}
+	// History block should be wrapped in tags and appear before "User message:"
+	openTag := strings.Index(out, "<conversation_context>")
+	closeTag := strings.Index(out, "</conversation_context>")
+	msgIdx := strings.Index(out, "User message:")
+	if openTag >= closeTag || closeTag >= msgIdx {
+		t.Fatalf("expected <conversation_context>...</conversation_context> before User message")
+	}
+}
+
+func TestBuildPromptWithoutRecentMessages(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("hello", "main", map[string]interface{}{
+		"channel":     "slack",
+		"chat_id":     "C123",
+		"user_id":     "U123",
+		"trust_level": "full",
+	})
+
+	if strings.Contains(out, "Recent conversation") {
+		t.Fatalf("expected no recent conversation block without messages, got %q", out)
+	}
+	if strings.Contains(out, "<conversation_context>") {
+		t.Fatalf("expected no <conversation_context> tags without messages, got %q", out)
+	}
+	if !strings.Contains(out, "User message:\nhello\n") {
+		t.Fatalf("expected user message, got %q", out)
+	}
+}

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -37,9 +37,10 @@ type SlackBot struct {
 	socketClient *socketmode.Client
 	ackFn        func(req socketmode.Request, payload ...interface{})
 
-	startFn       func(ctx context.Context) error
-	stopFn        func() error
-	sendMessageFn func(ctx context.Context, channelID, text string) error
+	startFn        func(ctx context.Context) error
+	stopFn         func() error
+	sendMessageFn  func(ctx context.Context, channelID, text string) error
+	fetchHistoryFn func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error)
 
 	socketClientFactoryFn func(apiClient *slack.Client) *socketmode.Client
 	runSocketModeFn       func(ctx context.Context, socketClient *socketmode.Client) error
@@ -427,7 +428,8 @@ func (b *SlackBot) slashCommandReply(ctx context.Context, msg *slackInboundMessa
 	}
 
 	if b.handler != nil {
-		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, selection.Task, selection.Agent, trustLevel))
+		recentMessages := b.fetchRecentMessages(ctx, msg.channelID, 5)
+		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, selection.Task, selection.Agent, trustLevel, recentMessages))
 		if err != nil {
 			log.Printf("slack handler error: %v", err)
 			replyText = "❌ Something went wrong. Please try again."
@@ -535,7 +537,8 @@ func (b *SlackBot) handleMessageEvent(ctx context.Context, msg *slackInboundMess
 	}
 
 	if b.handler != nil {
-		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, selection.Task, selection.Agent, trustLevel))
+		recentMessages := b.fetchRecentMessages(ctx, msg.channelID, 5)
+		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, selection.Task, selection.Agent, trustLevel, recentMessages))
 		if err != nil {
 			log.Printf("slack handler error: %v", err)
 			replyText = "❌ Something went wrong. Please try again."
@@ -587,7 +590,7 @@ func (b *SlackBot) commandResponse(ctx context.Context, msg *slackInboundMessage
 		if b.handler == nil {
 			return true, "⚠️ runtime tools are disabled", nil
 		}
-		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, msg.text, "", b.authorize(msg)))
+		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, msg.text, "", b.authorize(msg), nil))
 		if err != nil {
 			return true, "", err
 		}
@@ -603,7 +606,7 @@ func (b *SlackBot) commandResponse(ctx context.Context, msg *slackInboundMessage
 		if b.handler == nil {
 			return true, "⚠️ runtime tools are disabled", nil
 		}
-		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, "/tools", "", b.authorize(msg)))
+		replyText, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(msg, "/tools", "", b.authorize(msg), nil))
 		if err != nil {
 			return true, "", err
 		}
@@ -856,19 +859,70 @@ func (b *SlackBot) sendText(ctx context.Context, channelID, text string) error {
 	return nil
 }
 
-func (b *SlackBot) toProtocolMessage(msg *slackInboundMessage, text, agent, trustLevel string) *protocol.Message {
+func (b *SlackBot) fetchRecentMessages(ctx context.Context, channelID string, limit int) []map[string]interface{} {
+	fetchFn := b.fetchHistoryFn
+	if fetchFn == nil {
+		fetchFn = b.defaultFetchHistory
+	}
+	messages, err := fetchFn(ctx, channelID, limit)
+	if err != nil {
+		log.Printf("slack: failed to fetch recent messages for channel %s: %v", channelID, err)
+		return nil
+	}
+	return messages
+}
+
+func (b *SlackBot) defaultFetchHistory(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
+	if b.apiClient == nil {
+		return nil, errors.New("slack api client not initialized")
+	}
+	resp, err := b.apiClient.GetConversationHistoryContext(ctx, &slack.GetConversationHistoryParameters{
+		ChannelID: channelID,
+		Limit:     limit + 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	msgs := resp.Messages
+	// Slack returns newest-first; reverse to chronological order.
+	for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+		msgs[i], msgs[j] = msgs[j], msgs[i]
+	}
+	// Drop the last message (the trigger message itself).
+	if len(msgs) > 0 {
+		msgs = msgs[:len(msgs)-1]
+	}
+	// Take last `limit` messages.
+	if len(msgs) > limit {
+		msgs = msgs[len(msgs)-limit:]
+	}
+	result := make([]map[string]interface{}, 0, len(msgs))
+	for _, m := range msgs {
+		result = append(result, map[string]interface{}{
+			"user": m.User,
+			"text": m.Text,
+		})
+	}
+	return result, nil
+}
+
+func (b *SlackBot) toProtocolMessage(msg *slackInboundMessage, text, agent, trustLevel string, recentMessages []map[string]interface{}) *protocol.Message {
+	data := map[string]interface{}{
+		"channel":     "slack",
+		"text":        text,
+		"agent":       agent,
+		"user_id":     msg.userID,
+		"chat_id":     msg.channelID,
+		"chatType":    msg.channelType,
+		"trust_level": trustLevel,
+	}
+	if len(recentMessages) > 0 {
+		data["recent_messages"] = recentMessages
+	}
 	return &protocol.Message{
 		Kind:   protocol.MessageKindChannel,
 		Action: protocol.ActionCreate,
-		Data: map[string]interface{}{
-			"channel":     "slack",
-			"text":        text,
-			"agent":       agent,
-			"user_id":     msg.userID,
-			"chat_id":     msg.channelID,
-			"chatType":    msg.channelType,
-			"trust_level": trustLevel,
-		},
+		Data:   data,
 	}
 }
 

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -1141,3 +1141,124 @@ func TestSlackSocketModeReconnectsWithBackoff(t *testing.T) {
 		}
 	}
 }
+
+func TestSlackMentionIncludesRecentMessages(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, []string{"C555"}, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	handler := &fakeSlackHandler{reply: "ok"}
+	bot.SetHandler(handler)
+
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		return nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
+		_ = ctx
+		return []map[string]interface{}{
+			{"user": "U111", "text": "msg-1"},
+			{"user": "U222", "text": "msg-2"},
+		}, nil
+	}
+
+	// Trigger via AppMentionEvent path (slashCommandReply)
+	bot.slashCommandReply(context.Background(), &slackInboundMessage{
+		text:        "hello",
+		userID:      "U123",
+		channelID:   "C555",
+		channelType: "app_mention",
+	})
+
+	if !handler.called {
+		t.Fatalf("expected handler called")
+	}
+	data := handler.last.Data.(map[string]interface{})
+	recent, ok := data["recent_messages"].([]map[string]interface{})
+	if !ok || len(recent) != 2 {
+		t.Fatalf("expected 2 recent messages, got %v", data["recent_messages"])
+	}
+	if recent[0]["user"] != "U111" || recent[1]["text"] != "msg-2" {
+		t.Fatalf("unexpected recent messages: %v", recent)
+	}
+}
+
+func TestSlackDMIncludesRecentMessages(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	handler := &fakeSlackHandler{reply: "ok"}
+	bot.SetHandler(handler)
+
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		return nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
+		_ = ctx
+		return []map[string]interface{}{
+			{"user": "U123", "text": "previous DM"},
+		}, nil
+	}
+
+	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
+		text:        "hello",
+		userID:      "U123",
+		channelID:   "D456",
+		channelType: "im",
+	})
+
+	if !handler.called {
+		t.Fatalf("expected handler called")
+	}
+	data := handler.last.Data.(map[string]interface{})
+	recent, ok := data["recent_messages"].([]map[string]interface{})
+	if !ok || len(recent) != 1 {
+		t.Fatalf("expected 1 recent message, got %v", data["recent_messages"])
+	}
+	if recent[0]["text"] != "previous DM" {
+		t.Fatalf("unexpected recent message: %v", recent[0])
+	}
+}
+
+func TestSlackHistoryFetchErrorDoesNotBlock(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	handler := &fakeSlackHandler{reply: "ok"}
+	bot.SetHandler(handler)
+
+	var sent slackSendCapture
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		sent = slackSendCapture{channelID: channelID, text: text}
+		return nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
+		_ = ctx
+		return nil, errors.New("slack api error")
+	}
+
+	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
+		text:        "hello",
+		userID:      "U123",
+		channelID:   "D456",
+		channelType: "im",
+	})
+
+	if !handler.called {
+		t.Fatalf("expected handler called despite fetch error")
+	}
+	if sent.text != "ok" {
+		t.Fatalf("expected reply ok, got %q", sent.text)
+	}
+	data := handler.last.Data.(map[string]interface{})
+	if _, hasRecent := data["recent_messages"]; hasRecent {
+		t.Fatalf("expected no recent_messages on fetch error, got %v", data["recent_messages"])
+	}
+}


### PR DESCRIPTION
## Summary
- Slack @mention 和 DM 消息现在自动拉取最近 5 条聊天记录作为上下文
- Agent prompt 中新增 "Recent conversation" 段落，让 agent 能理解对话语境
- `trust_level=channel` 时历史消息用 `<conversation_context>` 标签包裹（安全隔离）
- Fetch 失败时优雅降级：log warning，消息仍正常路由

## Changes
- `internal/channels/slack.go` — 新增 `fetchHistoryFn` / `fetchRecentMessages` / `defaultFetchHistory`，修改 `toProtocolMessage` 签名传递 `recentMessages`
- `internal/agent/manager.go` — `buildOhMyCodeTaskPrompt` 提取 `recent_messages` 并格式化为对话上下文
- `internal/channels/slack_test.go` — 3 个新测试
- `internal/agent/manager_test.go` — 3 个新测试

## Test plan
- [x] `go test ./internal/channels/ ./internal/agent/` 全部通过
- [x] `go build -o fractalbot ./cmd/fractalbot/` 编译通过
- [ ] 从 Slack 群 @bot 发消息 → agent prompt 包含最近 5 条上下文
- [ ] 从 Slack DM 发消息 → 同样包含最近 5 条上下文