### PR TITLE
fix: isolate channel contexts to prevent cascade failures #284

### DIFF
--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -86,6 +86,9 @@ func (m *Manager) List() []Channel {
 }
 
 // Start starts configured channels.
+// Each channel gets an independent context (not derived from the parent) so
+// that a crash or context cancellation in one channel cannot cascade to others.
+// The parent ctx is only used to trigger graceful shutdown of all channels.
 func (m *Manager) Start(ctx context.Context) error {
 	if err := m.registerConfiguredChannels(); err != nil {
 		return err
@@ -99,7 +102,8 @@ func (m *Manager) Start(ctx context.Context) error {
 		if m.hasInFlightStart(name) {
 			continue
 		}
-		channelCtx, cancel := context.WithCancel(ctx)
+		// Independent context per channel — isolates crash/cancel from other channels.
+		channelCtx, cancel := context.WithCancel(context.Background())
 		m.trackInFlightStart(name, cancel)
 		go m.startChannel(name, channel, channelCtx)
 	}
@@ -130,6 +134,11 @@ func (m *Manager) Stop() error {
 
 func (m *Manager) startChannel(name string, channel Channel, ctx context.Context) {
 	defer m.clearInFlightStart(name)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("channel %s panicked: %v", name, r)
+		}
+	}()
 	if err := channel.Start(ctx); err != nil {
 		log.Printf("channel %s failed to start: %v", name, err)
 	}

--- a/internal/channels/manager_test.go
+++ b/internal/channels/manager_test.go
@@ -186,3 +186,135 @@ func waitForCondition(t *testing.T, timeout time.Duration, fn func() bool) {
 	}
 	t.Fatalf("condition not met before timeout (%s)", timeout)
 }
+
+func TestManagerStartUsesIndependentContexts(t *testing.T) {
+	// When the parent context is canceled, channels with independent contexts
+	// should NOT have their contexts canceled automatically. They should only
+	// stop when Stop() is called explicitly.
+	manager := NewManager(nil, nil)
+	ctxObserved := make(chan struct{})
+	ch := &contextObservingChannel{
+		name:       "observer",
+		ctxDoneCh:  ctxObserved,
+		startedCh:  make(chan struct{}),
+	}
+
+	if err := manager.Register(ch); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	parentCtx, parentCancel := context.WithCancel(context.Background())
+	if err := manager.Start(parentCtx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Wait for the channel to start
+	select {
+	case <-ch.startedCh:
+	case <-time.After(time.Second):
+		t.Fatalf("channel did not start in time")
+	}
+
+	// Cancel the parent context — channel should NOT be affected
+	parentCancel()
+
+	// Give it a moment to propagate (if it were a child, it would be canceled)
+	select {
+	case <-ctxObserved:
+		t.Fatalf("channel context was canceled when parent was canceled — contexts are not isolated")
+	case <-time.After(100 * time.Millisecond):
+		// Good — channel context was NOT canceled
+	}
+
+	// Now explicitly stop — this should cancel the channel
+	if err := manager.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+func TestManagerStartChannelPanicRecovery(t *testing.T) {
+	manager := NewManager(nil, nil)
+	good := &fakeChannel{name: "good"}
+	panicking := &panickingChannel{name: "panicky", panicDone: make(chan struct{})}
+
+	if err := manager.Register(good); err != nil {
+		t.Fatalf("register good: %v", err)
+	}
+	if err := manager.Register(panicking); err != nil {
+		t.Fatalf("register panicky: %v", err)
+	}
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	// Wait for both channels to attempt start
+	waitForCondition(t, time.Second, func() bool {
+		return good.started == 1
+	})
+
+	select {
+	case <-panicking.panicDone:
+	case <-time.After(time.Second):
+		t.Fatalf("panicking channel did not run")
+	}
+
+	// Good channel should still be running despite the other panicking
+	if !good.running {
+		t.Fatalf("expected good channel to be running after sibling panic")
+	}
+
+	if err := manager.Stop(); err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+}
+
+// contextObservingChannel blocks on Start until its context is canceled,
+// and signals on ctxDoneCh when that happens.
+type contextObservingChannel struct {
+	name      string
+	ctxDoneCh chan struct{}
+	startedCh chan struct{}
+	running   bool
+}
+
+func (c *contextObservingChannel) Name() string { return c.name }
+
+func (c *contextObservingChannel) Start(ctx context.Context) error {
+	c.running = true
+	close(c.startedCh)
+	<-ctx.Done()
+	close(c.ctxDoneCh)
+	c.running = false
+	return ctx.Err()
+}
+
+func (c *contextObservingChannel) Stop() error {
+	c.running = false
+	return nil
+}
+
+func (c *contextObservingChannel) SendMessage(ctx context.Context, target string, text string) error {
+	return nil
+}
+
+func (c *contextObservingChannel) IsRunning() bool { return c.running }
+
+// panickingChannel panics during Start to test panic recovery.
+type panickingChannel struct {
+	name      string
+	panicDone chan struct{}
+}
+
+func (p *panickingChannel) Name() string { return p.name }
+
+func (p *panickingChannel) Start(ctx context.Context) error {
+	defer close(p.panicDone)
+	panic("test panic in channel start")
+}
+
+func (p *panickingChannel) Stop() error              { return nil }
+func (p *panickingChannel) IsRunning() bool           { return false }
+func (p *panickingChannel) SendMessage(ctx context.Context, target string, text string) error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- Channel contexts are now independent (derived from `context.Background()` instead of the parent shutdown context), preventing one channel's crash from cascading to others
- Added panic recovery in `startChannel` goroutines so a panic in one channel's `Start()` does not crash the entire process
- Shutdown still works correctly: `Manager.Stop()` explicitly cancels in-flight starts and calls `Stop()` on each running channel

Closes #284

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing + 2 new tests)
- [ ] New test `TestManagerStartUsesIndependentContexts` verifies canceling the parent context does NOT cancel channel contexts
- [ ] New test `TestManagerStartChannelPanicRecovery` verifies a panic in one channel does not affect sibling channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)