### PR TITLE
fix: iMessage inbound routing and status visibility

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,6 +86,14 @@ channels:
     allowedUsers:
       - "123456789012345678"
 
+  # iMessage channel configuration (macOS only, optional)
+  imessage:
+    enabled: true
+    recipient: "+1234567890"
+    pollingEnabled: true
+    pollingIntervalSeconds: 5
+    pollingLimit: 20
+
 agents:
   # Workspace directory for agent sessions
   workspace: ./workspace

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -99,7 +99,7 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 	}
 
 	channel, _ := data["channel"].(string)
-	if channel != "telegram" && channel != "feishu" && channel != "slack" && channel != "discord" {
+	if channel != "telegram" && channel != "feishu" && channel != "slack" && channel != "discord" && channel != "imessage" {
 		return "", nil
 	}
 

--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -327,6 +327,8 @@ func (b *IMessageBot) toProtocolMessage(inbound IMessageInbound) *protocol.Messa
 			"channel":     "imessage",
 			"text":        inbound.Text,
 			"agent":       "",
+			"chat_id":     inbound.Sender,
+			"user_id":     inbound.Sender,
 			"sender":      inbound.Sender,
 			"message_id":  inbound.MessageID,
 			"timestamp":   inbound.Timestamp.UTC().Format(time.RFC3339),

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -369,7 +369,7 @@ func (s *Server) channelStatus() []channelStatus {
 		return nil
 	}
 
-	statuses := make([]channelStatus, 0, 3)
+	statuses := make([]channelStatus, 0, 5)
 	getChannel := func(name string) channels.Channel {
 		if s.agentManager == nil || s.agentManager.ChannelManager == nil {
 			return nil
@@ -442,6 +442,17 @@ func (s *Server) channelStatus() []channelStatus {
 		statuses = append(statuses, channelStatus{
 			Name:         "discord",
 			Enabled:      s.config.Channels.Discord.Enabled,
+			Running:      isRunning(ch),
+			LastError:    lastError,
+			LastActivity: lastActivity,
+		})
+	}
+	if s.config.Channels.IMessage != nil {
+		ch := getChannel("imessage")
+		lastError, lastActivity := telemetry(ch)
+		statuses = append(statuses, channelStatus{
+			Name:         "imessage",
+			Enabled:      s.config.Channels.IMessage.Enabled,
 			Running:      isRunning(ch),
 			LastError:    lastError,
 			LastActivity: lastActivity,


### PR DESCRIPTION
Fixes #308

## Summary
- allow `imessage` in `internal/agent/manager.go` inbound channel allowlist
- add iMessage to `/status` channel status output in `internal/gateway/server.go`
- include `chat_id` and `user_id` in iMessage protocol payload in `internal/channels/imessage.go`
- add iMessage section to `config.example.yaml`

## Verification
```bash
TMPDIR=/private/tmp go test ./...
go build ./cmd/fractalbot
```
