### PR TITLE
feat: default config path to ~/.config/fractalbot/config.yaml (closes #282)

### DIFF
--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -82,7 +82,7 @@ func runWithContext(ctx context.Context, args []string, out io.Writer) int {
 	fs := flag.NewFlagSet("fractalbot", flag.ContinueOnError)
 	fs.SetOutput(out)
 
-	configPath := fs.String("config", "./config.yaml", "path to config file")
+	configPath := fs.String("config", "", "path to config file (default: ~/.config/fractalbot/config.yaml)")
 	portOverride := fs.Int("port", 0, "override gateway port")
 	verbose := fs.Bool("verbose", false, "enable verbose logging")
 
@@ -95,7 +95,7 @@ func runWithContext(ctx context.Context, args []string, out io.Writer) int {
 		logger.SetFlags(log.LstdFlags | log.Lshortfile)
 	}
 
-	cfg, err := config.LoadConfig(*configPath)
+	cfg, err := config.LoadConfig(config.ResolveConfigPath(*configPath))
 	if err != nil {
 		logger.Printf("failed to load config: %v", err)
 		return 1

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,31 @@ type AgentsConfig struct {
 	OhMyCode      *OhMyCodeConfig `yaml:"ohMyCode,omitempty"`
 }
 
+// ResolveConfigPath returns the config file path using this priority:
+//  1. flagValue (if non-empty, i.e. --config was explicitly provided)
+//  2. $FRACTALBOT_CONFIG environment variable
+//  3. ~/.config/fractalbot/config.yaml (XDG-style default)
+//  4. ./config.yaml (legacy fallback)
+func ResolveConfigPath(flagValue string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+
+	if env := os.Getenv("FRACTALBOT_CONFIG"); env != "" {
+		return env
+	}
+
+	home, err := os.UserHomeDir()
+	if err == nil {
+		xdg := filepath.Join(home, ".config", "fractalbot", "config.yaml")
+		if _, err := os.Stat(xdg); err == nil {
+			return xdg
+		}
+	}
+
+	return "./config.yaml"
+}
+
 // LoadConfig loads configuration from file.
 func LoadConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -178,6 +178,79 @@ func TestLoadConfigAcceptsOhMyCodeAbsoluteWorkspaceWithRelativeScript(t *testing
 	}
 }
 
+func TestResolveConfigPathExplicitFlag(t *testing.T) {
+	got := ResolveConfigPath("/custom/path.yaml")
+	if got != "/custom/path.yaml" {
+		t.Fatalf("expected /custom/path.yaml, got %s", got)
+	}
+}
+
+func TestResolveConfigPathEnvVar(t *testing.T) {
+	t.Setenv("FRACTALBOT_CONFIG", "/from/env.yaml")
+	got := ResolveConfigPath("")
+	if got != "/from/env.yaml" {
+		t.Fatalf("expected /from/env.yaml, got %s", got)
+	}
+}
+
+func TestResolveConfigPathXDGDefault(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("FRACTALBOT_CONFIG", "")
+
+	xdgDir := filepath.Join(dir, ".config", "fractalbot")
+	if err := os.MkdirAll(xdgDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	xdgPath := filepath.Join(xdgDir, "config.yaml")
+	if err := os.WriteFile(xdgPath, []byte("gateway:\n  port: 1\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := ResolveConfigPath("")
+	if got != xdgPath {
+		t.Fatalf("expected %s, got %s", xdgPath, got)
+	}
+}
+
+func TestResolveConfigPathFallbackCWD(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("FRACTALBOT_CONFIG", "")
+	// No XDG file exists, should fall back to ./config.yaml
+	got := ResolveConfigPath("")
+	if got != "./config.yaml" {
+		t.Fatalf("expected ./config.yaml, got %s", got)
+	}
+}
+
+func TestResolveConfigPathFlagTakesPriorityOverEnv(t *testing.T) {
+	t.Setenv("FRACTALBOT_CONFIG", "/from/env.yaml")
+	got := ResolveConfigPath("/flag/path.yaml")
+	if got != "/flag/path.yaml" {
+		t.Fatalf("expected /flag/path.yaml, got %s", got)
+	}
+}
+
+func TestResolveConfigPathEnvTakesPriorityOverXDG(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("FRACTALBOT_CONFIG", "/from/env.yaml")
+
+	xdgDir := filepath.Join(dir, ".config", "fractalbot")
+	if err := os.MkdirAll(xdgDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(xdgDir, "config.yaml"), []byte("gateway:\n  port: 1\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got := ResolveConfigPath("")
+	if got != "/from/env.yaml" {
+		t.Fatalf("expected /from/env.yaml, got %s", got)
+	}
+}
+
 func TestLoadConfigAcceptsIMessagePollingConfig(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	content := []byte(`channels:


### PR DESCRIPTION
## Summary
- Added `ResolveConfigPath()` in `internal/config/config.go` with 4-level priority: `--config` flag > `$FRACTALBOT_CONFIG` env > `~/.config/fractalbot/config.yaml` > `./config.yaml`
- Changed `--config` flag default from `./config.yaml` to empty string so resolution kicks in when flag is omitted
- Zero breaking change: explicit `--config` and `./config.yaml` fallback both still work

## Test plan
- [x] `go test ./...` passes (6 new tests for `ResolveConfigPath`)
- [ ] CI green
- [ ] `fractalbot message send --channel telegram --to 123 --text hello` works without `--config` when config exists at `~/.config/fractalbot/config.yaml`
- [ ] `fractalbot --config /custom/path.yaml` still works
- [ ] `FRACTALBOT_CONFIG=/path.yaml fractalbot` picks up env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)