### PR TITLE
feat: add inbound attachment extraction and file download CLI

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -22,6 +23,7 @@ import (
 )
 
 var messageSendFn = sendMessageViaGatewayAPI
+var fileDownloadFn = downloadFileViaHTTP
 
 const exitCodeRestartRequested = 75
 
@@ -137,6 +139,8 @@ func runCommand(ctx context.Context, cfg *config.Config, args []string, out io.W
 	switch strings.ToLower(strings.TrimSpace(args[0])) {
 	case "message":
 		return runMessageCommand(ctx, cfg, args[1:], out, logger)
+	case "file":
+		return runFileCommand(ctx, cfg, args[1:], out, logger)
 	default:
 		logger.Printf("unknown command: %s", args[0])
 		return 1
@@ -192,6 +196,53 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 	}
 
 	fmt.Fprintf(out, "✅ Message sent via %s to %s\n", channelName, toValue)
+	return 0
+}
+
+func runFileCommand(ctx context.Context, cfg *config.Config, args []string, out io.Writer, logger *log.Logger) int {
+	if len(args) == 0 {
+		logger.Printf("file command requires a subcommand (download)")
+		return 1
+	}
+
+	subcmd := strings.ToLower(strings.TrimSpace(args[0]))
+	if subcmd != "download" {
+		logger.Printf("unknown file subcommand: %s", args[0])
+		return 1
+	}
+
+	downloadFS := flag.NewFlagSet("file download", flag.ContinueOnError)
+	downloadFS.SetOutput(out)
+	channel := downloadFS.String("channel", "", "source channel (slack or telegram)")
+	fileURL := downloadFS.String("url", "", "file URL")
+	output := downloadFS.String("output", "", "local output path")
+
+	if err := downloadFS.Parse(args[1:]); err != nil {
+		return 1
+	}
+
+	channelName := strings.ToLower(strings.TrimSpace(*channel))
+	if channelName == "" {
+		logger.Printf("--channel is required")
+		return 1
+	}
+	urlValue := strings.TrimSpace(*fileURL)
+	if urlValue == "" {
+		logger.Printf("--url is required")
+		return 1
+	}
+	outputPath := strings.TrimSpace(*output)
+	if outputPath == "" {
+		logger.Printf("--output is required")
+		return 1
+	}
+
+	if err := fileDownloadFn(ctx, cfg, channelName, urlValue, outputPath); err != nil {
+		logger.Printf("failed to download file: %v", err)
+		return 1
+	}
+
+	fmt.Fprintf(out, "✅ File downloaded via %s to %s\n", channelName, outputPath)
 	return 0
 }
 
@@ -266,4 +317,79 @@ func gatewaySendEndpoint(cfg *config.Config) string {
 	}
 
 	return fmt.Sprintf("http://%s/api/v1/message/send", net.JoinHostPort(bind, strconv.Itoa(port)))
+}
+
+func downloadFileViaHTTP(ctx context.Context, cfg *config.Config, channel, fileURL, outputPath string) error {
+	channelName := strings.ToLower(strings.TrimSpace(channel))
+	if channelName != "slack" && channelName != "telegram" {
+		return fmt.Errorf("unsupported channel %q (expected slack or telegram)", channel)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSpace(fileURL), nil)
+	if err != nil {
+		return fmt.Errorf("create download request: %w", err)
+	}
+	if channelName == "slack" {
+		token, err := slackBotTokenFromConfig(cfg)
+		if err != nil {
+			return err
+		}
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("download request failed: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+		message := strings.TrimSpace(string(body))
+		if message == "" {
+			message = http.StatusText(response.StatusCode)
+		}
+		return fmt.Errorf("download failed (%d): %s", response.StatusCode, message)
+	}
+
+	outputPath = strings.TrimSpace(outputPath)
+	outputDir := filepath.Dir(outputPath)
+	if outputDir != "." {
+		if err := os.MkdirAll(outputDir, 0755); err != nil {
+			return fmt.Errorf("create output directory: %w", err)
+		}
+	}
+
+	tmpFile, err := os.CreateTemp(outputDir, ".fractalbot-download-*")
+	if err != nil {
+		return fmt.Errorf("create temp output file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := io.Copy(tmpFile, response.Body); err != nil {
+		_ = tmpFile.Close()
+		return fmt.Errorf("write output file: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("close output file: %w", err)
+	}
+	if err := os.Rename(tmpPath, outputPath); err != nil {
+		return fmt.Errorf("finalize output file: %w", err)
+	}
+	return nil
+}
+
+func slackBotTokenFromConfig(cfg *config.Config) (string, error) {
+	if cfg == nil || cfg.Channels == nil || cfg.Channels.Slack == nil {
+		return "", fmt.Errorf("channels.slack.botToken is required for Slack file download")
+	}
+	token := strings.TrimSpace(cfg.Channels.Slack.BotToken)
+	if token == "" {
+		return "", fmt.Errorf("channels.slack.botToken is required for Slack file download")
+	}
+	return token, nil
 }

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -229,6 +231,181 @@ func TestRunMessageSend(t *testing.T) {
 			t.Fatalf("unexpected output: %q", buf.String())
 		}
 	})
+}
+
+func TestRunFileDownload(t *testing.T) {
+	configPath := writeMinimalConfig(t)
+	original := fileDownloadFn
+	t.Cleanup(func() { fileDownloadFn = original })
+
+	t.Run("success", func(t *testing.T) {
+		called := false
+		fileDownloadFn = func(ctx context.Context, cfg *config.Config, channel string, fileURL string, output string) error {
+			_ = ctx
+			_ = cfg
+			called = true
+			if channel != "slack" {
+				t.Fatalf("channel=%q", channel)
+			}
+			if fileURL != "https://example.com/file.png" {
+				t.Fatalf("url=%q", fileURL)
+			}
+			if output != "/tmp/file.png" {
+				t.Fatalf("output=%q", output)
+			}
+			return nil
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"file", "download",
+			"--channel", "slack",
+			"--url", "https://example.com/file.png",
+			"--output", "/tmp/file.png",
+		}, &buf)
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
+		}
+		if !called {
+			t.Fatalf("expected file download function to be called")
+		}
+		if !strings.Contains(buf.String(), "File downloaded via slack to /tmp/file.png") {
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+	})
+
+	t.Run("validation errors", func(t *testing.T) {
+		cases := []struct {
+			name          string
+			args          []string
+			expectedError string
+		}{
+			{
+				name:          "missing channel",
+				args:          []string{"--url", "https://example.com/x", "--output", "/tmp/x"},
+				expectedError: "--channel is required",
+			},
+			{
+				name:          "missing url",
+				args:          []string{"--channel", "slack", "--output", "/tmp/x"},
+				expectedError: "--url is required",
+			},
+			{
+				name:          "missing output",
+				args:          []string{"--channel", "slack", "--url", "https://example.com/x"},
+				expectedError: "--output is required",
+			},
+		}
+
+		for _, testCase := range cases {
+			t.Run(testCase.name, func(t *testing.T) {
+				fileDownloadFn = func(ctx context.Context, cfg *config.Config, channel string, fileURL string, output string) error {
+					_ = ctx
+					_ = cfg
+					_ = channel
+					_ = fileURL
+					_ = output
+					t.Fatalf("fileDownloadFn should not be called for validation error")
+					return nil
+				}
+
+				var buf bytes.Buffer
+				args := append([]string{"--config", configPath, "file", "download"}, testCase.args...)
+				code := runWithContext(context.Background(), args, &buf)
+				if code == 0 {
+					t.Fatalf("expected non-zero exit code for %s", testCase.name)
+				}
+				if !strings.Contains(buf.String(), testCase.expectedError) {
+					t.Fatalf("expected output to contain %q, got %q", testCase.expectedError, buf.String())
+				}
+			})
+		}
+	})
+
+	t.Run("unknown subcommand", func(t *testing.T) {
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"file", "inspect",
+		}, &buf)
+		if code == 0 {
+			t.Fatalf("expected non-zero exit code")
+		}
+		if !strings.Contains(buf.String(), "unknown file subcommand") {
+			t.Fatalf("unexpected output: %q", buf.String())
+		}
+	})
+}
+
+func TestDownloadFileViaHTTPSlackAuth(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("slack-file-data"))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "downloads", "file.bin")
+	cfg := &config.Config{
+		Channels: &config.ChannelsConfig{
+			Slack: &config.SlackConfig{BotToken: "xoxb-secret"},
+		},
+	}
+
+	if err := downloadFileViaHTTP(context.Background(), cfg, "slack", server.URL+"/private/file", outputPath); err != nil {
+		t.Fatalf("downloadFileViaHTTP: %v", err)
+	}
+	if gotAuth != "Bearer xoxb-secret" {
+		t.Fatalf("authorization=%q", gotAuth)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) != "slack-file-data" {
+		t.Fatalf("output data=%q", string(data))
+	}
+}
+
+func TestDownloadFileViaHTTPTelegramNoAuthHeader(t *testing.T) {
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte("telegram-file-data"))
+	}))
+	defer server.Close()
+
+	outputPath := filepath.Join(t.TempDir(), "tg.bin")
+	if err := downloadFileViaHTTP(context.Background(), &config.Config{}, "telegram", server.URL+"/bot123/file", outputPath); err != nil {
+		t.Fatalf("downloadFileViaHTTP: %v", err)
+	}
+	if gotAuth != "" {
+		t.Fatalf("expected empty Authorization header, got %q", gotAuth)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if string(data) != "telegram-file-data" {
+		t.Fatalf("output data=%q", string(data))
+	}
+}
+
+func TestDownloadFileViaHTTPSlackMissingToken(t *testing.T) {
+	err := downloadFileViaHTTP(
+		context.Background(),
+		&config.Config{},
+		"slack",
+		"https://files.slack.com/files-pri/T/F",
+		filepath.Join(t.TempDir(), "x.bin"),
+	)
+	if err == nil {
+		t.Fatalf("expected missing token error")
+	}
+	if !strings.Contains(err.Error(), "channels.slack.botToken") {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func writeMinimalConfig(t *testing.T) string {

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -952,13 +952,17 @@ func (b *SlackBot) toProtocolMessage(msg *slackInboundMessage, text, agent, trus
 		"trust_level": trustLevel,
 		"thread_ts":   msg.threadTS,
 	}
+	if len(msg.attachments) > 0 {
+		data["attachments"] = msg.attachments
+	}
 	if len(recentMessages) > 0 {
 		data["recent_messages"] = recentMessages
 	}
 	return &protocol.Message{
-		Kind:   protocol.MessageKindChannel,
-		Action: protocol.ActionCreate,
-		Data:   data,
+		Kind:        protocol.MessageKindChannel,
+		Action:      protocol.ActionCreate,
+		Data:        data,
+		Attachments: msg.attachments,
 	}
 }
 
@@ -968,6 +972,7 @@ type slackInboundMessage struct {
 	channelID   string
 	channelType string
 	threadTS    string
+	attachments []protocol.Attachment
 }
 
 func slackMessageFromEvent(event *slackevents.MessageEvent) *slackInboundMessage {
@@ -989,6 +994,7 @@ func slackMessageFromEvent(event *slackevents.MessageEvent) *slackInboundMessage
 		channelID:   event.Channel,
 		channelType: event.ChannelType,
 		threadTS:    event.ThreadTimeStamp,
+		attachments: slackAttachmentsFromEvent(event),
 	}
 }
 
@@ -1009,6 +1015,61 @@ func slackMessageFromAppMentionEvent(event *slackevents.AppMentionEvent) *slackI
 		channelID:   event.Channel,
 		channelType: "app_mention",
 		threadTS:    event.ThreadTimeStamp,
+	}
+}
+
+func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attachment {
+	if event == nil || event.Message == nil || len(event.Message.Files) == 0 {
+		return nil
+	}
+	attachments := make([]protocol.Attachment, 0, len(event.Message.Files))
+	for _, file := range event.Message.Files {
+		url := strings.TrimSpace(file.URLPrivate)
+		if url == "" {
+			url = strings.TrimSpace(file.URLPrivateDownload)
+		}
+		if url == "" {
+			continue
+		}
+		filename := strings.TrimSpace(file.Name)
+		if filename == "" {
+			filename = strings.TrimSpace(file.Title)
+		}
+		if filename == "" {
+			filename = strings.TrimSpace(file.ID)
+		}
+		attachments = append(attachments, protocol.Attachment{
+			Type:     slackAttachmentType(file.Mimetype, file.Filetype),
+			Filename: filename,
+			URL:      url,
+			Channel:  "slack",
+			MimeType: strings.TrimSpace(file.Mimetype),
+		})
+	}
+	return attachments
+}
+
+func slackAttachmentType(mimeType, fileType string) string {
+	mime := strings.ToLower(strings.TrimSpace(mimeType))
+	switch {
+	case strings.HasPrefix(mime, "image/"):
+		return "image"
+	case strings.HasPrefix(mime, "video/"):
+		return "video"
+	case strings.HasPrefix(mime, "audio/"):
+		return "audio"
+	}
+
+	kind := strings.ToLower(strings.TrimSpace(fileType))
+	switch kind {
+	case "png", "jpg", "jpeg", "gif", "bmp", "webp", "svg":
+		return "image"
+	case "mp4", "mov", "avi", "mkv", "webm":
+		return "video"
+	case "mp3", "wav", "ogg", "m4a", "flac", "aac":
+		return "audio"
+	default:
+		return "file"
 	}
 }
 

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -1281,6 +1281,48 @@ func TestSlackMessageFromEventIncludesThreadTS(t *testing.T) {
 	}
 }
 
+func TestSlackMessageFromEventIncludesAttachments(t *testing.T) {
+	msg := slackMessageFromEvent(&slackevents.MessageEvent{
+		User:        "U123",
+		Channel:     "D456",
+		ChannelType: "im",
+		Text:        "hello",
+		Message: &slack.Msg{
+			Files: []slack.File{
+				{
+					ID:         "F_IMAGE",
+					Name:       "image.png",
+					Mimetype:   "image/png",
+					Filetype:   "png",
+					URLPrivate: "https://files.slack.com/files-pri/T/F_IMAGE",
+				},
+				{
+					ID:                 "F_DOC",
+					Name:               "report.pdf",
+					Mimetype:           "application/pdf",
+					Filetype:           "pdf",
+					URLPrivateDownload: "https://files.slack.com/files-pri/T/F_DOC/download",
+				},
+			},
+		},
+	})
+	if msg == nil {
+		t.Fatalf("expected parsed inbound message")
+	}
+	if len(msg.attachments) != 2 {
+		t.Fatalf("attachments=%v", msg.attachments)
+	}
+	if msg.attachments[0].Type != "image" {
+		t.Fatalf("attachment[0].type=%q", msg.attachments[0].Type)
+	}
+	if msg.attachments[1].Type != "file" {
+		t.Fatalf("attachment[1].type=%q", msg.attachments[1].Type)
+	}
+	if msg.attachments[1].URL != "https://files.slack.com/files-pri/T/F_DOC/download" {
+		t.Fatalf("attachment[1].url=%q", msg.attachments[1].URL)
+	}
+}
+
 func TestSlackMessageFromAppMentionEventIncludesThreadTS(t *testing.T) {
 	msg := slackMessageFromAppMentionEvent(&slackevents.AppMentionEvent{
 		User:            "U123",
@@ -1348,6 +1390,41 @@ func TestSlackToProtocolMessageIncludesThreadTS(t *testing.T) {
 	}
 	if data["thread_ts"] != "1234567890.123456" {
 		t.Fatalf("thread_ts=%v", data["thread_ts"])
+	}
+}
+
+func TestSlackToProtocolMessageIncludesAttachments(t *testing.T) {
+	bot := &SlackBot{}
+	attachments := []protocol.Attachment{
+		{
+			Type:     "image",
+			Filename: "image.png",
+			URL:      "https://files.slack.com/files-pri/T/F_IMAGE",
+			Channel:  "slack",
+			MimeType: "image/png",
+		},
+	}
+	msg := &slackInboundMessage{
+		userID:      "U123",
+		channelID:   "C456",
+		channelType: "im",
+		attachments: attachments,
+	}
+
+	protoMsg := bot.toProtocolMessage(msg, "hello", "qa-1", "full", nil)
+	if len(protoMsg.Attachments) != 1 {
+		t.Fatalf("protocol attachments=%v", protoMsg.Attachments)
+	}
+	data, ok := protoMsg.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", protoMsg.Data)
+	}
+	dataAttachments, ok := data["attachments"].([]protocol.Attachment)
+	if !ok {
+		t.Fatalf("expected typed data attachments, got %T", data["attachments"])
+	}
+	if len(dataAttachments) != 1 || dataAttachments[0].URL != attachments[0].URL {
+		t.Fatalf("unexpected data attachments: %v", dataAttachments)
 	}
 }
 

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -706,7 +707,8 @@ func (b *TelegramBot) handleIncomingMessage(message *TelegramMessage) {
 		}
 	}
 
-	msg := b.convertToProtocolMessage(message, selection.Task, selection.Agent)
+	attachments := b.extractTelegramAttachments(b.ctx, message)
+	msg := b.convertToProtocolMessage(message, selection.Task, selection.Agent, attachments)
 
 	if b.handler != nil {
 		replyText, err := b.handler.HandleIncoming(b.ctx, msg)
@@ -1114,11 +1116,31 @@ func formatUserList(users []int64) string {
 
 // TelegramMessage represents a Telegram message.
 type TelegramMessage struct {
-	MessageID int64         `json:"message_id"`
-	From      *TelegramUser `json:"from"`
-	Chat      *TelegramChat `json:"chat"`
-	Date      int64         `json:"date"`
-	Text      string        `json:"text"`
+	MessageID int64               `json:"message_id"`
+	From      *TelegramUser       `json:"from"`
+	Chat      *TelegramChat       `json:"chat"`
+	Date      int64               `json:"date"`
+	Text      string              `json:"text"`
+	Photo     []TelegramPhotoSize `json:"photo,omitempty"`
+	Document  *TelegramDocument   `json:"document,omitempty"`
+}
+
+// TelegramPhotoSize represents a Telegram photo size object.
+type TelegramPhotoSize struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	Width        int    `json:"width"`
+	Height       int    `json:"height"`
+	FileSize     int64  `json:"file_size,omitempty"`
+}
+
+// TelegramDocument represents a Telegram document attachment.
+type TelegramDocument struct {
+	FileID       string `json:"file_id"`
+	FileUniqueID string `json:"file_unique_id"`
+	FileName     string `json:"file_name,omitempty"`
+	MimeType     string `json:"mime_type,omitempty"`
+	FileSize     int64  `json:"file_size,omitempty"`
 }
 
 // TelegramUser represents a Telegram user.
@@ -1134,19 +1156,185 @@ type TelegramChat struct {
 	Type string `json:"type"`
 }
 
-func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent string) *protocol.Message {
+func (b *TelegramBot) extractTelegramAttachments(ctx context.Context, msg *TelegramMessage) []protocol.Attachment {
+	if msg == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	attachments := make([]protocol.Attachment, 0, 2)
+	if photo := largestTelegramPhoto(msg.Photo); photo != nil {
+		fileURL, err := b.telegramFileURL(ctx, photo.FileID)
+		if err != nil {
+			log.Printf("telegram: failed to resolve photo file URL: %v", err)
+		} else {
+			filename := "photo_" + strings.TrimSpace(photo.FileID)
+			attachments = append(attachments, protocol.Attachment{
+				Type:     "image",
+				Filename: filename,
+				URL:      fileURL,
+				Channel:  "telegram",
+			})
+		}
+	}
+	if msg.Document != nil {
+		fileURL, err := b.telegramFileURL(ctx, msg.Document.FileID)
+		if err != nil {
+			log.Printf("telegram: failed to resolve document file URL: %v", err)
+		} else {
+			filename := strings.TrimSpace(msg.Document.FileName)
+			if filename == "" {
+				filename = "document_" + strings.TrimSpace(msg.Document.FileID)
+			}
+			attachments = append(attachments, protocol.Attachment{
+				Type:     telegramAttachmentType(msg.Document.MimeType, filename),
+				Filename: filename,
+				URL:      fileURL,
+				Channel:  "telegram",
+				MimeType: strings.TrimSpace(msg.Document.MimeType),
+			})
+		}
+	}
+	return attachments
+}
+
+type telegramGetFileResponse struct {
+	OK     bool `json:"ok"`
+	Result struct {
+		FileID   string `json:"file_id"`
+		FilePath string `json:"file_path"`
+	} `json:"result"`
+	ErrorCode   int    `json:"error_code"`
+	Description string `json:"description"`
+}
+
+func (b *TelegramBot) telegramFileURL(ctx context.Context, fileID string) (string, error) {
+	trimmedID := strings.TrimSpace(fileID)
+	if trimmedID == "" {
+		return "", errors.New("telegram file_id is required")
+	}
+
+	apiURL := fmt.Sprintf(
+		"https://api.telegram.org/bot%s/getFile?file_id=%s",
+		b.botToken,
+		url.QueryEscape(trimmedID),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create getFile request: %w", err)
+	}
+	resp, err := b.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to call getFile: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("telegram getFile returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed telegramGetFileResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("failed to parse getFile response: %w", err)
+	}
+	if !parsed.OK {
+		if parsed.Description != "" {
+			return "", fmt.Errorf("telegram getFile failed: %s", parsed.Description)
+		}
+		return "", errors.New("telegram getFile failed")
+	}
+	filePath := strings.TrimSpace(parsed.Result.FilePath)
+	if filePath == "" {
+		return "", errors.New("telegram getFile response missing file_path")
+	}
+	return fmt.Sprintf(
+		"https://api.telegram.org/file/bot%s/%s",
+		b.botToken,
+		strings.TrimLeft(filePath, "/"),
+	), nil
+}
+
+func largestTelegramPhoto(photos []TelegramPhotoSize) *TelegramPhotoSize {
+	if len(photos) == 0 {
+		return nil
+	}
+	bestIdx := 0
+	for i := 1; i < len(photos); i += 1 {
+		current := photos[i]
+		best := photos[bestIdx]
+		currentScore := current.FileSize
+		bestScore := best.FileSize
+		if currentScore == bestScore {
+			currentScore = int64(current.Width * current.Height)
+			bestScore = int64(best.Width * best.Height)
+		}
+		if currentScore > bestScore {
+			bestIdx = i
+		}
+	}
+	return &photos[bestIdx]
+}
+
+func telegramAttachmentType(mimeType, fileName string) string {
+	mime := strings.ToLower(strings.TrimSpace(mimeType))
+	switch {
+	case strings.HasPrefix(mime, "image/"):
+		return "image"
+	case strings.HasPrefix(mime, "video/"):
+		return "video"
+	case strings.HasPrefix(mime, "audio/"):
+		return "audio"
+	}
+
+	lowerName := strings.ToLower(strings.TrimSpace(fileName))
+	switch {
+	case strings.HasSuffix(lowerName, ".png"),
+		strings.HasSuffix(lowerName, ".jpg"),
+		strings.HasSuffix(lowerName, ".jpeg"),
+		strings.HasSuffix(lowerName, ".gif"),
+		strings.HasSuffix(lowerName, ".webp"),
+		strings.HasSuffix(lowerName, ".bmp"),
+		strings.HasSuffix(lowerName, ".svg"):
+		return "image"
+	case strings.HasSuffix(lowerName, ".mp4"),
+		strings.HasSuffix(lowerName, ".mov"),
+		strings.HasSuffix(lowerName, ".avi"),
+		strings.HasSuffix(lowerName, ".mkv"),
+		strings.HasSuffix(lowerName, ".webm"):
+		return "video"
+	case strings.HasSuffix(lowerName, ".mp3"),
+		strings.HasSuffix(lowerName, ".wav"),
+		strings.HasSuffix(lowerName, ".m4a"),
+		strings.HasSuffix(lowerName, ".ogg"),
+		strings.HasSuffix(lowerName, ".flac"),
+		strings.HasSuffix(lowerName, ".aac"):
+		return "audio"
+	default:
+		return "file"
+	}
+}
+
+func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent string, attachments []protocol.Attachment) *protocol.Message {
+	data := map[string]interface{}{
+		"channel":  "telegram",
+		"text":     text,
+		"agent":    agent,
+		"chat_id":  msg.Chat.ID,
+		"chatType": msg.Chat.Type,
+		"user_id":  msg.From.ID,
+		"username": msg.From.UserName,
+	}
+	if len(attachments) > 0 {
+		data["attachments"] = attachments
+	}
 	return &protocol.Message{
-		Kind:   protocol.MessageKindChannel,
-		Action: protocol.ActionCreate,
-		Data: map[string]interface{}{
-			"channel":  "telegram",
-			"text":     text,
-			"agent":    agent,
-			"chat_id":  msg.Chat.ID,
-			"chatType": msg.Chat.Type,
-			"user_id":  msg.From.ID,
-			"username": msg.From.UserName,
-		},
+		Kind:        protocol.MessageKindChannel,
+		Action:      protocol.ActionCreate,
+		Data:        data,
+		Attachments: attachments,
 	}
 }
 

--- a/internal/channels/telegram_attachments_test.go
+++ b/internal/channels/telegram_attachments_test.go
@@ -1,0 +1,182 @@
+package channels
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type captureTelegramInboundHandler struct {
+	called bool
+	last   *protocol.Message
+}
+
+func (h *captureTelegramInboundHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	_ = ctx
+	h.called = true
+	h.last = msg
+	return "", nil
+}
+
+func TestTelegramDocumentAttachmentIncludedInProtocolMessage(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	bot.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if !strings.Contains(req.URL.Path, "/getFile") {
+				t.Fatalf("unexpected request path %q", req.URL.Path)
+			}
+			if req.URL.Query().Get("file_id") != "doc123" {
+				t.Fatalf("file_id=%q", req.URL.Query().Get("file_id"))
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(
+					`{"ok":true,"result":{"file_id":"doc123","file_path":"documents/test.pdf"}}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		}),
+	}
+
+	handler := &captureTelegramInboundHandler{}
+	bot.SetHandler(handler)
+
+	bot.handleIncomingMessage(&TelegramMessage{
+		Text: "/agent qa-1 process this file",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55, Type: "private"},
+		Document: &TelegramDocument{
+			FileID:   "doc123",
+			FileName: "test.pdf",
+			MimeType: "application/pdf",
+		},
+	})
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if handler.last == nil || len(handler.last.Attachments) != 1 {
+		t.Fatalf("attachments=%v", handler.last.Attachments)
+	}
+	attachment := handler.last.Attachments[0]
+	if attachment.Type != "file" {
+		t.Fatalf("attachment.type=%q", attachment.Type)
+	}
+	if attachment.URL != "https://api.telegram.org/file/bottoken/documents/test.pdf" {
+		t.Fatalf("attachment.url=%q", attachment.URL)
+	}
+	if attachment.Filename != "test.pdf" {
+		t.Fatalf("attachment.filename=%q", attachment.Filename)
+	}
+	data, ok := handler.last.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", handler.last.Data)
+	}
+	dataAttachments, ok := data["attachments"].([]protocol.Attachment)
+	if !ok || len(dataAttachments) != 1 {
+		t.Fatalf("data attachments=%v", data["attachments"])
+	}
+}
+
+func TestTelegramPhotoAttachmentUsesLargestPhoto(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	requestedFileIDs := make([]string, 0, 2)
+	bot.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if !strings.Contains(req.URL.Path, "/getFile") {
+				t.Fatalf("unexpected request path %q", req.URL.Path)
+			}
+			fileID := req.URL.Query().Get("file_id")
+			requestedFileIDs = append(requestedFileIDs, fileID)
+			if fileID != "large-photo-id" {
+				t.Fatalf("expected only large photo file_id, got %q", fileID)
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(
+					`{"ok":true,"result":{"file_id":"large-photo-id","file_path":"photos/large.jpg"}}`,
+				)),
+				Header: make(http.Header),
+			}, nil
+		}),
+	}
+
+	handler := &captureTelegramInboundHandler{}
+	bot.SetHandler(handler)
+
+	bot.handleIncomingMessage(&TelegramMessage{
+		Text: "/agent qa-1 analyze image",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55, Type: "private"},
+		Photo: []TelegramPhotoSize{
+			{FileID: "small-photo-id", Width: 100, Height: 100, FileSize: 1024},
+			{FileID: "large-photo-id", Width: 1200, Height: 1200, FileSize: 4096},
+		},
+	})
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if len(requestedFileIDs) != 1 {
+		t.Fatalf("requestedFileIDs=%v", requestedFileIDs)
+	}
+	if len(handler.last.Attachments) != 1 {
+		t.Fatalf("attachments=%v", handler.last.Attachments)
+	}
+	if handler.last.Attachments[0].Type != "image" {
+		t.Fatalf("attachment.type=%q", handler.last.Attachments[0].Type)
+	}
+}
+
+func TestTelegramAttachmentResolutionFailureDoesNotBlockMessage(t *testing.T) {
+	bot, err := NewTelegramBot("token", []int64{123}, 0, "qa-1", []string{"qa-1"})
+	if err != nil {
+		t.Fatalf("NewTelegramBot: %v", err)
+	}
+
+	bot.httpClient = &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if !strings.Contains(req.URL.Path, "/getFile") {
+				t.Fatalf("unexpected request path %q", req.URL.Path)
+			}
+			return &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader(`{"ok":false,"description":"boom"}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	handler := &captureTelegramInboundHandler{}
+	bot.SetHandler(handler)
+
+	bot.handleIncomingMessage(&TelegramMessage{
+		Text: "/agent qa-1 continue",
+		From: &TelegramUser{ID: 123},
+		Chat: &TelegramChat{ID: 55, Type: "private"},
+		Document: &TelegramDocument{
+			FileID:   "doc123",
+			FileName: "test.pdf",
+			MimeType: "application/pdf",
+		},
+	})
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if len(handler.last.Attachments) != 0 {
+		t.Fatalf("expected no attachments on getFile failure, got %v", handler.last.Attachments)
+	}
+}

--- a/pkg/protocol/message.go
+++ b/pkg/protocol/message.go
@@ -25,10 +25,20 @@ const (
 
 // Message represents a protocol message
 type Message struct {
-	Kind   MessageKind `json:"kind"`
-	Action Action      `json:"action,omitempty"`
-	Data   interface{} `json:"data,omitempty"`
-	Error  string      `json:"error,omitempty"`
+	Kind        MessageKind  `json:"kind"`
+	Action      Action       `json:"action,omitempty"`
+	Data        interface{}  `json:"data,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
+	Error       string       `json:"error,omitempty"`
+}
+
+// Attachment represents a file/image/video/audio attachment passed through protocol.
+type Attachment struct {
+	Type     string `json:"type"`
+	Filename string `json:"filename"`
+	URL      string `json:"url"`
+	Channel  string `json:"channel"`
+	MimeType string `json:"mimeType,omitempty"`
 }
 
 // AgentInfo contains information about an agent


### PR DESCRIPTION
## Summary
- add protocol-level attachment support via `protocol.Attachment` and `Message.Attachments`
- extract Slack inbound file attachments (`url_private` / `url_private_download`, filename, mimetype, inferred type) and pass them through protocol messages
- extract Telegram inbound attachments from `photo[]` and `document` by resolving `file_id` through `getFile`, then constructing downloadable URLs
- add CLI command: `fractalbot file download --channel <slack|telegram> --url <url> --output <path>`
  - Slack downloads use `Authorization: Bearer <botToken>` from config
  - Telegram downloads use direct URL fetch

## Verification
- `go test ./internal/channels/ -v`
- `TMPDIR=/private/var/tmp go test ./... -v`
- `go build ./...`

Closes #299
