### PR TITLE
fix: harden imessage inbound dedupe and polling

### DIFF
--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -42,6 +42,7 @@ type imsgWatchEvent struct {
 	Text        string          `json:"text"`
 	Sender      string          `json:"sender"`
 	Timestamp   string          `json:"timestamp"`
+	IsFromMe    bool            `json:"is_from_me"`
 	Attachments json.RawMessage `json:"attachments"`
 }
 
@@ -302,6 +303,9 @@ func (b *IMessageBot) IsAllowed(senderID string) bool {
 func (b *IMessageBot) watchLoop(ctx context.Context) {
 	defer b.wg.Done()
 
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
+
 	for {
 		startWatch := b.startWatchFn
 		if startWatch == nil {
@@ -318,7 +322,8 @@ func (b *IMessageBot) watchLoop(ctx context.Context) {
 			select {
 			case <-ctx.Done():
 				return
-			case <-time.After(5 * time.Second):
+			case <-time.After(backoff):
+				backoff = minBackoff(backoff*2, maxBackoff)
 				continue
 			}
 		}
@@ -338,9 +343,17 @@ func (b *IMessageBot) watchLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(time.Second):
+		case <-time.After(backoff):
+			backoff = minBackoff(backoff*2, maxBackoff)
 		}
 	}
+}
+
+func minBackoff(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func (b *IMessageBot) processImsgStream(ctx context.Context, reader io.ReadCloser) {
@@ -360,6 +373,11 @@ func (b *IMessageBot) processImsgStream(ctx context.Context, reader io.ReadClose
 		var event imsgWatchEvent
 		if err := json.Unmarshal(line, &event); err != nil {
 			log.Printf("imessage: failed to parse imsg event: %v", err)
+			continue
+		}
+
+		// Skip messages sent by this bot — only process genuine inbound.
+		if event.IsFromMe {
 			continue
 		}
 

--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -45,6 +45,22 @@ type imsgWatchEvent struct {
 	Attachments json.RawMessage `json:"attachments"`
 }
 
+type imsgChat struct {
+	ID         int64  `json:"id"`
+	Identifier string `json:"identifier"`
+	Service    string `json:"service"`
+}
+
+type imsgHistoryEvent struct {
+	ID          int64           `json:"id"`
+	ChatID      int64           `json:"chat_id"`
+	Sender      string          `json:"sender"`
+	Text        string          `json:"text"`
+	CreatedAt   string          `json:"created_at"`
+	IsFromMe    bool            `json:"is_from_me"`
+	Attachments json.RawMessage `json:"attachments"`
+}
+
 // IMessageInbound represents a single inbound iMessage entry.
 type IMessageInbound struct {
 	MessageID    int64
@@ -77,6 +93,8 @@ type IMessageBot struct {
 	isMessagesRunning  func(ctx context.Context) (bool, error)
 	startMessagesApp   func(ctx context.Context) error
 	resolveServiceIDFn func(ctx context.Context) (string, error)
+	resolveChatIDFn    func(ctx context.Context, recipient string) (int64, error)
+	fetchHistoryFn     func(ctx context.Context, chatID int64, limit int) ([]imsgHistoryEvent, error)
 	sleepFn            func(d time.Duration)
 
 	resolvedServiceID string
@@ -87,6 +105,8 @@ type IMessageBot struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	watchStartTime time.Time
 
 	telemetryMu  sync.RWMutex
 	lastActivity time.Time
@@ -128,6 +148,8 @@ func NewIMessageBot(recipient, defaultMessage, service string) (*IMessageBot, er
 	bot.isMessagesRunning = bot.defaultIsMessagesRunning
 	bot.startMessagesApp = bot.defaultStartMessagesApp
 	bot.resolveServiceIDFn = bot.defaultResolveServiceID
+	bot.resolveChatIDFn = bot.defaultResolveChatID
+	bot.fetchHistoryFn = bot.defaultFetchHistory
 
 	return bot, nil
 }
@@ -211,6 +233,8 @@ func (b *IMessageBot) Start(ctx context.Context) error {
 	}
 
 	b.ctx, b.cancel = context.WithCancel(ctx)
+	b.watchStartTime = time.Now().UTC()
+	b.setRunning(true)
 
 	// Resolve iMessage service UUID for outbound sending (best-effort).
 	serviceID, err := b.resolveServiceIDFn(b.ctx)
@@ -223,19 +247,28 @@ func (b *IMessageBot) Start(ctx context.Context) error {
 
 	if b.pollingEnabled {
 		if err := b.ensureMessagesRunning(b.ctx); err != nil {
+			b.setRunning(false)
 			b.markError()
 			return err
 		}
 		if err := b.checkPermissionsFn(b.ctx); err != nil {
+			b.setRunning(false)
 			b.markError()
 			return err
 		}
 
+		if err := b.initializeLastSeenMessageID(b.ctx); err != nil {
+			log.Printf("imessage: initial history sync unavailable: %v", err)
+			b.markError()
+		}
+
 		b.wg.Add(1)
 		go b.watchLoop(b.ctx)
+
+		b.wg.Add(1)
+		go b.pollLoop(b.ctx)
 	}
 
-	b.setRunning(true)
 	return nil
 }
 
@@ -334,9 +367,12 @@ func (b *IMessageBot) processImsgStream(ctx context.Context, reader io.ReadClose
 		if strings.TrimSpace(inbound.Text) == "" {
 			continue
 		}
+		if b.shouldDropHistoricalWithoutBaseline(inbound) {
+			continue
+		}
 
-		if inbound.MessageID > 0 {
-			b.setLastSeenMessageID(inbound.MessageID)
+		if !b.claimMessageID(inbound.MessageID) {
+			continue
 		}
 
 		b.handleSingleInbound(ctx, inbound)
@@ -348,7 +384,7 @@ func (b *IMessageBot) processImsgStream(ctx context.Context, reader io.ReadClose
 }
 
 func (b *IMessageBot) defaultStartImsgWatch(ctx context.Context, recipient string) (io.ReadCloser, func() error, error) {
-	cmd := exec.CommandContext(ctx, "imsg", "watch", "--json", "--participants", recipient)
+	cmd := exec.CommandContext(ctx, "imsg", b.buildImsgWatchArgs(recipient)...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, nil, fmt.Errorf("imsg stdout pipe: %w", err)
@@ -359,10 +395,36 @@ func (b *IMessageBot) defaultStartImsgWatch(ctx context.Context, recipient strin
 	return stdout, cmd.Wait, nil
 }
 
+func (b *IMessageBot) buildImsgWatchArgs(recipient string) []string {
+	args := []string{"watch", "--json", "--participants", recipient}
+
+	if lastSeen := b.getLastSeenMessageID(); lastSeen > 0 {
+		args = append(args, "--since-rowid", fmt.Sprintf("%d", lastSeen))
+		return args
+	}
+
+	if !b.watchStartTime.IsZero() {
+		args = append(args, "--start", b.watchStartTime.Format(time.RFC3339))
+	}
+
+	return args
+}
+
 func imsgEventToInbound(event imsgWatchEvent) IMessageInbound {
 	ts, _ := time.Parse(time.RFC3339, event.Timestamp)
 	return IMessageInbound{
 		MessageID:    event.RowID,
+		Sender:       strings.TrimSpace(event.Sender),
+		Text:         strings.TrimSpace(event.Text),
+		Timestamp:    ts,
+		RawTimestamp: ts.UnixNano(),
+	}
+}
+
+func historyEventToInbound(event imsgHistoryEvent) IMessageInbound {
+	ts, _ := time.Parse(time.RFC3339, event.CreatedAt)
+	return IMessageInbound{
+		MessageID:    event.ID,
 		Sender:       strings.TrimSpace(event.Sender),
 		Text:         strings.TrimSpace(event.Text),
 		Timestamp:    ts,
@@ -518,6 +580,98 @@ func (b *IMessageBot) ensureMessagesRunning(ctx context.Context) error {
 	return b.startMessagesApp(ctx)
 }
 
+func (b *IMessageBot) initializeLastSeenMessageID(ctx context.Context) error {
+	resolveChatID := b.resolveChatIDFn
+	if resolveChatID == nil {
+		resolveChatID = b.defaultResolveChatID
+	}
+
+	chatID, err := resolveChatID(ctx, b.recipient)
+	if err != nil {
+		return err
+	}
+
+	fetchHistory := b.fetchHistoryFn
+	if fetchHistory == nil {
+		fetchHistory = b.defaultFetchHistory
+	}
+
+	events, err := fetchHistory(ctx, chatID, 1)
+	if err != nil {
+		return err
+	}
+	if len(events) == 0 || events[0].ID <= 0 {
+		return nil
+	}
+
+	b.setLastSeenMessageID(events[0].ID)
+	log.Printf("imessage: initialized last seen message id=%d for recipient=%s", events[0].ID, b.recipient)
+	return nil
+}
+
+func (b *IMessageBot) pollLoop(ctx context.Context) {
+	defer b.wg.Done()
+
+	for {
+		if err := b.pollOnce(ctx); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Printf("imessage: history poll failed: %v", err)
+			b.markError()
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(b.pollingInterval):
+		}
+	}
+}
+
+func (b *IMessageBot) pollOnce(ctx context.Context) error {
+	resolveChatID := b.resolveChatIDFn
+	if resolveChatID == nil {
+		resolveChatID = b.defaultResolveChatID
+	}
+
+	chatID, err := resolveChatID(ctx, b.recipient)
+	if err != nil {
+		return err
+	}
+
+	fetchHistory := b.fetchHistoryFn
+	if fetchHistory == nil {
+		fetchHistory = b.defaultFetchHistory
+	}
+
+	events, err := fetchHistory(ctx, chatID, b.pollingLimit)
+	if err != nil {
+		return err
+	}
+
+	for i := len(events) - 1; i >= 0; i-- {
+		event := events[i]
+		if event.IsFromMe {
+			continue
+		}
+
+		inbound := historyEventToInbound(event)
+		if strings.TrimSpace(inbound.Text) == "" {
+			continue
+		}
+		if b.shouldDropHistoricalWithoutBaseline(inbound) {
+			continue
+		}
+		if !b.claimMessageID(inbound.MessageID) {
+			continue
+		}
+		b.handleSingleInbound(ctx, inbound)
+	}
+
+	return nil
+}
+
 func (b *IMessageBot) getLastSeenMessageID() int64 {
 	b.lastSeenMu.Lock()
 	defer b.lastSeenMu.Unlock()
@@ -528,6 +682,135 @@ func (b *IMessageBot) setLastSeenMessageID(value int64) {
 	b.lastSeenMu.Lock()
 	b.lastSeenMessageID = value
 	b.lastSeenMu.Unlock()
+}
+
+func (b *IMessageBot) claimMessageID(value int64) bool {
+	if value <= 0 {
+		return true
+	}
+
+	b.lastSeenMu.Lock()
+	defer b.lastSeenMu.Unlock()
+
+	if value <= b.lastSeenMessageID {
+		return false
+	}
+
+	b.lastSeenMessageID = value
+	return true
+}
+
+func (b *IMessageBot) shouldDropHistoricalWithoutBaseline(inbound IMessageInbound) bool {
+	if b.getLastSeenMessageID() > 0 {
+		return false
+	}
+	if b.watchStartTime.IsZero() {
+		return false
+	}
+	if inbound.Timestamp.IsZero() {
+		return false
+	}
+	return inbound.Timestamp.Before(b.watchStartTime)
+}
+
+func (b *IMessageBot) defaultResolveChatID(ctx context.Context, recipient string) (int64, error) {
+	if b.execFn == nil {
+		return 0, errors.New("imessage executor not configured")
+	}
+
+	output, err := b.execFn(ctx, "imsg", "chats", "--json")
+	if err != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return 0, fmt.Errorf("imsg chats failed: %w: %s", err, trimmedOutput)
+		}
+		return 0, fmt.Errorf("imsg chats failed: %w", err)
+	}
+
+	chats, err := parseImsgChats(output)
+	if err != nil {
+		return 0, err
+	}
+
+	trimmedRecipient := strings.TrimSpace(recipient)
+	for _, chat := range chats {
+		if strings.TrimSpace(chat.Identifier) == trimmedRecipient {
+			return chat.ID, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no iMessage chat found for recipient %q", trimmedRecipient)
+}
+
+func (b *IMessageBot) defaultFetchHistory(ctx context.Context, chatID int64, limit int) ([]imsgHistoryEvent, error) {
+	if b.execFn == nil {
+		return nil, errors.New("imessage executor not configured")
+	}
+
+	if chatID <= 0 {
+		return nil, errors.New("imessage chat id is required")
+	}
+
+	if limit <= 0 {
+		limit = defaultIMessagePollingLimit
+	}
+
+	output, err := b.execFn(ctx, "imsg", "history", "--chat-id", fmt.Sprintf("%d", chatID), "--limit", fmt.Sprintf("%d", limit), "--json")
+	if err != nil {
+		trimmedOutput := strings.TrimSpace(string(output))
+		if trimmedOutput != "" {
+			return nil, fmt.Errorf("imsg history failed: %w: %s", err, trimmedOutput)
+		}
+		return nil, fmt.Errorf("imsg history failed: %w", err)
+	}
+
+	return parseImsgHistory(output)
+}
+
+func parseImsgChats(output []byte) ([]imsgChat, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	chats := make([]imsgChat, 0, 4)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var chat imsgChat
+		if err := json.Unmarshal(line, &chat); err != nil {
+			return nil, fmt.Errorf("parse imsg chats output: %w", err)
+		}
+		chats = append(chats, chat)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan imsg chats output: %w", err)
+	}
+
+	return chats, nil
+}
+
+func parseImsgHistory(output []byte) ([]imsgHistoryEvent, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	events := make([]imsgHistoryEvent, 0, 8)
+	for scanner.Scan() {
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+
+		var event imsgHistoryEvent
+		if err := json.Unmarshal(line, &event); err != nil {
+			return nil, fmt.Errorf("parse imsg history output: %w", err)
+		}
+		events = append(events, event)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("scan imsg history output: %w", err)
+	}
+
+	return events, nil
 }
 
 func (b *IMessageBot) send(ctx context.Context, recipient, text string) error {

--- a/internal/channels/imessage_test.go
+++ b/internal/channels/imessage_test.go
@@ -259,6 +259,49 @@ func TestImsgEventToInbound(t *testing.T) {
 	}
 }
 
+func TestBuildImsgWatchArgsUsesSinceRowIDWhenAvailable(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.watchStartTime = time.Date(2026, 3, 22, 18, 15, 59, 0, time.UTC)
+	bot.setLastSeenMessageID(635)
+
+	args := bot.buildImsgWatchArgs("+8619575545051")
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "watch --json --participants +8619575545051 --since-rowid 635") {
+		t.Fatalf("unexpected args: %v", args)
+	}
+	if strings.Contains(got, "--start") {
+		t.Fatalf("expected --start to be omitted when since-rowid is available: %v", args)
+	}
+}
+
+func TestBuildImsgWatchArgsFallsBackToStartTime(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.watchStartTime = time.Date(2026, 3, 22, 18, 15, 59, 0, time.UTC)
+
+	args := bot.buildImsgWatchArgs("+8619575545051")
+	got := strings.Join(args, " ")
+	if !strings.Contains(got, "watch --json --participants +8619575545051 --start 2026-03-22T18:15:59Z") {
+		t.Fatalf("unexpected args: %v", args)
+	}
+	if strings.Contains(got, "--since-rowid") {
+		t.Fatalf("expected --since-rowid to be omitted without baseline: %v", args)
+	}
+}
+
 func TestImsgWatchReconnectsOnProcessExit(t *testing.T) {
 	originalGOOS := currentGOOS
 	currentGOOS = "darwin"
@@ -281,6 +324,7 @@ func TestImsgWatchReconnectsOnProcessExit(t *testing.T) {
 		startCount++
 		if startCount == 1 {
 			// First call: return a single message then EOF (simulates process exit)
+			bot.watchStartTime = time.Time{}
 			events := `{"rowid":1,"text":"first","sender":"+999","timestamp":"2026-03-04T13:00:00Z","attachments":[]}`
 			return io.NopCloser(strings.NewReader(events)), func() error { return nil }, nil
 		}
@@ -517,5 +561,296 @@ func TestHandleSingleInboundDispatchesAndReplies(t *testing.T) {
 	}
 	if bot.LastActivity().IsZero() {
 		t.Fatalf("expected last activity to be set")
+	}
+}
+
+func TestParseImsgChats(t *testing.T) {
+	output := []byte(strings.Join([]string{
+		`{"name":"","last_message_at":"2026-03-22T18:04:26.590Z","identifier":"+8619575545051","id":3,"service":"iMessage"}`,
+		`{"name":"","last_message_at":"2026-02-01T14:12:28.893Z","identifier":"yubing744@gmail.com","id":2,"service":"iMessage"}`,
+	}, "\n"))
+
+	chats, err := parseImsgChats(output)
+	if err != nil {
+		t.Fatalf("parseImsgChats: %v", err)
+	}
+	if len(chats) != 2 {
+		t.Fatalf("len(chats)=%d want 2", len(chats))
+	}
+	if chats[0].ID != 3 {
+		t.Fatalf("chats[0].ID=%d want 3", chats[0].ID)
+	}
+	if chats[0].Identifier != "+8619575545051" {
+		t.Fatalf("chats[0].Identifier=%q want +8619575545051", chats[0].Identifier)
+	}
+}
+
+func TestDefaultResolveChatID(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		if name != "imsg" {
+			t.Fatalf("unexpected command %q", name)
+		}
+		if len(args) != 2 || args[0] != "chats" || args[1] != "--json" {
+			t.Fatalf("unexpected args: %v", args)
+		}
+		return []byte(strings.Join([]string{
+			`{"identifier":"+100","id":1,"service":"iMessage"}`,
+			`{"identifier":"+8619575545051","id":3,"service":"iMessage"}`,
+		}, "\n")), nil
+	}
+
+	chatID, err := bot.defaultResolveChatID(context.Background(), "+8619575545051")
+	if err != nil {
+		t.Fatalf("defaultResolveChatID: %v", err)
+	}
+	if chatID != 3 {
+		t.Fatalf("chatID=%d want 3", chatID)
+	}
+}
+
+func TestParseImsgHistory(t *testing.T) {
+	output := []byte(strings.Join([]string{
+		`{"created_at":"2026-03-22T18:04:26.590Z","chat_id":3,"sender":"+8619575545051","text":"汇报一下OKR进度","id":635,"guid":"FF15563D-6BD5-4691-99FC-B2EFD4C44433","is_from_me":false,"attachments":[],"reactions":[]}`,
+		`{"id":634,"created_at":"2026-03-22T18:01:44.618Z","reactions":[],"sender":"+8619575545051","guid":"C68BF610-041D-4128-88F8-EDAAD93A41C5","chat_id":3,"attachments":[],"text":"FractalBot fully up retest","is_from_me":true}`,
+	}, "\n"))
+
+	events, err := parseImsgHistory(output)
+	if err != nil {
+		t.Fatalf("parseImsgHistory: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("len(events)=%d want 2", len(events))
+	}
+	if events[0].ID != 635 {
+		t.Fatalf("events[0].ID=%d want 635", events[0].ID)
+	}
+	if events[0].Text != "汇报一下OKR进度" {
+		t.Fatalf("events[0].Text=%q want 汇报一下OKR进度", events[0].Text)
+	}
+	if events[0].IsFromMe {
+		t.Fatalf("events[0].IsFromMe=true want false")
+	}
+}
+
+func TestInitializeLastSeenMessageIDUsesLatestHistoryEvent(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	bot.resolveChatIDFn = func(ctx context.Context, recipient string) (int64, error) {
+		_ = ctx
+		if recipient != "+8619575545051" {
+			t.Fatalf("recipient=%q want +8619575545051", recipient)
+		}
+		return 3, nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, chatID int64, limit int) ([]imsgHistoryEvent, error) {
+		_ = ctx
+		if chatID != 3 {
+			t.Fatalf("chatID=%d want 3", chatID)
+		}
+		if limit != 1 {
+			t.Fatalf("limit=%d want 1", limit)
+		}
+		return []imsgHistoryEvent{
+			{ID: 635, IsFromMe: false, Text: "汇报一下OKR进度", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:04:26.590Z"},
+		}, nil
+	}
+
+	if err := bot.initializeLastSeenMessageID(context.Background()); err != nil {
+		t.Fatalf("initializeLastSeenMessageID: %v", err)
+	}
+	if bot.getLastSeenMessageID() != 635 {
+		t.Fatalf("lastSeenMessageID=%d want 635", bot.getLastSeenMessageID())
+	}
+}
+
+func TestPollOnceProcessesOnlyUnseenInboundHistory(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.pollingLimit = 20
+	bot.setLastSeenMessageID(634)
+
+	handler := &fakeIMessageHandler{}
+	bot.SetHandler(handler)
+	bot.resolveChatIDFn = func(ctx context.Context, recipient string) (int64, error) {
+		_ = ctx
+		_ = recipient
+		return 3, nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, chatID int64, limit int) ([]imsgHistoryEvent, error) {
+		_ = ctx
+		if chatID != 3 {
+			t.Fatalf("chatID=%d want 3", chatID)
+		}
+		if limit != 20 {
+			t.Fatalf("limit=%d want 20", limit)
+		}
+		return []imsgHistoryEvent{
+			{ID: 636, IsFromMe: true, Text: "reply", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:05:26.590Z"},
+			{ID: 635, IsFromMe: false, Text: "汇报一下OKR进度", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:04:26.590Z"},
+			{ID: 634, IsFromMe: true, Text: "FractalBot fully up retest", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:01:44.618Z"},
+		}, nil
+	}
+
+	if err := bot.pollOnce(context.Background()); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler calls=%d want 1", handler.calls)
+	}
+	data := handler.msgs[0].Data.(map[string]interface{})
+	if data["text"] != "汇报一下OKR进度" {
+		t.Fatalf("text=%q want 汇报一下OKR进度", data["text"])
+	}
+	if bot.getLastSeenMessageID() != 635 {
+		t.Fatalf("lastSeenMessageID=%d want 635", bot.getLastSeenMessageID())
+	}
+
+	if err := bot.pollOnce(context.Background()); err != nil {
+		t.Fatalf("pollOnce second call: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler calls=%d want 1 after dedupe", handler.calls)
+	}
+}
+
+func TestWatchAndPollDeduplicateByMessageID(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+
+	handler := &fakeIMessageHandler{}
+	bot.SetHandler(handler)
+	bot.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return nil, nil
+	}
+	bot.resolveChatIDFn = func(ctx context.Context, recipient string) (int64, error) {
+		_ = ctx
+		_ = recipient
+		return 3, nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, chatID int64, limit int) ([]imsgHistoryEvent, error) {
+		_ = ctx
+		_ = limit
+		if chatID != 3 {
+			t.Fatalf("chatID=%d want 3", chatID)
+		}
+		return []imsgHistoryEvent{
+			{ID: 635, IsFromMe: false, Text: "same message", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:04:26.590Z"},
+		}, nil
+	}
+
+	reader := io.NopCloser(strings.NewReader(`{"rowid":635,"text":"same message","sender":"+8619575545051","timestamp":"2026-03-22T18:04:26.590Z","attachments":[]}`))
+	bot.processImsgStream(context.Background(), reader)
+
+	if err := bot.pollOnce(context.Background()); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler calls=%d want 1", handler.calls)
+	}
+}
+
+func TestImsgWatchDropsHistoricalMessagesBeforeStartWhenNoBaseline(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.watchStartTime = time.Date(2026, 3, 22, 18, 27, 10, 0, time.UTC)
+
+	handler := &fakeIMessageHandler{}
+	bot.SetHandler(handler)
+
+	reader := io.NopCloser(strings.NewReader(strings.Join([]string{
+		`{"rowid":635,"text":"old message","sender":"+8619575545051","timestamp":"2026-03-22T18:23:59Z","attachments":[]}`,
+		`{"rowid":636,"text":"new message","sender":"+8619575545051","timestamp":"2026-03-22T18:27:11Z","attachments":[]}`,
+	}, "\n")))
+
+	bot.processImsgStream(context.Background(), reader)
+
+	if handler.calls != 1 {
+		t.Fatalf("handler calls=%d want 1", handler.calls)
+	}
+	data := handler.msgs[0].Data.(map[string]interface{})
+	if data["text"] != "new message" {
+		t.Fatalf("text=%q want new message", data["text"])
+	}
+	if bot.getLastSeenMessageID() != 636 {
+		t.Fatalf("lastSeenMessageID=%d want 636", bot.getLastSeenMessageID())
+	}
+}
+
+func TestPollOnceDropsHistoricalMessagesBeforeStartWhenNoBaseline(t *testing.T) {
+	originalGOOS := currentGOOS
+	currentGOOS = "darwin"
+	defer func() { currentGOOS = originalGOOS }()
+
+	bot, err := NewIMessageBot("+8619575545051", "", "")
+	if err != nil {
+		t.Fatalf("NewIMessageBot: %v", err)
+	}
+	bot.watchStartTime = time.Date(2026, 3, 22, 18, 27, 10, 0, time.UTC)
+	bot.pollingLimit = 20
+
+	handler := &fakeIMessageHandler{}
+	bot.SetHandler(handler)
+	bot.resolveChatIDFn = func(ctx context.Context, recipient string) (int64, error) {
+		_ = ctx
+		_ = recipient
+		return 3, nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, chatID int64, limit int) ([]imsgHistoryEvent, error) {
+		_ = ctx
+		_ = chatID
+		_ = limit
+		return []imsgHistoryEvent{
+			{ID: 635, IsFromMe: false, Text: "old message", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:23:59Z"},
+			{ID: 636, IsFromMe: false, Text: "new message", Sender: "+8619575545051", CreatedAt: "2026-03-22T18:27:11Z"},
+		}, nil
+	}
+
+	if err := bot.pollOnce(context.Background()); err != nil {
+		t.Fatalf("pollOnce: %v", err)
+	}
+	if handler.calls != 1 {
+		t.Fatalf("handler calls=%d want 1", handler.calls)
+	}
+	data := handler.msgs[0].Data.(map[string]interface{})
+	if data["text"] != "new message" {
+		t.Fatalf("text=%q want new message", data["text"])
+	}
+	if bot.getLastSeenMessageID() != 636 {
+		t.Fatalf("lastSeenMessageID=%d want 636", bot.getLastSeenMessageID())
 	}
 }


### PR DESCRIPTION
## Summary
- add a real iMessage history polling path using `imsg chats --json` and `imsg history --json`
- initialize `lastSeenMessageID` on startup and dedupe watch/history events by message id
- bound `imsg watch` with `--since-rowid` or startup time and drop pre-start messages when no baseline is available
- add coverage for chat/history parsing, baseline initialization, replay protection, and watch/poll dedupe

## Why
In the current iMessage channel, `pollingEnabled` only starts `imsg watch`, but there is no actual history polling/backfill implementation. If `imsg watch` misses events or later replays old events, inbound messages can be dropped or replayed in bulk into the routed agent.

This change adds the missing history path and hardens startup/reconnect behavior so older messages do not get re-delivered after restarts.

## Testing
- `go test ./...`
