### PR TITLE
feat(slack): support thread_ts in CLI and message send API

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -160,6 +160,7 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 	channel := sendFS.String("channel", "telegram", "target channel (e.g. telegram, slack, feishu, discord, imessage)")
 	to := sendFS.String("to", "", "target chat ID")
 	text := sendFS.String("text", "", "message text")
+	threadTS := sendFS.String("thread-ts", "", "optional Slack thread timestamp for threaded reply")
 
 	if err := sendFS.Parse(args[1:]); err != nil {
 		return 1
@@ -183,7 +184,9 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 		return 1
 	}
 
-	if err := messageSendFn(ctx, cfg, channelName, toValue, messageText); err != nil {
+	threadTSValue := strings.TrimSpace(*threadTS)
+
+	if err := messageSendFn(ctx, cfg, channelName, toValue, messageText, threadTSValue); err != nil {
 		logger.Printf("failed to send message: %v", err)
 		return 1
 	}
@@ -192,11 +195,12 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 	return 0
 }
 
-func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
+func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
 	type requestPayload struct {
-		Channel string `json:"channel"`
-		To      string `json:"to"`
-		Text    string `json:"text"`
+		Channel  string `json:"channel"`
+		To       string `json:"to"`
+		Text     string `json:"text"`
+		ThreadTS string `json:"thread_ts,omitempty"`
 	}
 
 	type responsePayload struct {
@@ -205,9 +209,10 @@ func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel s
 	}
 
 	requestBody, err := json.Marshal(requestPayload{
-		Channel: channel,
-		To:      to,
-		Text:    text,
+		Channel:  channel,
+		To:       to,
+		Text:     text,
+		ThreadTS: threadTS,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -55,7 +55,7 @@ func TestRunMessageSend(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		called := false
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
 			_ = ctx
 			_ = cfg
 			called = true
@@ -67,6 +67,9 @@ func TestRunMessageSend(t *testing.T) {
 			}
 			if text != "hello from cli" {
 				t.Fatalf("text=%q", text)
+			}
+			if threadTS != "" {
+				t.Fatalf("threadTS=%q", threadTS)
 			}
 			return nil
 		}
@@ -91,6 +94,45 @@ func TestRunMessageSend(t *testing.T) {
 		}
 	})
 
+	t.Run("success with thread ts", func(t *testing.T) {
+		called := false
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+			_ = ctx
+			_ = cfg
+			called = true
+			if channel != "slack" {
+				t.Fatalf("channel=%q", channel)
+			}
+			if to != "C0A8ESWV7D0" {
+				t.Fatalf("to=%s", to)
+			}
+			if text != "thread reply" {
+				t.Fatalf("text=%q", text)
+			}
+			if threadTS != "1234567890.123456" {
+				t.Fatalf("threadTS=%q", threadTS)
+			}
+			return nil
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"message", "send",
+			"--channel", "slack",
+			"--to", "C0A8ESWV7D0",
+			"--thread-ts", "1234567890.123456",
+			"--text", "thread reply",
+		}, &buf)
+
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
+		}
+		if !called {
+			t.Fatalf("expected message send function to be called")
+		}
+	})
+
 	t.Run("validation errors", func(t *testing.T) {
 		cases := []struct {
 			name          string
@@ -111,12 +153,13 @@ func TestRunMessageSend(t *testing.T) {
 
 		for _, testCase := range cases {
 			t.Run(testCase.name, func(t *testing.T) {
-				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
+				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
 					_ = ctx
 					_ = cfg
 					_ = channel
 					_ = to
 					_ = text
+					_ = threadTS
 					t.Fatalf("messageSendFn should not be called for validation error")
 					return nil
 				}
@@ -135,12 +178,13 @@ func TestRunMessageSend(t *testing.T) {
 	})
 
 	t.Run("unknown subcommand", func(t *testing.T) {
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
 			_ = ctx
 			_ = cfg
 			_ = channel
 			_ = to
 			_ = text
+			_ = threadTS
 			t.Fatalf("messageSendFn should not be called")
 			return nil
 		}
@@ -159,12 +203,13 @@ func TestRunMessageSend(t *testing.T) {
 	})
 
 	t.Run("send failure", func(t *testing.T) {
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
 			_ = ctx
 			_ = cfg
 			_ = channel
 			_ = to
 			_ = text
+			_ = threadTS
 			return fmt.Errorf("gateway down")
 		}
 

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -14,6 +14,16 @@ type Channel interface {
 	IsRunning() bool
 }
 
+// SendOptions defines optional outbound message metadata.
+type SendOptions struct {
+	ThreadTS string
+}
+
+// ThreadedSender is implemented by channels that support threaded sends.
+type ThreadedSender interface {
+	SendMessageWithOptions(ctx context.Context, target string, text string, opts SendOptions) error
+}
+
 // HandlerAware is implemented by channels that accept inbound handlers.
 type HandlerAware interface {
 	SetHandler(handler IncomingMessageHandler)

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -37,10 +37,11 @@ type SlackBot struct {
 	socketClient *socketmode.Client
 	ackFn        func(req socketmode.Request, payload ...interface{})
 
-	startFn        func(ctx context.Context) error
-	stopFn         func() error
-	sendMessageFn  func(ctx context.Context, channelID, text string) error
-	fetchHistoryFn func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error)
+	startFn                  func(ctx context.Context) error
+	stopFn                   func() error
+	sendMessageFn            func(ctx context.Context, channelID, text string) error
+	sendMessageWithOptionsFn func(ctx context.Context, channelID, text string, opts SendOptions) error
+	fetchHistoryFn           func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error)
 
 	socketClientFactoryFn func(apiClient *slack.Client) *socketmode.Client
 	runSocketModeFn       func(ctx context.Context, socketClient *socketmode.Client) error
@@ -154,11 +155,26 @@ func (b *SlackBot) Stop() error {
 }
 
 func (b *SlackBot) SendMessage(ctx context.Context, target string, text string) error {
-	if b.sendMessageFn == nil {
-		return errors.New("slack sender not configured")
-	}
+	return b.SendMessageWithOptions(ctx, target, text, SendOptions{})
+}
+
+func (b *SlackBot) SendMessageWithOptions(ctx context.Context, target string, text string, opts SendOptions) error {
 	if strings.TrimSpace(target) == "" {
 		return errors.New("slack channel ID is required")
+	}
+	if b.sendMessageWithOptionsFn != nil {
+		if err := b.sendMessageWithOptionsFn(ctx, target, text, opts); err != nil {
+			b.markError()
+			return err
+		}
+		b.markActivity()
+		return nil
+	}
+	if strings.TrimSpace(opts.ThreadTS) != "" {
+		return errors.New("slack threaded sender not configured")
+	}
+	if b.sendMessageFn == nil {
+		return errors.New("slack sender not configured")
 	}
 	if err := b.sendMessageFn(ctx, target, text); err != nil {
 		b.markError()
@@ -189,6 +205,7 @@ func (b *SlackBot) initClients() {
 	if b.waitReconnectFn == nil {
 		b.waitReconnectFn = waitForReconnect
 	}
+	b.sendMessageWithOptionsFn = b.sendTextWithOptions
 	b.sendMessageFn = b.sendText
 	b.startFn = b.startSocketMode
 }
@@ -843,6 +860,10 @@ func (b *SlackBot) reply(ctx context.Context, msg *slackInboundMessage, text str
 }
 
 func (b *SlackBot) sendText(ctx context.Context, channelID, text string) error {
+	return b.sendTextWithOptions(ctx, channelID, text, SendOptions{})
+}
+
+func (b *SlackBot) sendTextWithOptions(ctx context.Context, channelID, text string, opts SendOptions) error {
 	if b.apiClient == nil {
 		b.markError()
 		return errors.New("slack api client not initialized")
@@ -851,7 +872,13 @@ func (b *SlackBot) sendText(ctx context.Context, channelID, text string) error {
 		b.markError()
 		return errors.New("slack channel ID is required")
 	}
-	_, _, err := b.apiClient.PostMessageContext(ctx, channelID, slack.MsgOptionText(text, false))
+	msgOptions := []slack.MsgOption{
+		slack.MsgOptionText(text, false),
+	}
+	if strings.TrimSpace(opts.ThreadTS) != "" {
+		msgOptions = append(msgOptions, slack.MsgOptionTS(strings.TrimSpace(opts.ThreadTS)))
+	}
+	_, _, err := b.apiClient.PostMessageContext(ctx, channelID, msgOptions...)
 	if err != nil {
 		b.markError()
 		return err

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -3,6 +3,8 @@ package channels
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -1260,5 +1262,83 @@ func TestSlackHistoryFetchErrorDoesNotBlock(t *testing.T) {
 	data := handler.last.Data.(map[string]interface{})
 	if _, hasRecent := data["recent_messages"]; hasRecent {
 		t.Fatalf("expected no recent_messages on fetch error, got %v", data["recent_messages"])
+	}
+}
+
+func TestSlackSendMessageWithOptionsUsesThreadTS(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	var captured slackSendCapture
+	var capturedOpts SendOptions
+	bot.sendMessageWithOptionsFn = func(ctx context.Context, channelID, text string, opts SendOptions) error {
+		_ = ctx
+		captured = slackSendCapture{channelID: channelID, text: text}
+		capturedOpts = opts
+		return nil
+	}
+
+	if err := bot.SendMessageWithOptions(
+		context.Background(),
+		"C0A8ESWV7D0",
+		"thread reply",
+		SendOptions{ThreadTS: "1234567890.123456"},
+	); err != nil {
+		t.Fatalf("SendMessageWithOptions: %v", err)
+	}
+
+	if captured.channelID != "C0A8ESWV7D0" {
+		t.Fatalf("channelID=%q", captured.channelID)
+	}
+	if captured.text != "thread reply" {
+		t.Fatalf("text=%q", captured.text)
+	}
+	if capturedOpts.ThreadTS != "1234567890.123456" {
+		t.Fatalf("threadTS=%q", capturedOpts.ThreadTS)
+	}
+}
+
+func TestSlackSendTextWithOptionsPostsThreadTS(t *testing.T) {
+	var receivedChannel string
+	var receivedText string
+	var receivedThreadTS string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		receivedChannel = r.FormValue("channel")
+		receivedText = r.FormValue("text")
+		receivedThreadTS = r.FormValue("thread_ts")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C0A8ESWV7D0","ts":"123.456","message":{"text":"thread reply"}}`))
+	}))
+	defer server.Close()
+
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+	bot.apiClient = slack.New("xoxb-token", slack.OptionAPIURL(server.URL+"/"))
+
+	if err := bot.sendTextWithOptions(
+		context.Background(),
+		"C0A8ESWV7D0",
+		"thread reply",
+		SendOptions{ThreadTS: "1234567890.123456"},
+	); err != nil {
+		t.Fatalf("sendTextWithOptions: %v", err)
+	}
+
+	if receivedChannel != "C0A8ESWV7D0" {
+		t.Fatalf("channel=%q", receivedChannel)
+	}
+	if receivedText != "thread reply" {
+		t.Fatalf("text=%q", receivedText)
+	}
+	if receivedThreadTS != "1234567890.123456" {
+		t.Fatalf("thread_ts=%q", receivedThreadTS)
 	}
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -249,16 +249,18 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 type messageSendRequest struct {
-	Channel string `json:"channel"`
-	To      string `json:"to"`
-	Text    string `json:"text"`
+	Channel  string `json:"channel"`
+	To       string `json:"to"`
+	Text     string `json:"text"`
+	ThreadTS string `json:"thread_ts,omitempty"`
 }
 
 type messageSendResponse struct {
-	Status  string `json:"status"`
-	Channel string `json:"channel,omitempty"`
-	To      string `json:"to,omitempty"`
-	Error   string `json:"error,omitempty"`
+	Status   string `json:"status"`
+	Channel  string `json:"channel,omitempty"`
+	To       string `json:"to,omitempty"`
+	ThreadTS string `json:"thread_ts,omitempty"`
+	Error    string `json:"error,omitempty"`
 }
 
 func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
@@ -277,7 +279,9 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 	}
 
 	request.Channel = strings.ToLower(strings.TrimSpace(request.Channel))
+	request.To = strings.TrimSpace(request.To)
 	request.Text = strings.TrimSpace(request.Text)
+	request.ThreadTS = strings.TrimSpace(request.ThreadTS)
 
 	if request.Channel == "" {
 		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "channel is required"})
@@ -303,15 +307,23 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := channel.SendMessage(r.Context(), request.To, request.Text); err != nil {
+	if threaded, ok := channel.(channels.ThreadedSender); ok {
+		if err := threaded.SendMessageWithOptions(r.Context(), request.To, request.Text, channels.SendOptions{
+			ThreadTS: request.ThreadTS,
+		}); err != nil {
+			writeJSON(w, http.StatusBadGateway, messageSendResponse{Status: "error", Error: err.Error()})
+			return
+		}
+	} else if err := channel.SendMessage(r.Context(), request.To, request.Text); err != nil {
 		writeJSON(w, http.StatusBadGateway, messageSendResponse{Status: "error", Error: err.Error()})
 		return
 	}
 
 	writeJSON(w, http.StatusOK, messageSendResponse{
-		Status:  "ok",
-		Channel: request.Channel,
-		To:      request.To,
+		Status:   "ok",
+		Channel:  request.Channel,
+		To:       request.To,
+		ThreadTS: request.ThreadTS,
 	})
 }
 

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 	"github.com/gorilla/websocket"
@@ -427,6 +428,45 @@ func (f *fakeSendChannel) SendMessage(ctx context.Context, target string, text s
 
 func (f *fakeSendChannel) IsRunning() bool { return f.running }
 
+type fakeThreadedSendChannel struct {
+	name     string
+	running  bool
+	lastChat string
+	lastText string
+	lastOpts channels.SendOptions
+	sendErr  error
+}
+
+func (f *fakeThreadedSendChannel) Name() string { return f.name }
+
+func (f *fakeThreadedSendChannel) Start(ctx context.Context) error {
+	_ = ctx
+	f.running = true
+	return nil
+}
+
+func (f *fakeThreadedSendChannel) Stop() error {
+	f.running = false
+	return nil
+}
+
+func (f *fakeThreadedSendChannel) SendMessage(ctx context.Context, target string, text string) error {
+	_ = ctx
+	f.lastChat = target
+	f.lastText = text
+	return f.sendErr
+}
+
+func (f *fakeThreadedSendChannel) SendMessageWithOptions(ctx context.Context, target string, text string, opts channels.SendOptions) error {
+	_ = ctx
+	f.lastChat = target
+	f.lastText = text
+	f.lastOpts = opts
+	return f.sendErr
+}
+
+func (f *fakeThreadedSendChannel) IsRunning() bool { return f.running }
+
 func TestMessageSendAPI(t *testing.T) {
 	cfg := &config.Config{
 		Gateway:  &config.GatewayConfig{Bind: "127.0.0.1", Port: 0},
@@ -442,6 +482,10 @@ func TestMessageSendAPI(t *testing.T) {
 	fake := &fakeSendChannel{name: "telegram"}
 	if err := server.agentManager.ChannelManager.Register(fake); err != nil {
 		t.Fatalf("register fake channel: %v", err)
+	}
+	fakeSlack := &fakeThreadedSendChannel{name: "slack"}
+	if err := server.agentManager.ChannelManager.Register(fakeSlack); err != nil {
+		t.Fatalf("register fake slack channel: %v", err)
 	}
 
 	mux := http.NewServeMux()
@@ -481,6 +525,62 @@ func TestMessageSendAPI(t *testing.T) {
 		}
 	})
 
+	t.Run("success with thread ts on threaded channel", func(t *testing.T) {
+		fakeSlack.lastChat = ""
+		fakeSlack.lastText = ""
+		fakeSlack.lastOpts = channels.SendOptions{}
+
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"slack","to":"C0A8ESWV7D0","text":"reply","thread_ts":"1234567890.123456"}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d body=%s", resp.StatusCode, string(body))
+		}
+		if fakeSlack.lastChat != "C0A8ESWV7D0" {
+			t.Fatalf("expected lastChat=C0A8ESWV7D0 got %s", fakeSlack.lastChat)
+		}
+		if fakeSlack.lastText != "reply" {
+			t.Fatalf("expected text captured, got %q", fakeSlack.lastText)
+		}
+		if fakeSlack.lastOpts.ThreadTS != "1234567890.123456" {
+			t.Fatalf("expected thread ts passed, got %q", fakeSlack.lastOpts.ThreadTS)
+		}
+	})
+
+	t.Run("thread ts tolerated for non-threaded channel", func(t *testing.T) {
+		fake.lastChat = ""
+		fake.lastText = ""
+
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"telegram","to":"98765","text":"hello","thread_ts":"1234567890.123456"}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d body=%s", resp.StatusCode, string(body))
+		}
+		if fake.lastChat != "98765" {
+			t.Fatalf("expected lastChat=98765 got %s", fake.lastChat)
+		}
+		if fake.lastText != "hello" {
+			t.Fatalf("expected text captured, got %q", fake.lastText)
+		}
+	})
+
 	t.Run("validation", func(t *testing.T) {
 		resp, err := http.Post(
 			ts.URL+"/api/v1/message/send",
@@ -502,7 +602,7 @@ func TestMessageSendAPI(t *testing.T) {
 		resp, err := http.Post(
 			ts.URL+"/api/v1/message/send",
 			"application/json",
-			strings.NewReader(`{"channel":"slack","to":"1","text":"hello"}`),
+			strings.NewReader(`{"channel":"unknown-channel","to":"1","text":"hello"}`),
 		)
 		if err != nil {
 			t.Fatalf("post failed: %v", err)


### PR DESCRIPTION
## Summary
- add outbound send options in channel abstractions via `channels.SendOptions` and optional `channels.ThreadedSender`
- add Slack threaded send support with `SendMessageWithOptions(..., SendOptions{ThreadTS})`
- pass `thread_ts` into Slack `chat.postMessage` via `slack.MsgOptionTS(...)`
- extend gateway API `POST /api/v1/message/send` to accept optional `thread_ts`
- extend CLI `fractalbot message send` with optional `--thread-ts`
- keep existing non-thread send flow backward-compatible

## API / CLI
- CLI:
  - `fractalbot message send --channel slack --to C0A8ESWV7D0 --thread-ts 1234567890.123456 --text "reply in thread"`
- HTTP:
  - `POST /api/v1/message/send`
  - body supports optional `thread_ts`

## Tests
- Added/updated tests for:
  - CLI argument forwarding of `--thread-ts`
  - gateway threaded and non-threaded channel behavior
  - Slack threaded send option forwarding and Slack API `thread_ts` post behavior
- Ran:
  - `go test ./cmd/fractalbot ./internal/channels ./internal/gateway` ✅
  - `go test ./...` ⚠️ fails in pre-existing `internal/runtime` sandbox path tests on macOS (`/var` vs `/private/var` mismatch), unrelated to this change
