### PR TITLE
feat(gateway): upgrade /health endpoint to JSON with metrics #335

### DIFF
--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -39,6 +39,12 @@ type OutboundEnvelope struct {
 	errCh       chan error
 }
 
+// Stats holds message processing counters.
+type Stats struct {
+	InboundProcessed  int64
+	OutboundProcessed int64
+}
+
 // MessageBus provides async in-process message routing between channels and
 // the agent system. It decouples channel adapters from the agent router
 // using buffered channels for both inbound and outbound message flows.
@@ -47,6 +53,9 @@ type MessageBus struct {
 	outbound chan *OutboundEnvelope
 	closed   atomic.Bool
 	wg       sync.WaitGroup
+
+	inboundProcessed  atomic.Int64
+	outboundProcessed atomic.Int64
 
 	handler channels.IncomingMessageHandler
 	sender  ChannelSender
@@ -149,11 +158,20 @@ func (b *MessageBus) Wait() {
 	b.wg.Wait()
 }
 
+// Stats returns message processing counters.
+func (b *MessageBus) Stats() Stats {
+	return Stats{
+		InboundProcessed:  b.inboundProcessed.Load(),
+		OutboundProcessed: b.outboundProcessed.Load(),
+	}
+}
+
 func (b *MessageBus) consumeInbound() {
 	defer b.wg.Done()
 	for msg := range b.inbound {
 		text, err := b.handler.HandleIncoming(msg.Ctx, msg.Message)
 		msg.replyCh <- inboundReply{Text: text, Err: err}
+		b.inboundProcessed.Add(1)
 	}
 }
 
@@ -162,6 +180,7 @@ func (b *MessageBus) consumeOutbound() {
 	for env := range b.outbound {
 		err := b.sender.Send(env.Ctx, env.ChannelName, env.Message)
 		env.errCh <- err
+		b.outboundProcessed.Add(1)
 	}
 }
 

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -444,3 +444,38 @@ func containsAll(s string, substrs ...string) bool {
 	}
 	return true
 }
+
+func TestStatsCountsMessages(t *testing.T) {
+	handler := &fakeHandler{}
+	sender := &fakeSender{}
+	b := New(handler, sender, 8, 8)
+	b.Start()
+	defer func() { b.Close(); b.Wait() }()
+
+	stats := b.Stats()
+	if stats.InboundProcessed != 0 || stats.OutboundProcessed != 0 {
+		t.Fatalf("expected zero counts initially, got in=%d out=%d", stats.InboundProcessed, stats.OutboundProcessed)
+	}
+
+	// Send 3 inbound messages
+	for i := 0; i < 3; i++ {
+		if _, err := b.HandleIncoming(context.Background(), makeProtocolMsg("telegram", "msg")); err != nil {
+			t.Fatalf("HandleIncoming: %v", err)
+		}
+	}
+
+	// Send 2 outbound messages
+	for i := 0; i < 2; i++ {
+		if err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"}); err != nil {
+			t.Fatalf("PublishOutbound: %v", err)
+		}
+	}
+
+	stats = b.Stats()
+	if stats.InboundProcessed != 3 {
+		t.Fatalf("expected 3 inbound processed, got %d", stats.InboundProcessed)
+	}
+	if stats.OutboundProcessed != 2 {
+		t.Fatalf("expected 2 outbound processed, got %d", stats.OutboundProcessed)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -74,10 +74,7 @@ func (s *Server) Start(ctx context.Context) error {
 	mux.HandleFunc("/ws", s.handleWebSocket)
 
 	// Health check endpoint
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
-	})
+	mux.HandleFunc("/health", s.handleHealth)
 
 	// Status endpoint
 	mux.HandleFunc("/status", s.handleStatus)
@@ -235,6 +232,48 @@ func generateClientID() string {
 // GetAgentManager returns the agent manager
 func (s *Server) GetAgentManager() *agent.Manager {
 	return s.agentManager
+}
+
+type healthResponse struct {
+	Status            string               `json:"status"`
+	Uptime            string               `json:"uptime"`
+	Channels          []healthChannelEntry `json:"channels"`
+	MessagesProcessed int64                `json:"messages_processed"`
+}
+
+type healthChannelEntry struct {
+	Name    string `json:"name"`
+	Running bool   `json:"running"`
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	uptime := time.Duration(0)
+	if !s.startTime.IsZero() {
+		uptime = time.Since(s.startTime)
+	}
+
+	var messagesProcessed int64
+	if s.messageBus != nil {
+		stats := s.messageBus.Stats()
+		messagesProcessed = stats.InboundProcessed + stats.OutboundProcessed
+	}
+
+	chEntries := make([]healthChannelEntry, 0)
+	if s.agentManager != nil && s.agentManager.ChannelManager != nil {
+		for _, ch := range s.agentManager.ChannelManager.List() {
+			chEntries = append(chEntries, healthChannelEntry{
+				Name:    ch.Name(),
+				Running: ch.IsRunning(),
+			})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, healthResponse{
+		Status:            "ok",
+		Uptime:            uptime.String(),
+		Channels:          chEntries,
+		MessagesProcessed: messagesProcessed,
+	})
 }
 
 type statusResponse struct {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -401,6 +401,80 @@ func TestStatusDoesNotExposeSecrets(t *testing.T) {
 	}
 }
 
+func TestHealthEndpointReturnsJSON(t *testing.T) {
+	cfg := &config.Config{
+		Gateway: &config.GatewayConfig{
+			Bind: "127.0.0.1",
+			Port: 0,
+		},
+		Channels: &config.ChannelsConfig{
+			Telegram: &config.TelegramConfig{Enabled: true},
+		},
+		Agents: &config.AgentsConfig{},
+	}
+
+	server, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+	server.startTime = time.Now().Add(-5 * time.Second)
+
+	fake := &fakeSendChannel{name: "telegram", running: true}
+	if err := server.agentManager.ChannelManager.Register(fake); err != nil {
+		t.Fatalf("register fake channel: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", server.handleHealth)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/health")
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("expected application/json, got %q", ct)
+	}
+
+	var payload struct {
+		Status   string `json:"status"`
+		Uptime   string `json:"uptime"`
+		Channels []struct {
+			Name    string `json:"name"`
+			Running bool   `json:"running"`
+		} `json:"channels"`
+		MessagesProcessed int64 `json:"messages_processed"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode health response: %v", err)
+	}
+
+	if payload.Status != "ok" {
+		t.Fatalf("expected status=ok, got %q", payload.Status)
+	}
+	if payload.Uptime == "" || payload.Uptime == "0s" {
+		t.Fatalf("expected non-zero uptime, got %q", payload.Uptime)
+	}
+	if len(payload.Channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(payload.Channels))
+	}
+	if payload.Channels[0].Name != "telegram" {
+		t.Fatalf("expected channel name=telegram, got %q", payload.Channels[0].Name)
+	}
+	if !payload.Channels[0].Running {
+		t.Fatalf("expected channel running=true")
+	}
+	if payload.MessagesProcessed != 0 {
+		t.Fatalf("expected messages_processed=0, got %d", payload.MessagesProcessed)
+	}
+}
+
 type fakeSendChannel struct {
 	name       string
 	running    bool


### PR DESCRIPTION
## Summary
- Upgrade `/health` from plain-text `"OK"` to structured JSON: `{"status":"ok","uptime":"...","channels":[...],"messages_processed":N}`
- Add atomic inbound/outbound counters to `MessageBus` with `Stats()` method
- `channels` array shows each registered channel's name and running state
- `messages_processed` is the sum of inbound + outbound messages routed through the bus

## Test plan
- [x] `TestStatsCountsMessages` — verifies bus counters increment correctly for inbound and outbound
- [x] `TestHealthEndpointReturnsJSON` — verifies JSON response with correct content-type, status, uptime, channels, and messages_processed
- [x] All existing bus and gateway tests pass unchanged
- [x] `go vet ./...` clean

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)