### PR TITLE
fix(imessage): preserve URLs from attributedBody

### DIFF
--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -1,6 +1,7 @@
 package channels
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -9,10 +10,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 	_ "modernc.org/sqlite"
@@ -30,12 +33,14 @@ const (
 )
 
 var currentGOOS = runtime.GOOS
+var iMessageURLRegexp = regexp.MustCompile(`https?://[^\s<>"'\\]+`)
 
 type iMessageSQLiteRow struct {
-	MessageID int64   `json:"message_id"`
-	Sender    string  `json:"sender"`
-	Text      string  `json:"text"`
-	Date      float64 `json:"date"`
+	MessageID      int64   `json:"message_id"`
+	Sender         string  `json:"sender"`
+	Text           string  `json:"text"`
+	AttributedBody []byte  `json:"attributed_body"`
+	Date           float64 `json:"date"`
 }
 
 // IMessageInbound represents a single inbound iMessage entry.
@@ -43,6 +48,7 @@ type IMessageInbound struct {
 	MessageID    int64
 	Sender       string
 	Text         string
+	URLs         []string
 	Timestamp    time.Time
 	RawTimestamp int64
 }
@@ -341,21 +347,26 @@ func (b *IMessageBot) pollOnce(ctx context.Context) {
 }
 
 func (b *IMessageBot) toProtocolMessage(inbound IMessageInbound) *protocol.Message {
+	data := map[string]interface{}{
+		"channel":     "imessage",
+		"text":        inbound.Text,
+		"agent":       "",
+		"chat_id":     inbound.Sender,
+		"user_id":     inbound.Sender,
+		"sender":      inbound.Sender,
+		"message_id":  inbound.MessageID,
+		"timestamp":   inbound.Timestamp.UTC().Format(time.RFC3339),
+		"chatType":    "dm",
+		"raw_message": inbound.RawTimestamp,
+	}
+	if len(inbound.URLs) > 0 {
+		data["urls"] = append([]string(nil), inbound.URLs...)
+	}
+
 	return &protocol.Message{
 		Kind:   protocol.MessageKindChannel,
 		Action: protocol.ActionCreate,
-		Data: map[string]interface{}{
-			"channel":     "imessage",
-			"text":        inbound.Text,
-			"agent":       "",
-			"chat_id":     inbound.Sender,
-			"user_id":     inbound.Sender,
-			"sender":      inbound.Sender,
-			"message_id":  inbound.MessageID,
-			"timestamp":   inbound.Timestamp.UTC().Format(time.RFC3339),
-			"chatType":    "dm",
-			"raw_message": inbound.RawTimestamp,
-		},
+		Data:   data,
 	}
 }
 
@@ -391,6 +402,7 @@ func (b *IMessageBot) readMessagesFromSQLite(ctx context.Context, sinceMessageID
 		m.ROWID AS message_id,
 		COALESCE(h.id, '') AS sender,
 		COALESCE(m.text, '') AS text,
+		m.attributedBody AS attributed_body,
 		m.date AS date
 	FROM message m
 	LEFT JOIN handle h ON m.handle_id = h.ROWID
@@ -408,11 +420,18 @@ func (b *IMessageBot) readMessagesFromSQLite(ctx context.Context, sinceMessageID
 	messages := []IMessageInbound{}
 	for rows.Next() {
 		var row iMessageSQLiteRow
-		if err := rows.Scan(&row.MessageID, &row.Sender, &row.Text, &row.Date); err != nil {
+		if err := rows.Scan(&row.MessageID, &row.Sender, &row.Text, &row.AttributedBody, &row.Date); err != nil {
 			return nil, fmt.Errorf("scan row: %w", err)
 		}
 
 		text := strings.TrimSpace(row.Text)
+		attributedText, attributedURLs := extractTextAndURLsFromAttributedBody(row.AttributedBody)
+		if text == "" {
+			text = attributedText
+		} else if !containsURL(text) && len(attributedURLs) > 0 {
+			text = mergeURLsIntoText(text, attributedURLs)
+		}
+		text = strings.TrimSpace(text)
 		if text == "" {
 			continue
 		}
@@ -421,6 +440,7 @@ func (b *IMessageBot) readMessagesFromSQLite(ctx context.Context, sinceMessageID
 			MessageID:    row.MessageID,
 			Sender:       strings.TrimSpace(row.Sender),
 			Text:         text,
+			URLs:         attributedURLs,
 			Timestamp:    appleTimestampToTime(rawTimestamp),
 			RawTimestamp: rawTimestamp,
 		})
@@ -641,6 +661,147 @@ func escapeAppleScriptString(value string) string {
 		"\r", ``,
 	)
 	return replacer.Replace(value)
+}
+
+func extractTextAndURLsFromAttributedBody(blob []byte) (string, []string) {
+	urls := extractURLsFromAttributedBody(blob)
+	text := extractReadableTextFromAttributedBody(blob)
+
+	if len(urls) > 0 {
+		if text == "" || looksLikeAttributedArchiveText(text) {
+			text = strings.Join(urls, "\n")
+		} else {
+			text = mergeURLsIntoText(text, urls)
+		}
+	}
+
+	return strings.TrimSpace(text), urls
+}
+
+func extractURLsFromAttributedBody(blob []byte) []string {
+	if len(blob) == 0 {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	urls := make([]string, 0, 2)
+	collect := func(input []byte) {
+		for _, match := range iMessageURLRegexp.FindAll(input, -1) {
+			normalized := normalizeExtractedURL(string(match))
+			if normalized == "" {
+				continue
+			}
+			if _, exists := seen[normalized]; exists {
+				continue
+			}
+			seen[normalized] = struct{}{}
+			urls = append(urls, normalized)
+		}
+	}
+
+	collect(blob)
+	if bytes.IndexByte(blob, 0x00) >= 0 {
+		collect(bytes.ReplaceAll(blob, []byte{0x00}, nil))
+	}
+
+	return urls
+}
+
+func normalizeExtractedURL(url string) string {
+	trimmed := strings.TrimSpace(url)
+	trimmed = strings.TrimRight(trimmed, ".,;:!?)]}\"'")
+	if strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://") {
+		return trimmed
+	}
+	return ""
+}
+
+func extractReadableTextFromAttributedBody(blob []byte) string {
+	if len(blob) == 0 {
+		return ""
+	}
+
+	withoutNulls := bytes.ReplaceAll(blob, []byte{0x00}, nil)
+	return normalizeAttributedText(string(withoutNulls))
+}
+
+func normalizeAttributedText(input string) string {
+	if input == "" {
+		return ""
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(input))
+	lastWasSpace := false
+	for _, r := range input {
+		switch {
+		case unicode.IsPrint(r):
+			builder.WriteRune(r)
+			lastWasSpace = false
+		case unicode.IsSpace(r):
+			if !lastWasSpace {
+				builder.WriteByte(' ')
+				lastWasSpace = true
+			}
+		}
+	}
+
+	normalized := strings.Join(strings.Fields(builder.String()), " ")
+	if len(normalized) < 3 {
+		return ""
+	}
+	return strings.TrimSpace(normalized)
+}
+
+func containsURL(text string) bool {
+	return iMessageURLRegexp.MatchString(text)
+}
+
+func mergeURLsIntoText(text string, urls []string) string {
+	trimmed := strings.TrimSpace(text)
+	if len(urls) == 0 {
+		return trimmed
+	}
+
+	merged := trimmed
+	for _, url := range urls {
+		if containsURLWithValue(merged, url) {
+			continue
+		}
+		if merged == "" {
+			merged = url
+		} else {
+			merged += "\n" + url
+		}
+	}
+
+	return strings.TrimSpace(merged)
+}
+
+func containsURLWithValue(text string, url string) bool {
+	for _, match := range iMessageURLRegexp.FindAllString(text, -1) {
+		if normalizeExtractedURL(match) == url {
+			return true
+		}
+	}
+	return false
+}
+
+func looksLikeAttributedArchiveText(text string) bool {
+	lower := strings.ToLower(text)
+	markers := []string{
+		"streamtyped",
+		"nskeyedarchiver",
+		"nsdictionary",
+		"nsstring",
+		"__kimmessage",
+	}
+	for _, marker := range markers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 func expandHomePath(path string) (string, error) {

--- a/internal/channels/imessage_test.go
+++ b/internal/channels/imessage_test.go
@@ -27,12 +27,13 @@ func (f *fakeIMessageHandler) HandleIncoming(ctx context.Context, msg *protocol.
 }
 
 type testIMessageRow struct {
-	rowID    int64
-	handleID int64
-	sender   string
-	isFromMe int
-	text     string
-	date     int64
+	rowID          int64
+	handleID       int64
+	sender         string
+	isFromMe       int
+	text           string
+	attributedBody []byte
+	date           int64
 }
 
 func createTestIMessageDB(t *testing.T, rows []testIMessageRow) string {
@@ -57,6 +58,7 @@ func createTestIMessageDB(t *testing.T, rows []testIMessageRow) string {
 		handle_id INTEGER,
 		is_from_me INTEGER,
 		text TEXT,
+		attributedBody BLOB,
 		date INTEGER
 	)`); err != nil {
 		t.Fatalf("create message table: %v", err)
@@ -69,11 +71,12 @@ func createTestIMessageDB(t *testing.T, rows []testIMessageRow) string {
 			}
 		}
 		if _, err := db.Exec(
-			`INSERT INTO message (ROWID, handle_id, is_from_me, text, date) VALUES (?, ?, ?, ?, ?)`,
+			`INSERT INTO message (ROWID, handle_id, is_from_me, text, attributedBody, date) VALUES (?, ?, ?, ?, ?, ?)`,
 			row.rowID,
 			row.handleID,
 			row.isFromMe,
 			row.text,
+			row.attributedBody,
 			row.date,
 		); err != nil {
 			t.Fatalf("insert message row: %v", err)
@@ -200,6 +203,85 @@ func TestIMessageBotPollMessagesFromSQLite(t *testing.T) {
 	}
 	if bot.getLastSeenMessageID() != 11 {
 		t.Fatalf("lastSeenMessageID=%d want 11", bot.getLastSeenMessageID())
+	}
+}
+
+func TestIMessageBotPollMessagesAppendsURLsFromAttributedBody(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	dbPath := createTestIMessageDB(t, []testIMessageRow{
+		{
+			rowID:          21,
+			handleID:       1,
+			sender:         "+123",
+			isFromMe:       0,
+			text:           "install this skill:",
+			attributedBody: []byte("binary\x00blob\x00https://github.com/fractalmind-ai/fractalbot"),
+			date:           785000000000000001,
+		},
+	})
+	bot.ConfigurePolling(true, 5, 10, dbPath)
+
+	msgs, err := bot.PollMessages(context.Background())
+	if err != nil {
+		t.Fatalf("PollMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs)=%d want 1", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Text, "install this skill:") {
+		t.Fatalf("expected original text, got %q", msgs[0].Text)
+	}
+	if !strings.Contains(msgs[0].Text, "https://github.com/fractalmind-ai/fractalbot") {
+		t.Fatalf("expected url in text, got %q", msgs[0].Text)
+	}
+	if len(msgs[0].URLs) != 1 || msgs[0].URLs[0] != "https://github.com/fractalmind-ai/fractalbot" {
+		t.Fatalf("unexpected urls: %v", msgs[0].URLs)
+	}
+}
+
+func TestIMessageBotPollMessagesFromURLOnlyAttributedBody(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("recipient@example.com", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	dbPath := createTestIMessageDB(t, []testIMessageRow{
+		{
+			rowID:          31,
+			handleID:       1,
+			sender:         "+999",
+			isFromMe:       0,
+			text:           "",
+			attributedBody: []byte("streamtyped\x00\x00https://example.com/tasks/314"),
+			date:           785000000000000001,
+		},
+	})
+	bot.ConfigurePolling(true, 5, 10, dbPath)
+
+	msgs, err := bot.PollMessages(context.Background())
+	if err != nil {
+		t.Fatalf("PollMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs)=%d want 1", len(msgs))
+	}
+	if msgs[0].Text != "https://example.com/tasks/314" {
+		t.Fatalf("unexpected text: %q", msgs[0].Text)
+	}
+	if len(msgs[0].URLs) != 1 || msgs[0].URLs[0] != "https://example.com/tasks/314" {
+		t.Fatalf("unexpected urls: %v", msgs[0].URLs)
 	}
 }
 


### PR DESCRIPTION
## Summary
- read `message.attributedBody` during iMessage inbound polling
- extract URLs from attributedBody blobs and merge missing links back into inbound text
- keep URL-only messages instead of dropping them, and expose extracted URLs in protocol data (`urls`)
- extend iMessage SQLite tests to cover URL extraction and URL-only attributedBody messages

## Verification
- `go test ./internal/channels/... -run IMessage`
- `go build ./cmd/fractalbot`

Fixes #314
