### PR TITLE
Expose FractalBot routing telemetry on /status for heartbeat ingestion

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -40,6 +40,19 @@ type Manager struct {
 	ChannelManager *channels.Manager
 	mu             sync.RWMutex
 	agents         map[string]protocol.AgentInfo
+	routingMu      sync.RWMutex
+	lastRouting    *OhMyCodeRoutingOutcome
+}
+
+type OhMyCodeRoutingOutcome struct {
+	SelectedAgent string
+	Channel       string
+	ChatID        string
+	UserID        string
+	Username      string
+	Status        string
+	Error         string
+	RecordedAt    time.Time
 }
 
 // NewManager creates a new agent manager.
@@ -72,6 +85,16 @@ func (m *Manager) List() []protocol.AgentInfo {
 		agents = append(agents, info)
 	}
 	return agents
+}
+
+func (m *Manager) LastRoutingOutcome() *OhMyCodeRoutingOutcome {
+	m.routingMu.RLock()
+	defer m.routingMu.RUnlock()
+	if m.lastRouting == nil {
+		return nil
+	}
+	outcome := *m.lastRouting
+	return &outcome
 }
 
 // HandleIncoming implements channels.IncomingMessageHandler.
@@ -168,6 +191,7 @@ func (m *Manager) isOhMyCodeEnabled() bool {
 func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride string, inboundData map[string]interface{}) (string, error) {
 	workspace, script, err := m.resolveOhMyCodeWorkspaceAndScript()
 	if err != nil {
+		m.recordRoutingOutcome(inboundData, "", "error", err)
 		return "", err
 	}
 
@@ -180,6 +204,7 @@ func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride st
 	}
 	validatedName, err := m.validateOhMyCodeAgent(agentName)
 	if err != nil {
+		m.recordRoutingOutcome(inboundData, agentName, "error", err)
 		return "", err
 	}
 	name := validatedName
@@ -198,9 +223,11 @@ func (m *Manager) assignOhMyCode(ctx context.Context, userText, agentOverride st
 
 	prompt := buildOhMyCodeTaskPrompt(userText, name, inboundData)
 	if _, err := runOhMyCodeAgentManager(assignCtx, workspace, script, prompt, "assign", name); err != nil {
+		m.recordRoutingOutcome(inboundData, name, "error", err)
 		return "", err
 	}
 
+	m.recordRoutingOutcome(inboundData, name, "assigned", nil)
 	return ohMyCodeAssignAckMessage, nil
 }
 
@@ -446,6 +473,25 @@ func promptContextValue(inboundData map[string]interface{}, key string) string {
 		return ""
 	}
 	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func (m *Manager) recordRoutingOutcome(inboundData map[string]interface{}, selectedAgent, status string, err error) {
+	outcome := &OhMyCodeRoutingOutcome{
+		SelectedAgent: strings.TrimSpace(selectedAgent),
+		Channel:       promptContextValue(inboundData, "channel"),
+		ChatID:        promptContextValue(inboundData, "chat_id"),
+		UserID:        promptContextValue(inboundData, "user_id"),
+		Username:      promptContextValue(inboundData, "username"),
+		Status:        strings.TrimSpace(status),
+		RecordedAt:    time.Now().UTC(),
+	}
+	if err != nil {
+		outcome.Error = err.Error()
+	}
+
+	m.routingMu.Lock()
+	m.lastRouting = outcome
+	m.routingMu.Unlock()
 }
 
 func extractRecentMessages(inboundData map[string]interface{}) []map[string]interface{} {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -310,6 +310,23 @@ sys.exit(1)
 	if !strings.Contains(err.Error(), "assign failed") {
 		t.Fatalf("expected assign failure error, got %v", err)
 	}
+
+	telemetry := manager.LastRoutingOutcome()
+	if telemetry == nil {
+		t.Fatal("expected routing telemetry")
+	}
+	if telemetry.SelectedAgent != "qa-1" {
+		t.Fatalf("selected_agent=%q", telemetry.SelectedAgent)
+	}
+	if telemetry.Status != "error" {
+		t.Fatalf("status=%q", telemetry.Status)
+	}
+	if !strings.Contains(telemetry.Error, "assign failed") {
+		t.Fatalf("error=%q", telemetry.Error)
+	}
+	if telemetry.RecordedAt.IsZero() {
+		t.Fatal("expected recorded_at")
+	}
 }
 
 func TestAssignOhMyCodePromptUsesResolvedDefaultAgent(t *testing.T) {
@@ -376,6 +393,26 @@ sys.exit(1)
 		if !strings.Contains(prompt, part) {
 			t.Fatalf("expected %q in prompt, got %q", part, prompt)
 		}
+	}
+
+	telemetry := manager.LastRoutingOutcome()
+	if telemetry == nil {
+		t.Fatal("expected routing telemetry")
+	}
+	if telemetry.SelectedAgent != "qa-1" {
+		t.Fatalf("selected_agent=%q", telemetry.SelectedAgent)
+	}
+	if telemetry.Channel != "telegram" || telemetry.ChatID != "321" || telemetry.UserID != "456" || telemetry.Username != "bob" {
+		t.Fatalf("unexpected telemetry: %#v", telemetry)
+	}
+	if telemetry.Status != "assigned" {
+		t.Fatalf("status=%q", telemetry.Status)
+	}
+	if telemetry.Error != "" {
+		t.Fatalf("error=%q", telemetry.Error)
+	}
+	if telemetry.RecordedAt.IsZero() {
+		t.Fatal("expected recorded_at")
 	}
 }
 

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -406,11 +406,23 @@ type agentStatus struct {
 	OhMyCode            *ohMyCodeStatus `json:"oh_my_code,omitempty"`
 }
 
+type ohMyCodeRoutingStatus struct {
+	SelectedAgent string `json:"selected_agent,omitempty"`
+	Channel       string `json:"channel,omitempty"`
+	ChatID        string `json:"chat_id,omitempty"`
+	UserID        string `json:"user_id,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Status        string `json:"status,omitempty"`
+	Error         string `json:"error,omitempty"`
+	RecordedAt    string `json:"recorded_at,omitempty"`
+}
+
 type ohMyCodeStatus struct {
-	Enabled             bool     `json:"enabled"`
-	WorkspaceConfigured bool     `json:"workspace_configured"`
-	DefaultAgent        string   `json:"default_agent,omitempty"`
-	AllowedAgents       []string `json:"allowed_agents,omitempty"`
+	Enabled             bool                   `json:"enabled"`
+	WorkspaceConfigured bool                   `json:"workspace_configured"`
+	DefaultAgent        string                 `json:"default_agent,omitempty"`
+	AllowedAgents       []string               `json:"allowed_agents,omitempty"`
+	LastRouting         *ohMyCodeRoutingStatus `json:"last_routing,omitempty"`
 }
 
 func (s *Server) channelStatus() []channelStatus {
@@ -562,6 +574,20 @@ func (s *Server) agentStatus() *agentStatus {
 		}
 		if len(ohMyCode.AllowedAgents) > 0 {
 			status.OhMyCode.AllowedAgents = append([]string{}, ohMyCode.AllowedAgents...)
+		}
+		if s.agentManager != nil {
+			if routing := s.agentManager.LastRoutingOutcome(); routing != nil {
+				status.OhMyCode.LastRouting = &ohMyCodeRoutingStatus{
+					SelectedAgent: routing.SelectedAgent,
+					Channel:       routing.Channel,
+					ChatID:        routing.ChatID,
+					UserID:        routing.UserID,
+					Username:      routing.Username,
+					Status:        routing.Status,
+					Error:         routing.Error,
+					RecordedAt:    formatStatusTime(routing.RecordedAt),
+				}
+			}
 		}
 	}
 

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -130,6 +132,16 @@ type statusPayload struct {
 			WorkspaceConfigured bool     `json:"workspace_configured"`
 			DefaultAgent        string   `json:"default_agent"`
 			AllowedAgents       []string `json:"allowed_agents"`
+			LastRouting         *struct {
+				SelectedAgent string `json:"selected_agent"`
+				Channel       string `json:"channel"`
+				ChatID        string `json:"chat_id"`
+				UserID        string `json:"user_id"`
+				Username      string `json:"username"`
+				Status        string `json:"status"`
+				Error         string `json:"error"`
+				RecordedAt    string `json:"recorded_at"`
+			} `json:"last_routing"`
 		} `json:"oh_my_code"`
 	} `json:"agents"`
 }
@@ -398,6 +410,90 @@ func TestStatusDoesNotExposeSecrets(t *testing.T) {
 	text := string(body)
 	if strings.Contains(text, "bot-token-secret") || strings.Contains(text, "app-secret") || strings.Contains(text, "cli_secret") {
 		t.Fatalf("status response leaked secrets: %s", text)
+	}
+}
+
+func TestStatusIncludesOhMyCodeRoutingTelemetry(t *testing.T) {
+	workspace := t.TempDir()
+	scriptPath := filepath.Join(workspace, "agent_manager.py")
+
+	script := `import sys
+
+if len(sys.argv) >= 2 and sys.argv[1] == "assign":
+    print("assign ok")
+    sys.exit(0)
+
+print("unexpected command", file=sys.stderr)
+sys.exit(1)
+`
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0644); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	cfg := &config.Config{
+		Gateway: &config.GatewayConfig{
+			Bind: "127.0.0.1",
+			Port: 0,
+		},
+		Channels: &config.ChannelsConfig{},
+		Agents: &config.AgentsConfig{
+			Workspace: workspace,
+			OhMyCode: &config.OhMyCodeConfig{
+				Enabled:            true,
+				Workspace:          workspace,
+				AgentManagerScript: scriptPath,
+				DefaultAgent:       "qa-1",
+			},
+		},
+	}
+
+	server, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	reply, err := server.agentManager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel":  "telegram",
+			"text":     "hello",
+			"chat_id":  int64(321),
+			"user_id":  int64(456),
+			"username": "bob",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming failed: %v", err)
+	}
+	if reply != "处理中…" {
+		t.Fatalf("unexpected reply: %q", reply)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", server.handleStatus)
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	statusResp, err := fetchStatus(ts.URL + "/status")
+	if err != nil {
+		t.Fatalf("status request failed: %v", err)
+	}
+	if statusResp.Agents == nil || statusResp.Agents.OhMyCode == nil || statusResp.Agents.OhMyCode.LastRouting == nil {
+		t.Fatalf("expected last_routing telemetry, got %#v", statusResp.Agents)
+	}
+	routing := statusResp.Agents.OhMyCode.LastRouting
+	if routing.SelectedAgent != "qa-1" {
+		t.Fatalf("selected_agent=%q", routing.SelectedAgent)
+	}
+	if routing.Channel != "telegram" || routing.ChatID != "321" || routing.UserID != "456" || routing.Username != "bob" {
+		t.Fatalf("unexpected routing payload: %#v", routing)
+	}
+	if routing.Status != "assigned" {
+		t.Fatalf("status=%q", routing.Status)
+	}
+	if routing.RecordedAt == "" {
+		t.Fatal("expected recorded_at")
 	}
 }
 


### PR DESCRIPTION
Title: Expose FractalBot routing telemetry on `/status` for heartbeat ingestion

Closes #337

## Summary

This PR adds a thin routing telemetry surface to FractalBot’s existing `/status` response so heartbeat can observe live oh-my-code routing outcomes alongside the existing channel delivery-health fields.

## Changes

- add `agent.Manager.LastRoutingOutcome()` and in-memory routing outcome capture
- record routing success/error from `assignOhMyCode`
- expose `agents.oh_my_code.last_routing` in `/status`
- add focused tests for routing telemetry and `/status` payload coverage

## Touched files

- `internal/agent/manager.go`
- `internal/agent/manager_test.go`
- `internal/gateway/server.go`
- `internal/gateway/server_test.go`

## Acceptance scope

- `/status` remains the only telemetry surface used for this slice
- channel delivery health remains readable without schema breakage
- no new endpoint, sink, worker, or persistence layer is introduced

## Validation

```bash
cd /home/matrix/oh-my-code/workspace/fractalbot
GOPROXY=https://goproxy.cn,direct GOSUMDB=sum.golang.org go test ./internal/agent ./internal/gateway
```

```text
ok  	github.com/fractalmind-ai/fractalbot/internal/agent	(cached)
ok  	github.com/fractalmind-ai/fractalbot/internal/gateway	(cached)
```

## Follow-on heartbeat hook

Heartbeat should poll FractalBot `/status` and ingest:

- `channels[*].running`
- `channels[*].last_error`
- `channels[*].last_activity`
- `agents.oh_my_code.last_routing.*`

That is enough to begin demand-driven cross-project candidate generation without inventing another control plane.

## Risks

- local validation required `GOPROXY=https://goproxy.cn,direct` because the default Go proxy path stalled in this environment
- the local `workspace/fractalbot` checkout is currently snapshot-backed rather than a clean upstream clone
