### PR TITLE
fix(slack): forward file attachments in message routing

### DIFF
--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -1018,10 +1018,22 @@ func slackMessageFromAppMentionEvent(event *slackevents.AppMentionEvent) *slackI
 }
 
 func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attachment {
-	if event == nil || event.Message == nil || len(event.Message.Files) == 0 {
+	if event == nil || event.Message == nil {
 		return nil
 	}
-	attachments := make([]protocol.Attachment, 0, len(event.Message.Files))
+	attachments := make([]protocol.Attachment, 0, len(event.Message.Files)+len(event.Message.Attachments))
+	seenURL := make(map[string]struct{})
+	appendAttachment := func(attachment protocol.Attachment) {
+		if attachment.URL == "" {
+			return
+		}
+		if _, exists := seenURL[attachment.URL]; exists {
+			return
+		}
+		seenURL[attachment.URL] = struct{}{}
+		attachments = append(attachments, attachment)
+	}
+
 	for _, file := range event.Message.Files {
 		url := strings.TrimSpace(file.URLPrivate)
 		if url == "" {
@@ -1037,7 +1049,7 @@ func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attac
 		if filename == "" {
 			filename = strings.TrimSpace(file.ID)
 		}
-		attachments = append(attachments, protocol.Attachment{
+		appendAttachment(protocol.Attachment{
 			Type:     slackAttachmentType(file.Mimetype, file.Filetype),
 			Filename: filename,
 			URL:      url,
@@ -1045,7 +1057,75 @@ func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attac
 			MimeType: strings.TrimSpace(file.Mimetype),
 		})
 	}
+
+	for _, legacy := range event.Message.Attachments {
+		url := slackLegacyAttachmentURL(legacy)
+		if url == "" {
+			continue
+		}
+		filename := strings.TrimSpace(legacy.Title)
+		if filename == "" {
+			filename = slackFilenameFromURL(url)
+		}
+		appendAttachment(protocol.Attachment{
+			Type:     slackAttachmentType("", slackFileTypeFromFilename(filename)),
+			Filename: filename,
+			URL:      url,
+			Channel:  "slack",
+		})
+	}
+
+	if len(attachments) == 0 {
+		return nil
+	}
 	return attachments
+}
+
+func slackLegacyAttachmentURL(attachment slack.Attachment) string {
+	candidates := []string{
+		attachment.TitleLink,
+		attachment.OriginalURL,
+		attachment.FromURL,
+		attachment.ImageURL,
+		attachment.ThumbURL,
+	}
+	for _, candidate := range candidates {
+		if value := strings.TrimSpace(candidate); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func slackFilenameFromURL(rawURL string) string {
+	trimmed := strings.TrimSpace(rawURL)
+	if trimmed == "" {
+		return ""
+	}
+	if idx := strings.Index(trimmed, "?"); idx >= 0 {
+		trimmed = trimmed[:idx]
+	}
+	trimmed = strings.TrimSuffix(trimmed, "/")
+	if trimmed == "" {
+		return ""
+	}
+	slash := strings.LastIndex(trimmed, "/")
+	if slash < 0 || slash == len(trimmed)-1 {
+		return ""
+	}
+	return strings.TrimSpace(trimmed[slash+1:])
+}
+
+func slackFileTypeFromFilename(filename string) string {
+	trimmed := strings.TrimSpace(filename)
+	if trimmed == "" {
+		return ""
+	}
+	dot := strings.LastIndex(trimmed, ".")
+	if dot < 0 || dot == len(trimmed)-1 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(trimmed[dot+1:]))
 }
 
 func slackAttachmentType(mimeType, fileType string) string {

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -1321,6 +1321,115 @@ func TestSlackMessageFromEventIncludesAttachments(t *testing.T) {
 	if msg.attachments[1].URL != "https://files.slack.com/files-pri/T/F_DOC/download" {
 		t.Fatalf("attachment[1].url=%q", msg.attachments[1].URL)
 	}
+	if msg.attachments[1].Filename != "report.pdf" {
+		t.Fatalf("attachment[1].filename=%q", msg.attachments[1].Filename)
+	}
+	if msg.attachments[1].MimeType != "application/pdf" {
+		t.Fatalf("attachment[1].mimeType=%q", msg.attachments[1].MimeType)
+	}
+}
+
+func TestSlackMessageFromEventIncludesLegacyAttachmentLinks(t *testing.T) {
+	msg := slackMessageFromEvent(&slackevents.MessageEvent{
+		User:        "U123",
+		Channel:     "D456",
+		ChannelType: "im",
+		Text:        "please check this file",
+		Message: &slack.Msg{
+			Attachments: []slack.Attachment{
+				{
+					Title:     "product-spec.docx",
+					TitleLink: "https://files.slack.com/files-pri/T/F_DOC/product-spec.docx?download=1",
+				},
+			},
+		},
+	})
+	if msg == nil {
+		t.Fatalf("expected parsed inbound message")
+	}
+	if len(msg.attachments) != 1 {
+		t.Fatalf("attachments=%v", msg.attachments)
+	}
+	if msg.attachments[0].Filename != "product-spec.docx" {
+		t.Fatalf("attachment.filename=%q", msg.attachments[0].Filename)
+	}
+	if msg.attachments[0].URL != "https://files.slack.com/files-pri/T/F_DOC/product-spec.docx?download=1" {
+		t.Fatalf("attachment.url=%q", msg.attachments[0].URL)
+	}
+	if msg.attachments[0].MimeType != "" {
+		t.Fatalf("attachment.mimeType=%q", msg.attachments[0].MimeType)
+	}
+}
+
+func TestSlackHandleMessageEventForwardsAttachmentsToHandler(t *testing.T) {
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+
+	var sent slackSendCapture
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		_ = ctx
+		sent = slackSendCapture{channelID: channelID, text: text}
+		return nil
+	}
+
+	handler := &fakeSlackHandler{reply: "ok"}
+	bot.SetHandler(handler)
+
+	msg := slackMessageFromEvent(&slackevents.MessageEvent{
+		User:        "U123",
+		Channel:     "D456",
+		ChannelType: "im",
+		Text:        "please read attachment",
+		Message: &slack.Msg{
+			Files: []slack.File{
+				{
+					ID:         "F_DOC",
+					Name:       "requirements.docx",
+					Mimetype:   "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+					Filetype:   "docx",
+					URLPrivate: "https://files.slack.com/files-pri/T/F_DOC",
+				},
+			},
+		},
+	})
+	if msg == nil {
+		t.Fatalf("expected parsed inbound message")
+	}
+
+	bot.handleMessageEvent(context.Background(), msg)
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if sent.text != "ok" {
+		t.Fatalf("expected reply ok, got %q", sent.text)
+	}
+	if len(handler.last.Attachments) != 1 {
+		t.Fatalf("protocol attachments=%v", handler.last.Attachments)
+	}
+	if handler.last.Attachments[0].Filename != "requirements.docx" {
+		t.Fatalf("protocol attachment filename=%q", handler.last.Attachments[0].Filename)
+	}
+	if handler.last.Attachments[0].URL != "https://files.slack.com/files-pri/T/F_DOC" {
+		t.Fatalf("protocol attachment url=%q", handler.last.Attachments[0].URL)
+	}
+	if handler.last.Attachments[0].MimeType != "application/vnd.openxmlformats-officedocument.wordprocessingml.document" {
+		t.Fatalf("protocol attachment mimeType=%q", handler.last.Attachments[0].MimeType)
+	}
+
+	data, ok := handler.last.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", handler.last.Data)
+	}
+	dataAttachments, ok := data["attachments"].([]protocol.Attachment)
+	if !ok {
+		t.Fatalf("expected typed data attachments, got %T", data["attachments"])
+	}
+	if len(dataAttachments) != 1 {
+		t.Fatalf("data attachments=%v", dataAttachments)
+	}
 }
 
 func TestSlackMessageFromAppMentionEventIncludesThreadTS(t *testing.T) {


### PR DESCRIPTION
## Summary
- Extend Slack attachment extraction to include both:
  - `message.files` (existing Slack file metadata)
  - `message.attachments` link-based legacy payloads (TitleLink / OriginalURL / FromURL / ImageURL / ThumbURL)
- Deduplicate attachment entries by URL before forwarding
- Keep forwarding format in `protocol.Message.Attachments` unchanged (`filename`, `url`, `mimeType`, etc.)
- Add stronger unit coverage:
  - validates filename/url/mimeType extraction for Slack files
  - validates extraction from legacy `message.attachments`
  - validates end-to-end forwarding to handler includes `attachments[]`

## Why
Some Slack messages carry file/link metadata via legacy `message.attachments` instead of `message.files`. Those were previously dropped, causing attachment loss in agent routing.

## Validation
- `go test ./internal/channels -run Slack -count=1`
- `go test ./...`

Closes #318
