### PR TITLE
fix(agent): include thread_ts in oh-my-code task prompt

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -424,6 +424,7 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 	userID := promptContextValue(inboundData, "user_id")
 	username := promptContextValue(inboundData, "username")
 	trustLevel := promptContextValue(inboundData, "trust_level")
+	threadTS := promptContextValue(inboundData, "thread_ts")
 
 	var sb strings.Builder
 	sb.WriteString("# Task Assignment\n\n")
@@ -433,9 +434,13 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 	sb.WriteString(fmt.Sprintf("- user_id: %s\n", defaultPromptContextValue(userID)))
 	sb.WriteString(fmt.Sprintf("- username: %s\n", defaultPromptContextValue(username)))
 	sb.WriteString(fmt.Sprintf("- selected_agent: %s\n", defaultPromptContextValue(strings.TrimSpace(selectedAgent))))
+	if threadTS != "" {
+		sb.WriteString(fmt.Sprintf("- thread_ts: %s\n", threadTS))
+	}
 	sb.WriteString("\n")
 	sb.WriteString("Routing instructions:\n")
 	sb.WriteString("- selected_agent is the final routing target after default/allowlist resolution.\n")
+	sb.WriteString("- If thread_ts is present, reply in the same thread using `--thread-ts` flag.\n")
 	sb.WriteString("- For outbound messaging intent, prefer `use-fractalbot` skill.\n")
 	sb.WriteString("- Effective available skills:\n")
 	sb.WriteString("  - use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)\n")

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -90,10 +90,11 @@ func TestValidateOhMyCodeAgentInvalidName(t *testing.T) {
 
 func TestBuildOhMyCodeTaskPromptIncludesTelegramContextAndSkillHint(t *testing.T) {
 	out := buildOhMyCodeTaskPrompt("hello world", "main", map[string]interface{}{
-		"channel":  "telegram",
-		"chat_id":  int64(99),
-		"user_id":  int64(123),
-		"username": "alice",
+		"channel":   "telegram",
+		"chat_id":   int64(99),
+		"user_id":   int64(123),
+		"username":  "alice",
+		"thread_ts": "1234567890.123456",
 	})
 
 	expectedParts := []string{
@@ -103,6 +104,8 @@ func TestBuildOhMyCodeTaskPromptIncludesTelegramContextAndSkillHint(t *testing.T
 		"- user_id: 123",
 		"- username: alice",
 		"- selected_agent: main",
+		"- thread_ts: 1234567890.123456",
+		"If thread_ts is present, reply in the same thread using `--thread-ts` flag.",
 		"prefer `use-fractalbot` skill",
 		"use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)",
 		"default to current chat_id",
@@ -134,6 +137,18 @@ func TestBuildOhMyCodeTaskPromptIncludesResolvedTargetContract(t *testing.T) {
 		if !strings.Contains(out, part) {
 			t.Fatalf("expected %q in prompt, got %q", part, out)
 		}
+	}
+}
+
+func TestBuildOhMyCodeTaskPromptOmitsThreadTSWhenMissing(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("send a message", "qa-1", map[string]interface{}{
+		"channel": "slack",
+		"chat_id": "D123",
+		"user_id": "U123",
+	})
+
+	if strings.Contains(out, "- thread_ts:") {
+		t.Fatalf("expected thread_ts to be omitted when missing, got %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `thread_ts` extraction in `buildOhMyCodeTaskPrompt`
- include `thread_ts` in the inbound routing context block when present
- add routing guidance to reply in-thread with `--thread-ts` when `thread_ts` exists
- update prompt tests to verify inclusion/omission behavior

## Testing
- go test ./internal/agent/ -v
