### PR TITLE
fix(slack): propagate inbound thread_ts for threaded replies

### DIFF
--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -851,6 +851,14 @@ func (b *SlackBot) reply(ctx context.Context, msg *slackInboundMessage, text str
 	if b.sendMessageFn == nil {
 		return errors.New("slack sender not configured")
 	}
+	if msg.threadTS != "" {
+		if err := b.sendTextWithOptions(ctx, msg.channelID, TruncateSlackReply(text), SendOptions{ThreadTS: msg.threadTS}); err != nil {
+			b.markError()
+			return err
+		}
+		b.markActivity()
+		return nil
+	}
 	if err := b.sendMessageFn(ctx, msg.channelID, TruncateSlackReply(text)); err != nil {
 		b.markError()
 		return err
@@ -942,6 +950,7 @@ func (b *SlackBot) toProtocolMessage(msg *slackInboundMessage, text, agent, trus
 		"chat_id":     msg.channelID,
 		"chatType":    msg.channelType,
 		"trust_level": trustLevel,
+		"thread_ts":   msg.threadTS,
 	}
 	if len(recentMessages) > 0 {
 		data["recent_messages"] = recentMessages
@@ -958,6 +967,7 @@ type slackInboundMessage struct {
 	userID      string
 	channelID   string
 	channelType string
+	threadTS    string
 }
 
 func slackMessageFromEvent(event *slackevents.MessageEvent) *slackInboundMessage {
@@ -978,6 +988,7 @@ func slackMessageFromEvent(event *slackevents.MessageEvent) *slackInboundMessage
 		userID:      event.User,
 		channelID:   event.Channel,
 		channelType: event.ChannelType,
+		threadTS:    event.ThreadTimeStamp,
 	}
 }
 
@@ -997,6 +1008,7 @@ func slackMessageFromAppMentionEvent(event *slackevents.AppMentionEvent) *slackI
 		userID:      event.User,
 		channelID:   event.Channel,
 		channelType: "app_mention",
+		threadTS:    event.ThreadTimeStamp,
 	}
 }
 

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -1265,6 +1265,92 @@ func TestSlackHistoryFetchErrorDoesNotBlock(t *testing.T) {
 	}
 }
 
+func TestSlackMessageFromEventIncludesThreadTS(t *testing.T) {
+	msg := slackMessageFromEvent(&slackevents.MessageEvent{
+		User:            "U123",
+		Channel:         "D456",
+		ChannelType:     "im",
+		Text:            "hello",
+		ThreadTimeStamp: "1234567890.123456",
+	})
+	if msg == nil {
+		t.Fatalf("expected parsed inbound message")
+	}
+	if msg.threadTS != "1234567890.123456" {
+		t.Fatalf("threadTS=%q", msg.threadTS)
+	}
+}
+
+func TestSlackMessageFromAppMentionEventIncludesThreadTS(t *testing.T) {
+	msg := slackMessageFromAppMentionEvent(&slackevents.AppMentionEvent{
+		User:            "U123",
+		Channel:         "C456",
+		Text:            "<@B999> hello",
+		ThreadTimeStamp: "1234567890.123456",
+	})
+	if msg == nil {
+		t.Fatalf("expected parsed inbound mention message")
+	}
+	if msg.threadTS != "1234567890.123456" {
+		t.Fatalf("threadTS=%q", msg.threadTS)
+	}
+}
+
+func TestSlackReplyUsesThreadTSWhenPresent(t *testing.T) {
+	var receivedThreadTS string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("parse form: %v", err)
+		}
+		receivedThreadTS = r.FormValue("thread_ts")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C0A8ESWV7D0","ts":"123.456","message":{"text":"thread reply"}}`))
+	}))
+	defer server.Close()
+
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+	bot.apiClient = slack.New("xoxb-token", slack.OptionAPIURL(server.URL+"/"))
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		t.Fatalf("expected reply to use thread API path, got plain sendMessage call")
+		return nil
+	}
+
+	if err := bot.reply(context.Background(), &slackInboundMessage{
+		channelID: "C0A8ESWV7D0",
+		threadTS:  "1234567890.123456",
+	}, "thread reply"); err != nil {
+		t.Fatalf("reply: %v", err)
+	}
+
+	if receivedThreadTS != "1234567890.123456" {
+		t.Fatalf("thread_ts=%q", receivedThreadTS)
+	}
+}
+
+func TestSlackToProtocolMessageIncludesThreadTS(t *testing.T) {
+	bot := &SlackBot{}
+	msg := &slackInboundMessage{
+		userID:      "U123",
+		channelID:   "C456",
+		channelType: "app_mention",
+		threadTS:    "1234567890.123456",
+	}
+
+	protoMsg := bot.toProtocolMessage(msg, "hello", "qa-1", "full", nil)
+	data, ok := protoMsg.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", protoMsg.Data)
+	}
+	if data["thread_ts"] != "1234567890.123456" {
+		t.Fatalf("thread_ts=%v", data["thread_ts"])
+	}
+}
+
 func TestSlackSendMessageWithOptionsUsesThreadTS(t *testing.T) {
 	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
 	if err != nil {


### PR DESCRIPTION
## Summary
- propagate inbound `thread_ts` from Slack `MessageEvent`/`AppMentionEvent` into `slackInboundMessage`
- include `thread_ts` in protocol payloads passed to handlers
- make Slack replies use threaded send options when inbound message carries `thread_ts`
- add tests for inbound parsing, protocol mapping, and threaded reply behavior

## Testing
- go test ./internal/channels/ -v
