### PR TITLE
feat(bus): in-process message bus for async delivery and routing #303

### DIFF
--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -1,0 +1,194 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/fractalmind-ai/fractalbot/internal/channels"
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+// ChannelSender routes outbound messages to the correct channel.
+// Satisfied by channels.Manager.
+type ChannelSender interface {
+	Send(ctx context.Context, channelName string, msg channels.OutboundMessage) error
+}
+
+// InboundMessage wraps a protocol message with routing metadata.
+type InboundMessage struct {
+	Ctx         context.Context
+	ChannelName string
+	Message     *protocol.Message
+	replyCh     chan inboundReply
+}
+
+type inboundReply struct {
+	Text string
+	Err  error
+}
+
+// OutboundEnvelope wraps an outbound message with its target channel and
+// a completion channel for synchronous error reporting.
+type OutboundEnvelope struct {
+	Ctx         context.Context
+	ChannelName string
+	Message     channels.OutboundMessage
+	errCh       chan error
+}
+
+// MessageBus provides async in-process message routing between channels and
+// the agent system. It decouples channel adapters from the agent router
+// using buffered channels for both inbound and outbound message flows.
+type MessageBus struct {
+	inbound  chan *InboundMessage
+	outbound chan *OutboundEnvelope
+	closed   atomic.Bool
+	wg       sync.WaitGroup
+
+	handler channels.IncomingMessageHandler
+	sender  ChannelSender
+}
+
+// New creates a MessageBus with the given handler for inbound processing
+// and sender for outbound routing. Buffer sizes control backpressure.
+func New(handler channels.IncomingMessageHandler, sender ChannelSender, inboundBuf, outboundBuf int) *MessageBus {
+	if inboundBuf < 0 {
+		inboundBuf = 0
+	}
+	if outboundBuf < 0 {
+		outboundBuf = 0
+	}
+	return &MessageBus{
+		inbound:  make(chan *InboundMessage, inboundBuf),
+		outbound: make(chan *OutboundEnvelope, outboundBuf),
+		handler:  handler,
+		sender:   sender,
+	}
+}
+
+// Start launches the inbound and outbound consumer goroutines.
+func (b *MessageBus) Start() {
+	b.wg.Add(2)
+	go b.consumeInbound()
+	go b.consumeOutbound()
+}
+
+// HandleIncoming implements channels.IncomingMessageHandler.
+// It publishes the message to the inbound pipe and blocks until the consumer
+// processes it, preserving the synchronous request-reply contract.
+func (b *MessageBus) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	if b.closed.Load() {
+		return "", errors.New("bus is closed")
+	}
+
+	replyCh := make(chan inboundReply, 1)
+	inMsg := &InboundMessage{
+		Ctx:         ctx,
+		ChannelName: extractChannelName(msg),
+		Message:     msg,
+		replyCh:     replyCh,
+	}
+
+	select {
+	case b.inbound <- inMsg:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+
+	select {
+	case reply := <-replyCh:
+		return reply.Text, reply.Err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// PublishOutbound sends an outbound message through the bus.
+// It blocks until the consumer processes the send and returns the result.
+func (b *MessageBus) PublishOutbound(ctx context.Context, channelName string, msg channels.OutboundMessage) error {
+	if b.closed.Load() {
+		return errors.New("bus is closed")
+	}
+
+	errCh := make(chan error, 1)
+	env := &OutboundEnvelope{
+		Ctx:         ctx,
+		ChannelName: channelName,
+		Message:     msg,
+		errCh:       errCh,
+	}
+
+	select {
+	case b.outbound <- env:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Close signals both consumer goroutines to stop. It is safe to call
+// multiple times.
+func (b *MessageBus) Close() {
+	if b.closed.CompareAndSwap(false, true) {
+		close(b.inbound)
+		close(b.outbound)
+	}
+}
+
+// Wait blocks until both consumer goroutines have exited.
+func (b *MessageBus) Wait() {
+	b.wg.Wait()
+}
+
+func (b *MessageBus) consumeInbound() {
+	defer b.wg.Done()
+	for msg := range b.inbound {
+		text, err := b.handler.HandleIncoming(msg.Ctx, msg.Message)
+		msg.replyCh <- inboundReply{Text: text, Err: err}
+	}
+}
+
+func (b *MessageBus) consumeOutbound() {
+	defer b.wg.Done()
+	for env := range b.outbound {
+		err := b.sender.Send(env.Ctx, env.ChannelName, env.Message)
+		env.errCh <- err
+	}
+}
+
+// extractChannelName pulls the "channel" field from a protocol.Message's Data map.
+func extractChannelName(msg *protocol.Message) string {
+	if msg == nil || msg.Data == nil {
+		return ""
+	}
+	data, ok := msg.Data.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	name, _ := data["channel"].(string)
+	return name
+}
+
+// Ensure MessageBus satisfies IncomingMessageHandler at compile time.
+var _ channels.IncomingMessageHandler = (*MessageBus)(nil)
+
+// String returns a human-readable description for debugging.
+func (b *MessageBus) String() string {
+	state := "running"
+	if b.closed.Load() {
+		state = "closed"
+	}
+	return fmt.Sprintf("MessageBus(%s, inbound=%d/%d, outbound=%d/%d)",
+		state,
+		len(b.inbound), cap(b.inbound),
+		len(b.outbound), cap(b.outbound))
+}

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -1,0 +1,446 @@
+package bus
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/channels"
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+// --- test helpers ---
+
+type fakeHandler struct {
+	mu      sync.Mutex
+	calls   int
+	lastMsg *protocol.Message
+	replyFn func(ctx context.Context, msg *protocol.Message) (string, error)
+}
+
+func (h *fakeHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	h.mu.Lock()
+	h.calls++
+	h.lastMsg = msg
+	fn := h.replyFn
+	h.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, msg)
+	}
+	return "ack", nil
+}
+
+func (h *fakeHandler) callCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls
+}
+
+type fakeSender struct {
+	mu      sync.Mutex
+	calls   int
+	lastCh  string
+	lastMsg channels.OutboundMessage
+	sendErr error
+}
+
+func (s *fakeSender) Send(ctx context.Context, channelName string, msg channels.OutboundMessage) error {
+	s.mu.Lock()
+	s.calls++
+	s.lastCh = channelName
+	s.lastMsg = msg
+	err := s.sendErr
+	s.mu.Unlock()
+	return err
+}
+
+func (s *fakeSender) callCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls
+}
+
+func makeProtocolMsg(channel, text string) *protocol.Message {
+	return &protocol.Message{
+		Kind:   protocol.MessageKindChannel,
+		Action: protocol.ActionCreate,
+		Data: map[string]interface{}{
+			"channel": channel,
+			"text":    text,
+		},
+	}
+}
+
+// --- tests ---
+
+func TestInboundPublishAndConsume(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 8, 8)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	msg := makeProtocolMsg("telegram", "hello")
+	reply, err := b.HandleIncoming(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("HandleIncoming: %v", err)
+	}
+	if reply != "ack" {
+		t.Fatalf("expected reply 'ack', got %q", reply)
+	}
+	if handler.callCount() != 1 {
+		t.Fatalf("expected 1 handler call, got %d", handler.callCount())
+	}
+}
+
+func TestInboundExtractsChannelName(t *testing.T) {
+	var gotName string
+	handler := &fakeHandler{
+		replyFn: func(ctx context.Context, msg *protocol.Message) (string, error) {
+			return "ok", nil
+		},
+	}
+	sender := &fakeSender{}
+
+	// Override: inspect the InboundMessage directly via extractChannelName
+	msg := makeProtocolMsg("slack", "test")
+	name := extractChannelName(msg)
+	if name != "slack" {
+		t.Fatalf("expected channel name 'slack', got %q", name)
+	}
+	_ = gotName
+
+	b := New(handler, sender, 4, 4)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	reply, err := b.HandleIncoming(context.Background(), msg)
+	if err != nil {
+		t.Fatalf("HandleIncoming: %v", err)
+	}
+	if reply != "ok" {
+		t.Fatalf("expected reply 'ok', got %q", reply)
+	}
+}
+
+func TestInboundHandlerError(t *testing.T) {
+	handler := &fakeHandler{
+		replyFn: func(ctx context.Context, msg *protocol.Message) (string, error) {
+			return "", errors.New("handler boom")
+		},
+	}
+	sender := &fakeSender{}
+	b := New(handler, sender, 4, 4)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	_, err := b.HandleIncoming(context.Background(), makeProtocolMsg("telegram", "x"))
+	if err == nil || err.Error() != "handler boom" {
+		t.Fatalf("expected 'handler boom' error, got %v", err)
+	}
+}
+
+func TestOutboundPublishAndConsume(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 4, 4)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{
+		To:   "12345",
+		Text: "hello from bus",
+	})
+	if err != nil {
+		t.Fatalf("PublishOutbound: %v", err)
+	}
+	if sender.callCount() != 1 {
+		t.Fatalf("expected 1 sender call, got %d", sender.callCount())
+	}
+	sender.mu.Lock()
+	if sender.lastCh != "telegram" {
+		t.Fatalf("expected channel 'telegram', got %q", sender.lastCh)
+	}
+	if sender.lastMsg.To != "12345" {
+		t.Fatalf("expected to '12345', got %q", sender.lastMsg.To)
+	}
+	if sender.lastMsg.Text != "hello from bus" {
+		t.Fatalf("expected text 'hello from bus', got %q", sender.lastMsg.Text)
+	}
+	sender.mu.Unlock()
+}
+
+func TestOutboundSendError(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{sendErr: errors.New("send failed")}
+	b := New(handler, sender, 4, 4)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	err := b.PublishOutbound(context.Background(), "slack", channels.OutboundMessage{
+		To:   "C123",
+		Text: "test",
+	})
+	if err == nil || err.Error() != "send failed" {
+		t.Fatalf("expected 'send failed' error, got %v", err)
+	}
+}
+
+func TestOutboundWithThreadTS(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 4, 4)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	err := b.PublishOutbound(context.Background(), "slack", channels.OutboundMessage{
+		To:       "C123",
+		Text:     "reply",
+		ThreadTS: "1234567890.123456",
+	})
+	if err != nil {
+		t.Fatalf("PublishOutbound: %v", err)
+	}
+	sender.mu.Lock()
+	if sender.lastMsg.ThreadTS != "1234567890.123456" {
+		t.Fatalf("expected thread ts, got %q", sender.lastMsg.ThreadTS)
+	}
+	sender.mu.Unlock()
+}
+
+func TestPublishInboundContextCanceled(t *testing.T) {
+	handler := &fakeHandler{
+		replyFn: func(ctx context.Context, msg *protocol.Message) (string, error) {
+			time.Sleep(time.Second) // slow handler
+			return "late", nil
+		},
+	}
+	sender := &fakeSender{}
+	// buffer=0 so publish blocks until consumer picks up
+	b := New(handler, sender, 0, 0)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := b.HandleIncoming(ctx, makeProtocolMsg("telegram", "x"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestPublishOutboundContextCanceled(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	// buffer=0 so publish blocks until consumer picks up
+	b := New(handler, sender, 0, 0)
+	// Don't start consumers — publish will block on channel send
+	// (We need to start, but make sender slow instead)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	// Make sender block
+	sender.sendErr = nil
+	origSend := sender.Send
+	_ = origSend
+	slowSender := &fakeSender{}
+	b2 := New(handler, slowSender, 0, 0)
+	// Don't start b2 — no consumer, so publish blocks on channel write
+	defer b2.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := b2.PublishOutbound(ctx, "telegram", channels.OutboundMessage{To: "1", Text: "x"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestClosePreventsFurtherPublish(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 4, 4)
+	b.Start()
+	b.Close()
+	b.Wait()
+
+	_, err := b.HandleIncoming(context.Background(), makeProtocolMsg("telegram", "x"))
+	if err == nil || err.Error() != "bus is closed" {
+		t.Fatalf("expected 'bus is closed', got %v", err)
+	}
+
+	err = b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"})
+	if err == nil || err.Error() != "bus is closed" {
+		t.Fatalf("expected 'bus is closed', got %v", err)
+	}
+}
+
+func TestCloseIdempotent(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 4, 4)
+	b.Start()
+
+	// Should not panic
+	b.Close()
+	b.Close()
+	b.Close()
+	b.Wait()
+}
+
+func TestCloseDrainsInFlight(t *testing.T) {
+	var processed atomic.Int32
+	handler := &fakeHandler{
+		replyFn: func(ctx context.Context, msg *protocol.Message) (string, error) {
+			processed.Add(1)
+			return "ok", nil
+		},
+	}
+	sender := &fakeSender{}
+	b := New(handler, sender, 8, 8)
+	b.Start()
+
+	// Publish several messages
+	const n = 5
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < n; i++ {
+			_, _ = b.HandleIncoming(context.Background(), makeProtocolMsg("telegram", "msg"))
+		}
+	}()
+	<-done
+
+	b.Close()
+	b.Wait()
+
+	if got := processed.Load(); got != n {
+		t.Fatalf("expected %d processed, got %d", n, got)
+	}
+}
+
+func TestConcurrentPublish(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 64, 64)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	const goroutines = 10
+	const perGoroutine = 5
+	var wg sync.WaitGroup
+
+	// Concurrent inbound
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				_, err := b.HandleIncoming(context.Background(), makeProtocolMsg("telegram", "x"))
+				if err != nil {
+					t.Errorf("inbound error: %v", err)
+				}
+			}
+		}()
+	}
+
+	// Concurrent outbound
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perGoroutine; j++ {
+				err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"})
+				if err != nil {
+					t.Errorf("outbound error: %v", err)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expected := goroutines * perGoroutine
+	if got := handler.callCount(); got != expected {
+		t.Fatalf("expected %d handler calls, got %d", expected, got)
+	}
+	if got := sender.callCount(); got != expected {
+		t.Fatalf("expected %d sender calls, got %d", expected, got)
+	}
+}
+
+func TestExtractChannelName(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *protocol.Message
+		want string
+	}{
+		{"nil message", nil, ""},
+		{"nil data", &protocol.Message{}, ""},
+		{"non-map data", &protocol.Message{Data: "string"}, ""},
+		{"missing channel key", &protocol.Message{Data: map[string]interface{}{"text": "hello"}}, ""},
+		{"telegram", makeProtocolMsg("telegram", "hi"), "telegram"},
+		{"slack", makeProtocolMsg("slack", "hi"), "slack"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractChannelName(tt.msg)
+			if got != tt.want {
+				t.Fatalf("extractChannelName()=%q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNegativeBufferSizesClamped(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, -5, -10)
+	if cap(b.inbound) != 0 {
+		t.Fatalf("expected inbound cap=0, got %d", cap(b.inbound))
+	}
+	if cap(b.outbound) != 0 {
+		t.Fatalf("expected outbound cap=0, got %d", cap(b.outbound))
+	}
+}
+
+func TestString(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 8, 16)
+	s := b.String()
+	if s == "" {
+		t.Fatal("String() returned empty")
+	}
+	// Verify it contains key info
+	if !containsAll(s, "MessageBus", "running", "inbound", "outbound") {
+		t.Fatalf("unexpected String() output: %s", s)
+	}
+
+	b.Close()
+	s = b.String()
+	if !containsAll(s, "closed") {
+		t.Fatalf("expected 'closed' in String(), got: %s", s)
+	}
+}
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		found := false
+		for i := 0; i <= len(s)-len(sub); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/fractalmind-ai/fractalbot/internal/agent"
+	"github.com/fractalmind-ai/fractalbot/internal/bus"
 	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/gorilla/websocket"
@@ -28,6 +29,7 @@ type Server struct {
 	clientsMutex sync.RWMutex
 	httpServer   *http.Server
 	agentManager *agent.Manager
+	messageBus   *bus.MessageBus
 	startTime    time.Time
 }
 
@@ -43,7 +45,13 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	// Initialize agent manager
 	agentManager := agent.NewManager(cfg.Agents)
 	agentManager.ChannelManager = channelManager
-	channelManager.SetHandler(agentManager)
+
+	// Initialize message bus — decouples channels from agent router
+	messageBus := bus.New(agentManager, channelManager, 64, 64)
+	messageBus.Start()
+
+	// Wire bus as the inbound handler (bus implements IncomingMessageHandler)
+	channelManager.SetHandler(messageBus)
 
 	return &Server{
 		config: cfg,
@@ -54,6 +62,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 		},
 		clients:      make(map[string]*Client),
 		agentManager: agentManager,
+		messageBus:   messageBus,
 	}, nil
 }
 
@@ -114,6 +123,12 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	// Close bus first — drain pending messages while channels still run
+	if s.messageBus != nil {
+		s.messageBus.Close()
+		s.messageBus.Wait()
+	}
 
 	if s.agentManager != nil {
 		if s.agentManager.ChannelManager != nil {
@@ -296,12 +311,12 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if s.agentManager == nil || s.agentManager.ChannelManager == nil {
-		writeJSON(w, http.StatusServiceUnavailable, messageSendResponse{Status: "error", Error: "channel manager unavailable"})
+	if s.messageBus == nil {
+		writeJSON(w, http.StatusServiceUnavailable, messageSendResponse{Status: "error", Error: "message bus unavailable"})
 		return
 	}
 
-	if err := s.agentManager.ChannelManager.Send(r.Context(), request.Channel, channels.OutboundMessage{
+	if err := s.messageBus.PublishOutbound(r.Context(), request.Channel, channels.OutboundMessage{
 		To:       request.To,
 		Text:     request.Text,
 		ThreadTS: request.ThreadTS,


### PR DESCRIPTION
## Summary

- Adds `internal/bus/` package with `MessageBus` that decouples channel adapters from the agent router using buffered channels (configurable buffer size, default 64) for both inbound and outbound message flows
- Bus implements `IncomingMessageHandler` — channels publish through it transparently without any code changes
- `PublishOutbound` routes through `ChannelSender` (satisfied by `Manager.Send`) with synchronous error reporting via per-message completion channels
- Context-aware publish (`select` with `ctx.Done()`) and atomic close (`CompareAndSwap`) prevent panics
- Gateway server wired: bus created in `NewServer`, closed+drained in `Stop`, outbound sends in `handleMessageSend` route through the bus

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` — all packages pass
- [x] `go test -race ./internal/bus/... ./internal/gateway/...` — race-free
- [x] `gofmt -w .` — formatted
- [ ] QA: verify inbound messages from Telegram/Slack still get ack replies
- [ ] QA: verify outbound sends via `/api/v1/message/send` still deliver

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)