### PR TITLE
fix(telegram): restore lifecycle commands when using message bus

### DIFF
--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -115,6 +115,43 @@ func (b *MessageBus) HandleIncoming(ctx context.Context, msg *protocol.Message) 
 	}
 }
 
+// MonitorAgent forwards lifecycle monitor requests when the underlying handler
+// supports channel agent lifecycle commands.
+func (b *MessageBus) MonitorAgent(ctx context.Context, agentName string, lines int) (string, error) {
+	lifecycle, ok := b.handler.(channels.AgentLifecycle)
+	if !ok || lifecycle == nil {
+		return "", errors.New("agent-manager is not available")
+	}
+	return lifecycle.MonitorAgent(ctx, agentName, lines)
+}
+
+// StartAgent forwards lifecycle start requests when available.
+func (b *MessageBus) StartAgent(ctx context.Context, agentName string) (string, error) {
+	lifecycle, ok := b.handler.(channels.AgentLifecycle)
+	if !ok || lifecycle == nil {
+		return "", errors.New("agent-manager is not available")
+	}
+	return lifecycle.StartAgent(ctx, agentName)
+}
+
+// StopAgent forwards lifecycle stop requests when available.
+func (b *MessageBus) StopAgent(ctx context.Context, agentName string) (string, error) {
+	lifecycle, ok := b.handler.(channels.AgentLifecycle)
+	if !ok || lifecycle == nil {
+		return "", errors.New("agent-manager is not available")
+	}
+	return lifecycle.StopAgent(ctx, agentName)
+}
+
+// Doctor forwards lifecycle doctor requests when available.
+func (b *MessageBus) Doctor(ctx context.Context) (string, error) {
+	lifecycle, ok := b.handler.(channels.AgentLifecycle)
+	if !ok || lifecycle == nil {
+		return "", errors.New("agent-manager is not available")
+	}
+	return lifecycle.Doctor(ctx)
+}
+
 // PublishOutbound sends an outbound message through the bus.
 // It blocks until the consumer processes the send and returns the result.
 func (b *MessageBus) PublishOutbound(ctx context.Context, channelName string, msg channels.OutboundMessage) error {
@@ -199,6 +236,7 @@ func extractChannelName(msg *protocol.Message) string {
 
 // Ensure MessageBus satisfies IncomingMessageHandler at compile time.
 var _ channels.IncomingMessageHandler = (*MessageBus)(nil)
+var _ channels.AgentLifecycle = (*MessageBus)(nil)
 
 // String returns a human-readable description for debugging.
 func (b *MessageBus) String() string {

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -39,6 +39,34 @@ func (h *fakeHandler) callCount() int {
 	return h.calls
 }
 
+type fakeLifecycleHandler struct {
+	fakeHandler
+	monitorReply string
+	monitorErr   error
+	startReply   string
+	startErr     error
+	stopReply    string
+	stopErr      error
+	doctorReply  string
+	doctorErr    error
+}
+
+func (h *fakeLifecycleHandler) MonitorAgent(ctx context.Context, agentName string, lines int) (string, error) {
+	return h.monitorReply, h.monitorErr
+}
+
+func (h *fakeLifecycleHandler) StartAgent(ctx context.Context, agentName string) (string, error) {
+	return h.startReply, h.startErr
+}
+
+func (h *fakeLifecycleHandler) StopAgent(ctx context.Context, agentName string) (string, error) {
+	return h.stopReply, h.stopErr
+}
+
+func (h *fakeLifecycleHandler) Doctor(ctx context.Context) (string, error) {
+	return h.doctorReply, h.doctorErr
+}
+
 type fakeSender struct {
 	mu      sync.Mutex
 	calls   int
@@ -477,5 +505,75 @@ func TestStatsCountsMessages(t *testing.T) {
 	}
 	if stats.OutboundProcessed != 2 {
 		t.Fatalf("expected 2 outbound processed, got %d", stats.OutboundProcessed)
+	}
+}
+
+func TestLifecycleDelegatesToUnderlyingHandler(t *testing.T) {
+	handler := &fakeLifecycleHandler{
+		monitorReply: "monitor ok",
+		startReply:   "start ok",
+		stopReply:    "stop ok",
+		doctorReply:  "doctor ok",
+	}
+	b := New(handler, &fakeSender{}, 1, 1)
+
+	if got, err := b.MonitorAgent(context.Background(), "main", 10); err != nil || got != "monitor ok" {
+		t.Fatalf("MonitorAgent() = %q, %v", got, err)
+	}
+	if got, err := b.StartAgent(context.Background(), "main"); err != nil || got != "start ok" {
+		t.Fatalf("StartAgent() = %q, %v", got, err)
+	}
+	if got, err := b.StopAgent(context.Background(), "main"); err != nil || got != "stop ok" {
+		t.Fatalf("StopAgent() = %q, %v", got, err)
+	}
+	if got, err := b.Doctor(context.Background()); err != nil || got != "doctor ok" {
+		t.Fatalf("Doctor() = %q, %v", got, err)
+	}
+}
+
+func TestLifecycleReturnsNotAvailableWithoutUnderlyingLifecycle(t *testing.T) {
+	b := New(&fakeHandler{}, &fakeSender{}, 1, 1)
+
+	checks := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "monitor",
+			call: func() error {
+				_, err := b.MonitorAgent(context.Background(), "main", 10)
+				return err
+			},
+		},
+		{
+			name: "start",
+			call: func() error {
+				_, err := b.StartAgent(context.Background(), "main")
+				return err
+			},
+		},
+		{
+			name: "stop",
+			call: func() error {
+				_, err := b.StopAgent(context.Background(), "main")
+				return err
+			},
+		},
+		{
+			name: "doctor",
+			call: func() error {
+				_, err := b.Doctor(context.Background())
+				return err
+			},
+		},
+	}
+
+	for _, tc := range checks {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil || err.Error() != "agent-manager is not available" {
+				t.Fatalf("expected agent-manager unavailable, got %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- forward Telegram/Slack/Discord lifecycle commands through `MessageBus`
- make `MessageBus` satisfy `channels.AgentLifecycle`
- add bus coverage for lifecycle delegation and unavailable-handler fallback

## Root Cause
`channelManager.SetHandler(messageBus)` sets channel handlers to `MessageBus`, but `MessageBus` only implemented `IncomingMessageHandler`.

Telegram lifecycle commands such as `/monitor` type-assert the channel handler to `AgentLifecycle`. After the bus refactor, that assertion failed even though `agent.Manager` still supported the lifecycle methods, so Telegram replied with `agent-manager is not available`.

## Testing
- `go test ./internal/bus ./internal/channels ./internal/agent -run 'Bus|TelegramLifecycle|Monitor|Slack|Discord'`
- locally rebuilt and restarted `fractalbot.service`
- verified Telegram polling recovered and `/monitor main` worked again in live testing
