### PR TITLE
fix(slack): allow file_share subtype through inbound filter

### DIFF
--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -979,7 +979,7 @@ func slackMessageFromEvent(event *slackevents.MessageEvent) *slackInboundMessage
 	if event == nil {
 		return nil
 	}
-	if event.SubType != "" {
+	if event.SubType != "" && event.SubType != "file_share" {
 		return nil
 	}
 	if event.BotID != "" {


### PR DESCRIPTION
## Summary
- `slackMessageFromEvent` was dropping all messages with non-empty `SubType`, including `file_share` events
- This caused Slack file/image uploads to be silently discarded before reaching agents
- Fix: allow `file_share` subtype through the filter so attachments (extracted by PR #301) actually reach the task prompt (rendered by PR #305)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/channels/ -v` — all Slack tests pass
- [x] Local service rebuilt and restarted, health OK
- [ ] Manual test: send screenshot in Slack DM, verify agent receives attachment info