### PR TITLE
fix(slack): resolve @mentions to <@USERID> in outbound messages #321

### DIFF
--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -57,6 +58,11 @@ type SlackBot struct {
 	telemetryMu  sync.RWMutex
 	lastActivity time.Time
 	lastError    time.Time
+
+	userDirMu      sync.RWMutex
+	userDir        map[string]string // lowercase name → user ID
+	userDirUpdated time.Time
+	resolveUsersFn func(ctx context.Context) ([]slack.User, error)
 }
 
 func NewSlackBot(botToken, appToken string, allowedUsers []string, allowedChannels []string, defaultAgent string, allowedAgents []string) (*SlackBot, error) {
@@ -881,8 +887,9 @@ func (b *SlackBot) sendTextWithOptions(ctx context.Context, channelID, text stri
 		b.markError()
 		return errors.New("slack channel ID is required")
 	}
+	resolved := b.resolveSlackMentions(ctx, text)
 	msgOptions := []slack.MsgOption{
-		slack.MsgOptionText(text, false),
+		slack.MsgOptionText(resolved, false),
 	}
 	if strings.TrimSpace(opts.ThreadTS) != "" {
 		msgOptions = append(msgOptions, slack.MsgOptionTS(strings.TrimSpace(opts.ThreadTS)))
@@ -1183,6 +1190,97 @@ func slackAttachmentType(mimeType, fileType string) string {
 	default:
 		return "file"
 	}
+}
+
+// slackMentionRe matches @username patterns that are NOT already inside <@...>
+// brackets and NOT part of an email address (preceded by a non-whitespace char).
+var slackMentionRe = regexp.MustCompile(`(^|[\s(])@(\w[\w.-]*)`)
+
+const userDirTTL = 30 * time.Minute
+
+// refreshUserDirectory populates the user directory cache from the Slack API.
+func (b *SlackBot) refreshUserDirectory(ctx context.Context) {
+	fetchFn := b.resolveUsersFn
+	if fetchFn == nil {
+		if b.apiClient == nil {
+			return
+		}
+		fetchFn = func(ctx context.Context) ([]slack.User, error) {
+			return b.apiClient.GetUsersContext(ctx)
+		}
+	}
+
+	users, err := fetchFn(ctx)
+	if err != nil {
+		log.Printf("slack: failed to fetch user directory: %v", err)
+		return
+	}
+
+	dir := make(map[string]string, len(users))
+	for _, u := range users {
+		if u.Deleted || u.IsBot {
+			continue
+		}
+		id := u.ID
+		if name := strings.ToLower(strings.TrimSpace(u.Name)); name != "" {
+			dir[name] = id
+		}
+		if dn := strings.ToLower(strings.TrimSpace(u.Profile.DisplayName)); dn != "" {
+			dir[dn] = id
+		}
+		if dn := strings.ToLower(strings.TrimSpace(u.Profile.DisplayNameNormalized)); dn != "" {
+			dir[dn] = id
+		}
+		if rn := strings.ToLower(strings.TrimSpace(u.RealName)); rn != "" {
+			dir[rn] = id
+		}
+	}
+
+	b.userDirMu.Lock()
+	b.userDir = dir
+	b.userDirUpdated = time.Now()
+	b.userDirMu.Unlock()
+}
+
+// lookupUserID returns the Slack user ID for a given name, if cached.
+func (b *SlackBot) lookupUserID(name string) (string, bool) {
+	b.userDirMu.RLock()
+	defer b.userDirMu.RUnlock()
+	id, ok := b.userDir[strings.ToLower(name)]
+	return id, ok
+}
+
+// userDirStale returns true if the user directory needs refreshing.
+func (b *SlackBot) userDirStale() bool {
+	b.userDirMu.RLock()
+	defer b.userDirMu.RUnlock()
+	return b.userDir == nil || time.Since(b.userDirUpdated) > userDirTTL
+}
+
+// resolveSlackMentions converts @name patterns in outbound text to <@USERID> format.
+func (b *SlackBot) resolveSlackMentions(ctx context.Context, text string) string {
+	if !strings.Contains(text, "@") {
+		return text
+	}
+
+	if b.userDirStale() {
+		b.refreshUserDirectory(ctx)
+	}
+
+	return slackMentionRe.ReplaceAllStringFunc(text, func(match string) string {
+		sub := slackMentionRe.FindStringSubmatch(match)
+		if len(sub) < 3 {
+			return match
+		}
+		prefix := sub[1]
+		name := sub[2]
+
+		id, ok := b.lookupUserID(name)
+		if !ok {
+			return match
+		}
+		return prefix + "<@" + id + ">"
+	})
 }
 
 func stripLeadingSlackMentions(text string) string {

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -1796,3 +1796,206 @@ func TestSlackFixupDoesNotOverrideExistingFiles(t *testing.T) {
 		t.Fatalf("file ID=%q, expected F_TOP", msgEvent.Message.Files[0].ID)
 	}
 }
+
+func TestResolveSlackMentions(t *testing.T) {
+	bot := &SlackBot{
+		resolveUsersFn: func(ctx context.Context) ([]slack.User, error) {
+			return []slack.User{
+				{ID: "U111", Name: "alice", Profile: slack.UserProfile{DisplayName: "Alice W"}, RealName: "Alice Wonderland"},
+				{ID: "U222", Name: "bob", Profile: slack.UserProfile{DisplayName: "Bob"}, RealName: "Bob Builder"},
+				{ID: "U333", Name: "charlie", Profile: slack.UserProfile{DisplayName: "Charlie"}, RealName: "Charlie Chaplin", Deleted: true},
+				{ID: "U444", Name: "botuser", IsBot: true},
+			}, nil
+		},
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "simple mention",
+			in:   "Hey @alice, check this",
+			want: "Hey <@U111>, check this",
+		},
+		{
+			name: "mention at start",
+			in:   "@bob please review",
+			want: "<@U222> please review",
+		},
+		{
+			name: "case insensitive",
+			in:   "cc @Alice",
+			want: "cc <@U111>",
+		},
+		{
+			name: "display name with space",
+			in:   "Hey @bob, and @alice",
+			want: "Hey <@U222>, and <@U111>",
+		},
+		{
+			name: "already resolved mention unchanged",
+			in:   "Hey <@U111> check this",
+			want: "Hey <@U111> check this",
+		},
+		{
+			name: "unknown user unchanged",
+			in:   "Hey @unknown, check this",
+			want: "Hey @unknown, check this",
+		},
+		{
+			name: "deleted user not resolved",
+			in:   "Hey @charlie",
+			want: "Hey @charlie",
+		},
+		{
+			name: "bot user not resolved",
+			in:   "Hey @botuser",
+			want: "Hey @botuser",
+		},
+		{
+			name: "no mentions unchanged",
+			in:   "Hello world",
+			want: "Hello world",
+		},
+		{
+			name: "email address not resolved",
+			in:   "Send to user@example.com",
+			want: "Send to user@example.com",
+		},
+		{
+			name: "mention in parens",
+			in:   "Assigned to (@alice)",
+			want: "Assigned to (<@U111>)",
+		},
+		{
+			name: "multiple mentions",
+			in:   "@alice and @bob should review",
+			want: "<@U111> and <@U222> should review",
+		},
+	}
+
+	ctx := context.Background()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bot.resolveSlackMentions(ctx, tt.in)
+			if got != tt.want {
+				t.Errorf("resolveSlackMentions(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveSlackMentionsCacheTTL(t *testing.T) {
+	callCount := 0
+	bot := &SlackBot{
+		resolveUsersFn: func(ctx context.Context) ([]slack.User, error) {
+			callCount++
+			return []slack.User{
+				{ID: "U111", Name: "alice"},
+			}, nil
+		},
+	}
+
+	ctx := context.Background()
+
+	// First call populates the cache.
+	got := bot.resolveSlackMentions(ctx, "@alice hi")
+	if got != "<@U111> hi" {
+		t.Fatalf("first call: got %q, want %q", got, "<@U111> hi")
+	}
+	if callCount != 1 {
+		t.Fatalf("expected 1 API call, got %d", callCount)
+	}
+
+	// Second call should use cache, not call API again.
+	got = bot.resolveSlackMentions(ctx, "@alice hi")
+	if got != "<@U111> hi" {
+		t.Fatalf("second call: got %q, want %q", got, "<@U111> hi")
+	}
+	if callCount != 1 {
+		t.Fatalf("expected still 1 API call, got %d", callCount)
+	}
+
+	// Simulate stale cache by backdating the timestamp.
+	bot.userDirMu.Lock()
+	bot.userDirUpdated = time.Now().Add(-userDirTTL - time.Minute)
+	bot.userDirMu.Unlock()
+
+	got = bot.resolveSlackMentions(ctx, "@alice hi")
+	if got != "<@U111> hi" {
+		t.Fatalf("stale cache: got %q, want %q", got, "<@U111> hi")
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 API calls after TTL, got %d", callCount)
+	}
+}
+
+func TestResolveSlackMentionsAPIError(t *testing.T) {
+	bot := &SlackBot{
+		resolveUsersFn: func(ctx context.Context) ([]slack.User, error) {
+			return nil, errors.New("api error")
+		},
+	}
+
+	ctx := context.Background()
+	// Should return text unchanged when API fails.
+	got := bot.resolveSlackMentions(ctx, "Hey @alice")
+	if got != "Hey @alice" {
+		t.Fatalf("got %q, want unchanged %q", got, "Hey @alice")
+	}
+}
+
+func TestSendTextWithOptionsResolvesMentions(t *testing.T) {
+	var sentText string
+	bot := &SlackBot{
+		apiClient: slack.New("xoxb-fake-token"),
+		resolveUsersFn: func(ctx context.Context) ([]slack.User, error) {
+			return []slack.User{
+				{ID: "U111", Name: "alice"},
+			}, nil
+		},
+	}
+
+	// Override PostMessageContext by setting sendMessageWithOptionsFn to capture text.
+	bot.sendMessageWithOptionsFn = func(ctx context.Context, channelID, text string, opts SendOptions) error {
+		sentText = text
+		return nil
+	}
+
+	ctx := context.Background()
+	err := bot.SendMessageWithOptions(ctx, "C123", "Hey @alice, check this", SendOptions{})
+	if err != nil {
+		t.Fatalf("SendMessageWithOptions: %v", err)
+	}
+
+	// sendMessageWithOptionsFn is called before sendTextWithOptions (which does resolution),
+	// so we need to verify through the sendTextWithOptions path directly.
+	sentText = ""
+	// Use a test HTTP server to capture the sent text.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		sentText = r.FormValue("text")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true,"channel":"C123","ts":"1234.5678"}`))
+	}))
+	defer ts.Close()
+
+	bot2 := &SlackBot{
+		apiClient: slack.New("xoxb-fake-token", slack.OptionAPIURL(ts.URL+"/")),
+		resolveUsersFn: func(ctx context.Context) ([]slack.User, error) {
+			return []slack.User{
+				{ID: "U111", Name: "alice"},
+			}, nil
+		},
+	}
+
+	err = bot2.sendTextWithOptions(ctx, "C123", "Hey @alice, check this", SendOptions{})
+	if err != nil {
+		t.Fatalf("sendTextWithOptions: %v", err)
+	}
+	if sentText != "Hey <@U111>, check this" {
+		t.Fatalf("sent text = %q, want %q", sentText, "Hey <@U111>, check this")
+	}
+}


### PR DESCRIPTION
## Summary

- Add user directory cache on `SlackBot` that maps lowercase usernames, display names, and real names to Slack user IDs (populated from `users.list` API with 30-minute TTL)
- Add `resolveSlackMentions()` that converts `@name` patterns to `<@USERID>` format in outbound text before calling `PostMessageContext`
- Preserves already-resolved `<@USERID>` mentions, skips email addresses, deleted users, and bot users

Fixes #321

## Root Cause

Outbound messages from agents contained plain-text `@username` mentions. Slack's API only recognizes the `<@USERID>` format for mention notifications — plain `@username` was sent as-is, causing missed notifications and incorrect tagging in group channels.

## Test plan

- [x] `TestResolveSlackMentions` — 12 subtests covering simple mentions, case insensitivity, already-resolved mentions, unknown users, deleted/bot users, email addresses, parenthesized mentions, multiple mentions
- [x] `TestResolveSlackMentionsCacheTTL` — verifies cache is used on second call and refreshed after TTL expiry
- [x] `TestResolveSlackMentionsAPIError` — verifies graceful degradation when API fails (text unchanged)
- [x] `TestSendTextWithOptionsResolvesMentions` — end-to-end test via httptest server verifying `sendTextWithOptions` sends resolved text
- [x] `go test ./...` all pass
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)