### PR TITLE
fix(slack): extract file attachments from raw event JSON #320

### DIFF
--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -2,6 +2,7 @@ package channels
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
@@ -379,6 +380,7 @@ func (b *SlackBot) handleEventsAPIEvent(ctx context.Context, event slackevents.E
 	}
 	switch ev := event.InnerEvent.Data.(type) {
 	case *slackevents.MessageEvent:
+		fixupSlackMessageEventFiles(ev, event)
 		msg := slackMessageFromEvent(ev)
 		if msg == nil {
 			return
@@ -1014,6 +1016,37 @@ func slackMessageFromAppMentionEvent(event *slackevents.AppMentionEvent) *slackI
 		channelID:   event.Channel,
 		channelType: "app_mention",
 		threadTS:    event.ThreadTimeStamp,
+	}
+}
+
+// fixupSlackMessageEventFiles works around a bug in the slack-go library's
+// custom UnmarshalJSON for MessageEvent. When Slack sends a message event with
+// files at the top level AND a "message" key (even if empty), the custom
+// unmarshaller sees Message != nil and skips populating Files from the top
+// level. This function re-parses files from the raw inner event JSON when
+// Message.Files is empty.
+func fixupSlackMessageEventFiles(ev *slackevents.MessageEvent, apiEvent slackevents.EventsAPIEvent) {
+	if ev == nil || ev.Message == nil {
+		return
+	}
+	if len(ev.Message.Files) > 0 || len(ev.Message.Attachments) > 0 {
+		return // already has file data
+	}
+
+	cbEvent, ok := apiEvent.Data.(*slackevents.EventsAPICallbackEvent)
+	if !ok || cbEvent == nil || cbEvent.InnerEvent == nil {
+		return
+	}
+
+	var msg slack.Msg
+	if err := json.Unmarshal(*cbEvent.InnerEvent, &msg); err != nil {
+		return
+	}
+	if len(msg.Files) > 0 {
+		ev.Message.Files = msg.Files
+	}
+	if len(msg.Attachments) > 0 {
+		ev.Message.Attachments = msg.Attachments
 	}
 }
 

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -2,6 +2,7 @@ package channels
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -1612,5 +1613,186 @@ func TestSlackSendTextWithOptionsPostsThreadTS(t *testing.T) {
 	}
 	if receivedThreadTS != "1234567890.123456" {
 		t.Fatalf("thread_ts=%q", receivedThreadTS)
+	}
+}
+
+func TestSlackEventsParseMessageWithFilesViaJSON(t *testing.T) {
+	// This test simulates the actual parsing path that socket mode uses.
+	// It verifies that files at the top level of a message event are correctly
+	// populated into event.Message.Files by the custom UnmarshalJSON.
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "message",
+			"text": "check this doc",
+			"user": "U123",
+			"channel": "D456",
+			"channel_type": "im",
+			"ts": "1234567890.123456",
+			"files": [
+				{
+					"id": "F123",
+					"name": "report.docx",
+					"mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+					"filetype": "docx",
+					"url_private": "https://files.slack.com/files-pri/T123-F123/report.docx"
+				}
+			]
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	msgEvent, ok := event.InnerEvent.Data.(*slackevents.MessageEvent)
+	if !ok {
+		t.Fatalf("expected *MessageEvent, got %T", event.InnerEvent.Data)
+	}
+
+	// Check if custom unmarshaller populated Message
+	if msgEvent.Message == nil {
+		t.Fatalf("Message is nil — custom UnmarshalJSON did not populate it")
+	}
+
+	// Check if files were extracted from top-level JSON into Message.Files
+	if len(msgEvent.Message.Files) == 0 {
+		t.Fatalf("Message.Files is empty — files not parsed from event JSON")
+	}
+
+	if msgEvent.Message.Files[0].URLPrivate != "https://files.slack.com/files-pri/T123-F123/report.docx" {
+		t.Fatalf("URLPrivate=%q", msgEvent.Message.Files[0].URLPrivate)
+	}
+
+	// Verify our slackAttachmentsFromEvent function works end-to-end
+	attachments := slackAttachmentsFromEvent(msgEvent)
+	if len(attachments) == 0 {
+		t.Fatalf("slackAttachmentsFromEvent returned no attachments")
+	}
+	if attachments[0].URL != "https://files.slack.com/files-pri/T123-F123/report.docx" {
+		t.Fatalf("attachment.URL=%q", attachments[0].URL)
+	}
+	if attachments[0].Filename != "report.docx" {
+		t.Fatalf("attachment.Filename=%q", attachments[0].Filename)
+	}
+}
+
+func TestSlackEventsParseMessageWithFilesAndEmptyMessageField(t *testing.T) {
+	// This test reproduces a scenario where Slack sends a message event with
+	// files at the top level AND an empty "message" field. The custom
+	// UnmarshalJSON on MessageEvent sees Message != nil and skips populating
+	// Files from the top level. fixupSlackMessageEventFiles corrects this.
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "message",
+			"text": "check this doc",
+			"user": "U123",
+			"channel": "D456",
+			"channel_type": "im",
+			"ts": "1234567890.123456",
+			"files": [
+				{
+					"id": "F123",
+					"name": "report.docx",
+					"mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+					"filetype": "docx",
+					"url_private": "https://files.slack.com/files-pri/T123-F123/report.docx"
+				}
+			],
+			"message": {}
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	msgEvent, ok := event.InnerEvent.Data.(*slackevents.MessageEvent)
+	if !ok {
+		t.Fatalf("expected *MessageEvent, got %T", event.InnerEvent.Data)
+	}
+
+	// Before fixup: Message.Files should be empty due to UnmarshalJSON behavior
+	if len(msgEvent.Message.Files) != 0 {
+		t.Fatalf("expected empty Files before fixup, got %d", len(msgEvent.Message.Files))
+	}
+
+	// Apply the fixup
+	fixupSlackMessageEventFiles(msgEvent, event)
+
+	// After fixup: Message.Files should be populated from raw JSON
+	if len(msgEvent.Message.Files) == 0 {
+		t.Fatalf("expected Files to be populated after fixup")
+	}
+	if msgEvent.Message.Files[0].URLPrivate != "https://files.slack.com/files-pri/T123-F123/report.docx" {
+		t.Fatalf("URLPrivate=%q", msgEvent.Message.Files[0].URLPrivate)
+	}
+
+	// Verify slackAttachmentsFromEvent works after fixup
+	attachments := slackAttachmentsFromEvent(msgEvent)
+	if len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(attachments))
+	}
+	if attachments[0].Filename != "report.docx" {
+		t.Fatalf("attachment.Filename=%q", attachments[0].Filename)
+	}
+	if attachments[0].URL != "https://files.slack.com/files-pri/T123-F123/report.docx" {
+		t.Fatalf("attachment.URL=%q", attachments[0].URL)
+	}
+}
+
+func TestSlackFixupDoesNotOverrideExistingFiles(t *testing.T) {
+	// When Message.Files already has data, fixup should not replace it.
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "message",
+			"text": "hello",
+			"user": "U123",
+			"channel": "D456",
+			"channel_type": "im",
+			"ts": "1234567890.123456",
+			"files": [
+				{
+					"id": "F_TOP",
+					"name": "top-level.docx",
+					"url_private": "https://files.slack.com/top"
+				}
+			]
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	msgEvent := event.InnerEvent.Data.(*slackevents.MessageEvent)
+
+	// For a message without "message" key, custom unmarshaller copies files correctly
+	if len(msgEvent.Message.Files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(msgEvent.Message.Files))
+	}
+
+	// Fixup should be a no-op since files already exist
+	fixupSlackMessageEventFiles(msgEvent, event)
+
+	if len(msgEvent.Message.Files) != 1 {
+		t.Fatalf("expected 1 file after fixup, got %d", len(msgEvent.Message.Files))
+	}
+	if msgEvent.Message.Files[0].ID != "F_TOP" {
+		t.Fatalf("file ID=%q, expected F_TOP", msgEvent.Message.Files[0].ID)
 	}
 }


### PR DESCRIPTION
## Summary
- Root cause: slack-go library's custom `UnmarshalJSON` for `MessageEvent` skips populating `Message.Files` when the event JSON contains an empty `"message"` key alongside top-level `"files"`. The unmarshaller sees `Message != nil` and doesn't fall through to copy file data from the top level.
- Fix: Added `fixupSlackMessageEventFiles()` which re-parses the raw inner event JSON from `EventsAPICallbackEvent.InnerEvent` when `Message.Files` is empty, recovering the file metadata that was lost during unmarshalling.
- The fixup is a no-op when files are already correctly populated (normal case).

Closes #320

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all existing + 3 new tests)
- [ ] New test `TestSlackEventsParseMessageWithFilesViaJSON` verifies normal JSON parsing path works
- [ ] New test `TestSlackEventsParseMessageWithFilesAndEmptyMessageField` reproduces the bug and verifies the fixup corrects it
- [ ] New test `TestSlackFixupDoesNotOverrideExistingFiles` verifies the fixup doesn't interfere when files are already present

🤖 Generated with [Claude Code](https://claude.com/claude-code)