### PR TITLE
feat: channel metadata, send response, and body-only file-wrap

### DIFF
--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
@@ -117,6 +119,14 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 	text = strings.TrimSpace(text)
 	if text == "" {
 		return "", nil
+	}
+
+	// Apply channel-agnostic body wrapping: short bodies stay inline,
+	// long bodies are written to a file so downstream consumers can
+	// skip a second file-wrap pass.
+	bodyDir := filepath.Join(os.TempDir(), "fractalbot", "bodies")
+	if err := channels.WrapMessageBody(msg, bodyDir); err != nil {
+		log.Printf("body wrap: %v", err)
 	}
 
 	if isRuntimeToolInvocation(text) {
@@ -392,6 +402,8 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 	username := promptContextValue(inboundData, "username")
 	trustLevel := promptContextValue(inboundData, "trust_level")
 	threadTS := promptContextValue(inboundData, "thread_ts")
+	bodyMode := promptContextValue(inboundData, "body_mode")
+	bodyFile := promptContextValue(inboundData, "body_file")
 
 	var sb strings.Builder
 	sb.WriteString("# Task Assignment\n\n")
@@ -404,6 +416,12 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 	if threadTS != "" {
 		sb.WriteString(fmt.Sprintf("- thread_ts: %s\n", threadTS))
 	}
+	if bodyMode != "" {
+		sb.WriteString(fmt.Sprintf("- body_mode: %s\n", bodyMode))
+	}
+	if bodyFile != "" {
+		sb.WriteString(fmt.Sprintf("- body_file: %s\n", bodyFile))
+	}
 	sb.WriteString("\n")
 	sb.WriteString("Routing instructions:\n")
 	sb.WriteString("- selected_agent is the final routing target after default/allowlist resolution.\n")
@@ -412,6 +430,9 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 	sb.WriteString("- Effective available skills:\n")
 	sb.WriteString("  - use-fractalbot (.claude/skills/use-fractalbot/SKILL.md)\n")
 	sb.WriteString("- If channel=telegram and recipient is omitted, default to current chat_id.\n")
+	if bodyMode == channels.BodyModeFilePointer {
+		sb.WriteString("- body_mode=file_pointer: the user message body is in the file above. Read it with your file tools. Do NOT re-wrap it into another file.\n")
+	}
 	sb.WriteString("\n")
 
 	// Insert recent conversation context if available.
@@ -437,11 +458,15 @@ func buildOhMyCodeTaskPrompt(userText, selectedAgent string, inboundData map[str
 		sb.WriteString("\n")
 	}
 
-	sb.WriteString("User message:\n")
-	if trustLevel == "full" || trustLevel == "" {
+	// When body is file-backed, reference the file instead of embedding the full text.
+	if bodyMode == channels.BodyModeFilePointer && bodyFile != "" {
+		sb.WriteString(fmt.Sprintf("User message body: see file %s\n", bodyFile))
+	} else if trustLevel == "full" || trustLevel == "" {
+		sb.WriteString("User message:\n")
 		sb.WriteString(strings.TrimSpace(userText))
 		sb.WriteString("\n")
 	} else {
+		sb.WriteString("User message:\n")
 		sb.WriteString("<user_input>\n")
 		sb.WriteString(strings.TrimSpace(userText))
 		sb.WriteString("\n</user_input>\n")

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 )
@@ -497,4 +498,103 @@ func TestBuildPromptWithoutRecentMessages(t *testing.T) {
 	if !strings.Contains(out, "User message:\nhello\n") {
 		t.Fatalf("expected user message, got %q", out)
 	}
+}
+
+func TestBuildPromptBodyModeFilePointer(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("this text is ignored when file-backed", "main", map[string]interface{}{
+		"channel":   "slack",
+		"chat_id":   "C123",
+		"user_id":   "U123",
+		"body_mode": channels.BodyModeFilePointer,
+		"body_file": "/tmp/fractalbot/bodies/body-123.md",
+	})
+
+	if !strings.Contains(out, "- body_mode: file_pointer") {
+		t.Fatalf("expected body_mode in routing context, got %q", out)
+	}
+	if !strings.Contains(out, "- body_file: /tmp/fractalbot/bodies/body-123.md") {
+		t.Fatalf("expected body_file in routing context, got %q", out)
+	}
+	if !strings.Contains(out, "see file /tmp/fractalbot/bodies/body-123.md") {
+		t.Fatalf("expected file reference in user message section, got %q", out)
+	}
+	if strings.Contains(out, "this text is ignored") {
+		t.Fatalf("expected inline text to be omitted when file-backed, got %q", out)
+	}
+	if !strings.Contains(out, "Do NOT re-wrap it into another file") {
+		t.Fatalf("expected no-double-wrap instruction, got %q", out)
+	}
+}
+
+func TestBuildPromptBodyModeInlineUnchanged(t *testing.T) {
+	out := buildOhMyCodeTaskPrompt("hello inline", "main", map[string]interface{}{
+		"channel":     "slack",
+		"chat_id":     "C123",
+		"user_id":     "U123",
+		"body_mode":   channels.BodyModeInline,
+		"trust_level": "full",
+	})
+
+	if !strings.Contains(out, "User message:\nhello inline\n") {
+		t.Fatalf("expected inline body, got %q", out)
+	}
+	if strings.Contains(out, "body_file") {
+		t.Fatalf("expected no body_file for inline mode, got %q", out)
+	}
+}
+
+func TestHandleIncomingBodyWrapShortMessage(t *testing.T) {
+	manager := NewManager(&config.AgentsConfig{})
+
+	msg := &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "slack",
+			"text":    "short message",
+		},
+	}
+
+	_, _ = manager.HandleIncoming(context.Background(), msg)
+
+	data := msg.Data.(map[string]interface{})
+	if data["body_mode"] != channels.BodyModeInline {
+		t.Fatalf("body_mode=%v, want inline", data["body_mode"])
+	}
+	if data["body_text"] != "short message" {
+		t.Fatalf("body_text=%v", data["body_text"])
+	}
+}
+
+func TestHandleIncomingBodyWrapLongMessage(t *testing.T) {
+	manager := NewManager(&config.AgentsConfig{})
+
+	longText := strings.Repeat("This is a long line of text for testing.\n", 15)
+	msg := &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "slack",
+			"text":    longText,
+		},
+	}
+
+	_, _ = manager.HandleIncoming(context.Background(), msg)
+
+	data := msg.Data.(map[string]interface{})
+	if data["body_mode"] != channels.BodyModeFilePointer {
+		t.Fatalf("body_mode=%v, want file_pointer", data["body_mode"])
+	}
+
+	bodyFile, ok := data["body_file"].(string)
+	if !ok || bodyFile == "" {
+		t.Fatal("body_file should be set")
+	}
+
+	content, err := os.ReadFile(bodyFile)
+	if err != nil {
+		t.Fatalf("read body file: %v", err)
+	}
+	if string(content) != longText {
+		t.Fatal("file content mismatch")
+	}
+
+	// Cleanup
+	_ = os.Remove(bodyFile)
 }

--- a/internal/bus/bus.go
+++ b/internal/bus/bus.go
@@ -14,7 +14,7 @@ import (
 // ChannelSender routes outbound messages to the correct channel.
 // Satisfied by channels.Manager.
 type ChannelSender interface {
-	Send(ctx context.Context, channelName string, msg channels.OutboundMessage) error
+	Send(ctx context.Context, channelName string, msg channels.OutboundMessage) (*channels.SendResult, error)
 }
 
 // InboundMessage wraps a protocol message with routing metadata.
@@ -30,13 +30,19 @@ type inboundReply struct {
 	Err  error
 }
 
+// outboundResult pairs a send result with an error for channel communication.
+type outboundResult struct {
+	Result *channels.SendResult
+	Err    error
+}
+
 // OutboundEnvelope wraps an outbound message with its target channel and
-// a completion channel for synchronous error reporting.
+// a completion channel for synchronous result reporting.
 type OutboundEnvelope struct {
 	Ctx         context.Context
 	ChannelName string
 	Message     channels.OutboundMessage
-	errCh       chan error
+	resultCh    chan outboundResult
 }
 
 // Stats holds message processing counters.
@@ -154,30 +160,30 @@ func (b *MessageBus) Doctor(ctx context.Context) (string, error) {
 
 // PublishOutbound sends an outbound message through the bus.
 // It blocks until the consumer processes the send and returns the result.
-func (b *MessageBus) PublishOutbound(ctx context.Context, channelName string, msg channels.OutboundMessage) error {
+func (b *MessageBus) PublishOutbound(ctx context.Context, channelName string, msg channels.OutboundMessage) (*channels.SendResult, error) {
 	if b.closed.Load() {
-		return errors.New("bus is closed")
+		return nil, errors.New("bus is closed")
 	}
 
-	errCh := make(chan error, 1)
+	resultCh := make(chan outboundResult, 1)
 	env := &OutboundEnvelope{
 		Ctx:         ctx,
 		ChannelName: channelName,
 		Message:     msg,
-		errCh:       errCh,
+		resultCh:    resultCh,
 	}
 
 	select {
 	case b.outbound <- env:
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 
 	select {
-	case err := <-errCh:
-		return err
+	case res := <-resultCh:
+		return res.Result, res.Err
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil, ctx.Err()
 	}
 }
 
@@ -215,8 +221,8 @@ func (b *MessageBus) consumeInbound() {
 func (b *MessageBus) consumeOutbound() {
 	defer b.wg.Done()
 	for env := range b.outbound {
-		err := b.sender.Send(env.Ctx, env.ChannelName, env.Message)
-		env.errCh <- err
+		result, err := b.sender.Send(env.Ctx, env.ChannelName, env.Message)
+		env.resultCh <- outboundResult{Result: result, Err: err}
 		b.outboundProcessed.Add(1)
 	}
 }

--- a/internal/bus/bus_test.go
+++ b/internal/bus/bus_test.go
@@ -75,14 +75,17 @@ type fakeSender struct {
 	sendErr error
 }
 
-func (s *fakeSender) Send(ctx context.Context, channelName string, msg channels.OutboundMessage) error {
+func (s *fakeSender) Send(ctx context.Context, channelName string, msg channels.OutboundMessage) (*channels.SendResult, error) {
 	s.mu.Lock()
 	s.calls++
 	s.lastCh = channelName
 	s.lastMsg = msg
 	err := s.sendErr
 	s.mu.Unlock()
-	return err
+	if err != nil {
+		return nil, err
+	}
+	return &channels.SendResult{ChannelID: msg.To}, nil
 }
 
 func (s *fakeSender) callCount() int {
@@ -178,12 +181,15 @@ func TestOutboundPublishAndConsume(t *testing.T) {
 	b.Start()
 	defer func() { b.Close(); b.Wait() }()
 
-	err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{
+	result, err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{
 		To:   "12345",
 		Text: "hello from bus",
 	})
 	if err != nil {
 		t.Fatalf("PublishOutbound: %v", err)
+	}
+	if result == nil || result.ChannelID != "12345" {
+		t.Fatalf("expected SendResult with ChannelID=12345, got %v", result)
 	}
 	if sender.callCount() != 1 {
 		t.Fatalf("expected 1 sender call, got %d", sender.callCount())
@@ -208,7 +214,7 @@ func TestOutboundSendError(t *testing.T) {
 	b.Start()
 	defer func() { b.Close(); b.Wait() }()
 
-	err := b.PublishOutbound(context.Background(), "slack", channels.OutboundMessage{
+	_, err := b.PublishOutbound(context.Background(), "slack", channels.OutboundMessage{
 		To:   "C123",
 		Text: "test",
 	})
@@ -224,7 +230,7 @@ func TestOutboundWithThreadTS(t *testing.T) {
 	b.Start()
 	defer func() { b.Close(); b.Wait() }()
 
-	err := b.PublishOutbound(context.Background(), "slack", channels.OutboundMessage{
+	_, err := b.PublishOutbound(context.Background(), "slack", channels.OutboundMessage{
 		To:       "C123",
 		Text:     "reply",
 		ThreadTS: "1234567890.123456",
@@ -283,7 +289,7 @@ func TestPublishOutboundContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
-	err := b2.PublishOutbound(ctx, "telegram", channels.OutboundMessage{To: "1", Text: "x"})
+	_, err := b2.PublishOutbound(ctx, "telegram", channels.OutboundMessage{To: "1", Text: "x"})
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("expected context.DeadlineExceeded, got %v", err)
 	}
@@ -302,7 +308,7 @@ func TestClosePreventsFurtherPublish(t *testing.T) {
 		t.Fatalf("expected 'bus is closed', got %v", err)
 	}
 
-	err = b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"})
+	_, err = b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"})
 	if err == nil || err.Error() != "bus is closed" {
 		t.Fatalf("expected 'bus is closed', got %v", err)
 	}
@@ -383,7 +389,7 @@ func TestConcurrentPublish(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < perGoroutine; j++ {
-				err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"})
+				_, err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"})
 				if err != nil {
 					t.Errorf("outbound error: %v", err)
 				}
@@ -494,7 +500,7 @@ func TestStatsCountsMessages(t *testing.T) {
 
 	// Send 2 outbound messages
 	for i := 0; i < 2; i++ {
-		if err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"}); err != nil {
+		if _, err := b.PublishOutbound(context.Background(), "telegram", channels.OutboundMessage{To: "1", Text: "x"}); err != nil {
 			t.Fatalf("PublishOutbound: %v", err)
 		}
 	}

--- a/internal/channels/body_wrap.go
+++ b/internal/channels/body_wrap.go
@@ -1,0 +1,88 @@
+package channels
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+const (
+	// BodyModeInline means the message body is carried inline in the data map.
+	BodyModeInline = "inline"
+	// BodyModeFilePointer means the body was written to a file; body_file holds the path.
+	BodyModeFilePointer = "file_pointer"
+
+	// bodyLineThreshold triggers file-backing when the body has this many lines or more.
+	bodyLineThreshold = 12
+	// bodyCharThreshold triggers file-backing when the body has this many characters or more.
+	bodyCharThreshold = 1800
+)
+
+// IsLongBody returns true when text exceeds the long-body thresholds.
+func IsLongBody(text string) bool {
+	if len(text) >= bodyCharThreshold {
+		return true
+	}
+	return strings.Count(text, "\n")+1 >= bodyLineThreshold
+}
+
+// WrapMessageBody evaluates the "text" field in msg.Data and annotates the
+// message with body_mode metadata. If the body exceeds the long-body threshold
+// and bodyDir is non-empty, the body is written to a file and body_file is set.
+//
+// The original "text" key is preserved for backward compatibility. Callers that
+// understand body_mode should prefer body_file (when file_pointer) or body_text
+// (when inline) over the raw text field.
+func WrapMessageBody(msg *protocol.Message, bodyDir string) error {
+	if msg == nil {
+		return nil
+	}
+	data, ok := msg.Data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	text, _ := data["text"].(string)
+	if strings.TrimSpace(text) == "" {
+		return nil
+	}
+
+	if !IsLongBody(text) {
+		data["body_mode"] = BodyModeInline
+		data["body_text"] = text
+		return nil
+	}
+
+	// Long body — attempt to write to file.
+	if strings.TrimSpace(bodyDir) == "" {
+		bodyDir = filepath.Join(os.TempDir(), "fractalbot", "bodies")
+	}
+	if err := os.MkdirAll(bodyDir, 0755); err != nil {
+		log.Printf("body_wrap: cannot create dir %s: %v; keeping inline", bodyDir, err)
+		data["body_mode"] = BodyModeInline
+		data["body_text"] = text
+		return nil
+	}
+
+	filename := fmt.Sprintf("body-%d.md", time.Now().UnixNano())
+	filePath := filepath.Join(bodyDir, filename)
+	if err := os.WriteFile(filePath, []byte(text), 0644); err != nil {
+		log.Printf("body_wrap: write failed %s: %v; keeping inline", filePath, err)
+		data["body_mode"] = BodyModeInline
+		data["body_text"] = text
+		return nil
+	}
+
+	hash := sha256.Sum256([]byte(text))
+	data["body_mode"] = BodyModeFilePointer
+	data["body_file"] = filePath
+	data["body_sha256"] = fmt.Sprintf("%x", hash)
+
+	return nil
+}

--- a/internal/channels/body_wrap_test.go
+++ b/internal/channels/body_wrap_test.go
@@ -1,0 +1,167 @@
+package channels
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+func TestIsLongBodyShort(t *testing.T) {
+	if IsLongBody("hello") {
+		t.Fatal("expected short body")
+	}
+}
+
+func TestIsLongBodyByChars(t *testing.T) {
+	long := strings.Repeat("x", bodyCharThreshold)
+	if !IsLongBody(long) {
+		t.Fatalf("expected long body at %d chars", bodyCharThreshold)
+	}
+}
+
+func TestIsLongBodyByLines(t *testing.T) {
+	lines := strings.Repeat("line\n", bodyLineThreshold)
+	if !IsLongBody(lines) {
+		t.Fatalf("expected long body at %d lines", bodyLineThreshold)
+	}
+}
+
+func TestIsLongBodyBelowThreshold(t *testing.T) {
+	text := strings.Repeat("line\n", bodyLineThreshold-2)
+	if IsLongBody(text) {
+		t.Fatal("expected short body below line threshold")
+	}
+}
+
+func TestWrapMessageBodyNilMessage(t *testing.T) {
+	if err := WrapMessageBody(nil, ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWrapMessageBodyInline(t *testing.T) {
+	msg := &protocol.Message{
+		Kind: protocol.MessageKindChannel,
+		Data: map[string]interface{}{
+			"channel": "slack",
+			"text":    "short message",
+		},
+	}
+
+	if err := WrapMessageBody(msg, ""); err != nil {
+		t.Fatalf("WrapMessageBody: %v", err)
+	}
+
+	data := msg.Data.(map[string]interface{})
+	if data["body_mode"] != BodyModeInline {
+		t.Fatalf("body_mode=%v, want %s", data["body_mode"], BodyModeInline)
+	}
+	if data["body_text"] != "short message" {
+		t.Fatalf("body_text=%v", data["body_text"])
+	}
+	// text should still be present for backward compat.
+	if data["text"] != "short message" {
+		t.Fatalf("text should be preserved, got %v", data["text"])
+	}
+}
+
+func TestWrapMessageBodyFilePointer(t *testing.T) {
+	bodyDir := t.TempDir()
+	longText := strings.Repeat("This is a long line of text.\n", bodyLineThreshold+5)
+
+	msg := &protocol.Message{
+		Kind: protocol.MessageKindChannel,
+		Data: map[string]interface{}{
+			"channel": "telegram",
+			"text":    longText,
+		},
+	}
+
+	if err := WrapMessageBody(msg, bodyDir); err != nil {
+		t.Fatalf("WrapMessageBody: %v", err)
+	}
+
+	data := msg.Data.(map[string]interface{})
+	if data["body_mode"] != BodyModeFilePointer {
+		t.Fatalf("body_mode=%v, want %s", data["body_mode"], BodyModeFilePointer)
+	}
+
+	bodyFile, ok := data["body_file"].(string)
+	if !ok || bodyFile == "" {
+		t.Fatal("body_file should be set")
+	}
+	if !strings.HasPrefix(bodyFile, bodyDir) {
+		t.Fatalf("body_file=%s not in bodyDir=%s", bodyFile, bodyDir)
+	}
+
+	sha, ok := data["body_sha256"].(string)
+	if !ok || sha == "" {
+		t.Fatal("body_sha256 should be set")
+	}
+
+	// Verify file contents match original text.
+	content, err := os.ReadFile(bodyFile)
+	if err != nil {
+		t.Fatalf("read body file: %v", err)
+	}
+	if string(content) != longText {
+		t.Fatalf("file content mismatch")
+	}
+
+	// text should still be present for backward compat.
+	if data["text"] != longText {
+		t.Fatalf("text should be preserved")
+	}
+}
+
+func TestWrapMessageBodyEmptyText(t *testing.T) {
+	msg := &protocol.Message{
+		Kind: protocol.MessageKindChannel,
+		Data: map[string]interface{}{
+			"channel": "slack",
+			"text":    "",
+		},
+	}
+
+	if err := WrapMessageBody(msg, ""); err != nil {
+		t.Fatalf("WrapMessageBody: %v", err)
+	}
+
+	data := msg.Data.(map[string]interface{})
+	if _, ok := data["body_mode"]; ok {
+		t.Fatal("body_mode should not be set for empty text")
+	}
+}
+
+func TestWrapMessageBodyFallbackOnBadDir(t *testing.T) {
+	// Use a directory that cannot be created (nested under a file).
+	tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(tmpFile, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	badDir := filepath.Join(tmpFile, "subdir")
+
+	longText := strings.Repeat("x", bodyCharThreshold+100)
+	msg := &protocol.Message{
+		Kind: protocol.MessageKindChannel,
+		Data: map[string]interface{}{
+			"text": longText,
+		},
+	}
+
+	if err := WrapMessageBody(msg, badDir); err != nil {
+		t.Fatalf("WrapMessageBody: %v", err)
+	}
+
+	data := msg.Data.(map[string]interface{})
+	// Should fall back to inline.
+	if data["body_mode"] != BodyModeInline {
+		t.Fatalf("body_mode=%v, want inline fallback", data["body_mode"])
+	}
+	if data["body_text"] != longText {
+		t.Fatal("body_text should contain original text on fallback")
+	}
+}

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -10,9 +10,18 @@ type Channel interface {
 	Name() string
 	Start(ctx context.Context) error
 	Stop(ctx context.Context) error
-	Send(ctx context.Context, msg OutboundMessage) error
+	Send(ctx context.Context, msg OutboundMessage) (*SendResult, error)
 	IsRunning() bool
 	IsAllowed(senderID string) bool
+}
+
+// SendResult carries metadata about a successfully sent message.
+// Fields are best-effort: channels populate what they can.
+type SendResult struct {
+	ChannelID   string `json:"channel_id,omitempty"`
+	ChannelName string `json:"channel_name,omitempty"`
+	MessageTS   string `json:"message_ts,omitempty"`
+	ThreadTS    string `json:"thread_ts,omitempty"`
 }
 
 // OutboundMessage carries all data needed to send a message through a channel.

--- a/internal/channels/discord.go
+++ b/internal/channels/discord.go
@@ -137,19 +137,19 @@ func (b *DiscordBot) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (b *DiscordBot) Send(ctx context.Context, msg OutboundMessage) error {
+func (b *DiscordBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	if b.sendMessageFn == nil {
-		return errors.New("discord sender not configured")
+		return nil, errors.New("discord sender not configured")
 	}
 	if strings.TrimSpace(msg.To) == "" {
-		return errors.New("discord channel ID is required")
+		return nil, errors.New("discord channel ID is required")
 	}
 	if err := b.sendMessageFn(ctx, msg.To, msg.Text); err != nil {
 		b.markError()
-		return err
+		return nil, err
 	}
 	b.markActivity()
-	return nil
+	return &SendResult{ChannelID: msg.To}, nil
 }
 
 // IsAllowed reports whether senderID is on the allowlist.

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -156,19 +156,19 @@ func (b *FeishuBot) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (b *FeishuBot) Send(ctx context.Context, msg OutboundMessage) error {
+func (b *FeishuBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	if b.sendMessageFn == nil {
-		return errors.New("feishu sender not configured")
+		return nil, errors.New("feishu sender not configured")
 	}
 	if strings.TrimSpace(msg.To) == "" {
-		return errors.New("feishu receive_id is required")
+		return nil, errors.New("feishu receive_id is required")
 	}
 	if err := b.sendMessageFn(ctx, "open_id", msg.To, msg.Text); err != nil {
 		b.markError()
-		return err
+		return nil, err
 	}
 	b.markActivity()
-	return nil
+	return &SendResult{ChannelID: msg.To}, nil
 }
 
 // IsAllowed reports whether senderID is on the allowlist.

--- a/internal/channels/imessage.go
+++ b/internal/channels/imessage.go
@@ -249,7 +249,7 @@ func (b *IMessageBot) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (b *IMessageBot) Send(ctx context.Context, msg OutboundMessage) error {
+func (b *IMessageBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	recipient := strings.TrimSpace(msg.To)
 	if recipient == "" {
 		recipient = b.recipient
@@ -258,7 +258,10 @@ func (b *IMessageBot) Send(ctx context.Context, msg OutboundMessage) error {
 	if message == "" {
 		message = b.defaultMessage
 	}
-	return b.send(ctx, recipient, message)
+	if err := b.send(ctx, recipient, message); err != nil {
+		return nil, err
+	}
+	return &SendResult{ChannelID: recipient}, nil
 }
 
 // IsAllowed always returns true for iMessage (single-recipient channel).

--- a/internal/channels/imessage_test.go
+++ b/internal/channels/imessage_test.go
@@ -61,7 +61,7 @@ func TestIMessageBotSendMessageUsesAppleScript(t *testing.T) {
 		return []byte("ok"), nil
 	}
 
-	if err := bot.Send(context.Background(), OutboundMessage{Text: "hello from test"}); err != nil {
+	if _, err := bot.Send(context.Background(), OutboundMessage{Text: "hello from test"}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 
@@ -106,7 +106,7 @@ func TestIMessageBotSendFallsBackToConfiguredMessage(t *testing.T) {
 		return nil, nil
 	}
 
-	if err := bot.Send(context.Background(), OutboundMessage{}); err != nil {
+	if _, err := bot.Send(context.Background(), OutboundMessage{}); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
 	if !strings.Contains(script, `send "configured default"`) {

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -146,19 +146,20 @@ func (m *Manager) Stop() error {
 	return nil
 }
 
-// Send routes an outbound message through the channel's worker queue.
-// Returns error if the channel is not found or the queue is full.
-func (m *Manager) Send(ctx context.Context, channelName string, msg OutboundMessage) error {
+// Send routes an outbound message through the channel's worker.
+// It performs a synchronous send with rate limiting and returns result metadata.
+// Returns error if the channel is not found.
+func (m *Manager) Send(ctx context.Context, channelName string, msg OutboundMessage) (*SendResult, error) {
 	w, ok := m.workers[channelName]
 	if !ok {
 		// Fallback to direct send if worker not started yet
 		ch := m.Get(channelName)
 		if ch == nil {
-			return fmt.Errorf("channel %q not found", channelName)
+			return nil, fmt.Errorf("channel %q not found", channelName)
 		}
 		return ch.Send(ctx, msg)
 	}
-	return w.enqueue(msg)
+	return w.sendSync(ctx, msg)
 }
 
 func (m *Manager) startChannel(name string, channel Channel, ctx context.Context) {

--- a/internal/channels/manager_test.go
+++ b/internal/channels/manager_test.go
@@ -37,11 +37,11 @@ func (f *fakeChannel) Stop(ctx context.Context) error {
 	return f.stopErr
 }
 
-func (f *fakeChannel) Send(ctx context.Context, msg OutboundMessage) error {
+func (f *fakeChannel) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	_ = ctx
 	f.lastChat = msg.To
 	f.lastText = msg.Text
-	return nil
+	return &SendResult{ChannelID: msg.To}, nil
 }
 
 func (f *fakeChannel) IsRunning() bool { return f.running }
@@ -169,9 +169,9 @@ func (b *blockingStartChannel) Start(ctx context.Context) error {
 
 func (b *blockingStartChannel) Stop(ctx context.Context) error { _ = ctx; return nil }
 
-func (b *blockingStartChannel) Send(ctx context.Context, msg OutboundMessage) error {
+func (b *blockingStartChannel) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	_ = ctx
-	return nil
+	return nil, nil
 }
 
 func (b *blockingStartChannel) IsRunning() bool { return false }
@@ -298,8 +298,8 @@ func (c *contextObservingChannel) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (c *contextObservingChannel) Send(ctx context.Context, msg OutboundMessage) error {
-	return nil
+func (c *contextObservingChannel) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
+	return nil, nil
 }
 
 func (c *contextObservingChannel) IsRunning() bool { return c.running }
@@ -322,6 +322,6 @@ func (p *panickingChannel) Start(ctx context.Context) error {
 func (p *panickingChannel) Stop(ctx context.Context) error { _ = ctx; return nil }
 func (p *panickingChannel) IsRunning() bool                { return false }
 func (p *panickingChannel) IsAllowed(senderID string) bool { return true }
-func (p *panickingChannel) Send(ctx context.Context, msg OutboundMessage) error {
-	return nil
+func (p *panickingChannel) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
+	return nil, nil
 }

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -63,6 +63,17 @@ type SlackBot struct {
 	userDir        map[string]string // lowercase name → user ID
 	userDirUpdated time.Time
 	resolveUsersFn func(ctx context.Context) ([]slack.User, error)
+
+	chanInfoMu      sync.RWMutex
+	chanInfoCache   map[string]*slackChannelInfo // channelID → info
+	chanInfoUpdated map[string]time.Time
+	getConvInfoFn   func(ctx context.Context, channelID string) (*slack.Channel, error)
+}
+
+// slackChannelInfo caches display-relevant channel metadata.
+type slackChannelInfo struct {
+	Name             string // e.g. "general"
+	ConversationType string // "channel", "im", "mpim", "group"
 }
 
 func NewSlackBot(botToken, appToken string, allowedUsers []string, allowedChannels []string, defaultAgent string, allowedAgents []string) (*SlackBot, error) {
@@ -892,11 +903,16 @@ func (b *SlackBot) sendTextWithOptions(ctx context.Context, channelID, text, thr
 		b.markError()
 		return nil, err
 	}
-	return &SendResult{
+	result := &SendResult{
 		ChannelID: respChannel,
 		MessageTS: respTS,
 		ThreadTS:  strings.TrimSpace(threadTS),
-	}, nil
+	}
+	// Best-effort: enrich with channel_name from cache
+	if info := b.resolveChannelInfo(ctx, respChannel); info != nil && info.Name != "" {
+		result.ChannelName = info.Name
+	}
+	return result, nil
 }
 
 func (b *SlackBot) fetchRecentMessages(ctx context.Context, channelID string, limit int) []map[string]interface{} {
@@ -947,15 +963,31 @@ func (b *SlackBot) defaultFetchHistory(ctx context.Context, channelID string, li
 }
 
 func (b *SlackBot) toProtocolMessage(msg *slackInboundMessage, text, agent, trustLevel string, recentMessages []map[string]interface{}) *protocol.Message {
+	convType := msg.channelType
+	channelName := ""
+
+	// Resolve human-readable channel metadata via API cache
+	if info := b.resolveChannelInfo(b.ctx, msg.channelID); info != nil {
+		if info.Name != "" {
+			channelName = info.Name
+		}
+		if info.ConversationType != "" {
+			convType = info.ConversationType
+		}
+	}
+
 	data := map[string]interface{}{
-		"channel":     "slack",
-		"text":        text,
-		"agent":       agent,
-		"user_id":     msg.userID,
-		"chat_id":     msg.channelID,
-		"chatType":    msg.channelType,
-		"trust_level": trustLevel,
-		"thread_ts":   msg.threadTS,
+		"channel":           "slack",
+		"text":              text,
+		"agent":             agent,
+		"user_id":           msg.userID,
+		"chat_id":           msg.channelID,
+		"conversation_type": convType,
+		"trust_level":       trustLevel,
+		"thread_ts":         msg.threadTS,
+	}
+	if channelName != "" {
+		data["channel_name"] = channelName
 	}
 	if len(msg.attachments) > 0 {
 		data["attachments"] = msg.attachments
@@ -1252,6 +1284,75 @@ func (b *SlackBot) userDirStale() bool {
 	b.userDirMu.RLock()
 	defer b.userDirMu.RUnlock()
 	return b.userDir == nil || time.Since(b.userDirUpdated) > userDirTTL
+}
+
+const chanInfoTTL = 30 * time.Minute
+
+// resolveChannelInfo returns cached channel metadata, fetching from the API if stale.
+func (b *SlackBot) resolveChannelInfo(ctx context.Context, channelID string) *slackChannelInfo {
+	if strings.TrimSpace(channelID) == "" {
+		return nil
+	}
+
+	b.chanInfoMu.RLock()
+	info, cached := b.chanInfoCache[channelID]
+	updated := b.chanInfoUpdated[channelID]
+	b.chanInfoMu.RUnlock()
+
+	if cached && time.Since(updated) < chanInfoTTL {
+		return info
+	}
+
+	fetchFn := b.getConvInfoFn
+	if fetchFn == nil {
+		if b.apiClient == nil {
+			return nil
+		}
+		fetchFn = func(ctx context.Context, channelID string) (*slack.Channel, error) {
+			return b.apiClient.GetConversationInfoContext(ctx, &slack.GetConversationInfoInput{
+				ChannelID: channelID,
+			})
+		}
+	}
+
+	ch, err := fetchFn(ctx, channelID)
+	if err != nil {
+		log.Printf("slack: failed to resolve channel info for %s: %v", channelID, err)
+		return nil
+	}
+
+	resolved := &slackChannelInfo{
+		Name:             ch.Name,
+		ConversationType: slackConversationType(ch),
+	}
+
+	b.chanInfoMu.Lock()
+	if b.chanInfoCache == nil {
+		b.chanInfoCache = make(map[string]*slackChannelInfo)
+		b.chanInfoUpdated = make(map[string]time.Time)
+	}
+	b.chanInfoCache[channelID] = resolved
+	b.chanInfoUpdated[channelID] = time.Now()
+	b.chanInfoMu.Unlock()
+
+	return resolved
+}
+
+// slackConversationType maps Slack channel properties to a human-readable type.
+func slackConversationType(ch *slack.Channel) string {
+	if ch == nil {
+		return ""
+	}
+	if ch.IsIM {
+		return "im"
+	}
+	if ch.IsMpIM {
+		return "mpim"
+	}
+	if ch.IsGroup {
+		return "group"
+	}
+	return "channel"
 }
 
 // resolveSlackMentions converts @name patterns in outbound text to <@USERID> format.

--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -41,8 +41,8 @@ type SlackBot struct {
 
 	startFn                  func(ctx context.Context) error
 	stopFn                   func() error
-	sendMessageFn            func(ctx context.Context, channelID, text string) error
-	sendMessageWithOptionsFn func(ctx context.Context, channelID, text, threadTS string) error
+	sendMessageFn            func(ctx context.Context, channelID, text string) (*SendResult, error)
+	sendMessageWithOptionsFn func(ctx context.Context, channelID, text, threadTS string) (*SendResult, error)
 	fetchHistoryFn           func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error)
 
 	socketClientFactoryFn func(apiClient *slack.Client) *socketmode.Client
@@ -162,30 +162,32 @@ func (b *SlackBot) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (b *SlackBot) Send(ctx context.Context, msg OutboundMessage) error {
+func (b *SlackBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	if strings.TrimSpace(msg.To) == "" {
-		return errors.New("slack channel ID is required")
+		return nil, errors.New("slack channel ID is required")
 	}
 	if b.sendMessageWithOptionsFn != nil {
-		if err := b.sendMessageWithOptionsFn(ctx, msg.To, msg.Text, msg.ThreadTS); err != nil {
+		result, err := b.sendMessageWithOptionsFn(ctx, msg.To, msg.Text, msg.ThreadTS)
+		if err != nil {
 			b.markError()
-			return err
+			return nil, err
 		}
 		b.markActivity()
-		return nil
+		return result, nil
 	}
 	if strings.TrimSpace(msg.ThreadTS) != "" {
-		return errors.New("slack threaded sender not configured")
+		return nil, errors.New("slack threaded sender not configured")
 	}
 	if b.sendMessageFn == nil {
-		return errors.New("slack sender not configured")
+		return nil, errors.New("slack sender not configured")
 	}
-	if err := b.sendMessageFn(ctx, msg.To, msg.Text); err != nil {
+	result, err := b.sendMessageFn(ctx, msg.To, msg.Text)
+	if err != nil {
 		b.markError()
-		return err
+		return nil, err
 	}
 	b.markActivity()
-	return nil
+	return result, nil
 }
 
 // IsAllowed reports whether senderID is on the allowlist.
@@ -857,25 +859,26 @@ func (b *SlackBot) ack(req socketmode.Request, payload ...interface{}) {
 }
 
 func (b *SlackBot) reply(ctx context.Context, msg *slackInboundMessage, text string) error {
-	return b.Send(ctx, OutboundMessage{
+	_, err := b.Send(ctx, OutboundMessage{
 		To:       msg.channelID,
 		Text:     TruncateSlackReply(text),
 		ThreadTS: msg.threadTS,
 	})
+	return err
 }
 
-func (b *SlackBot) sendText(ctx context.Context, channelID, text string) error {
+func (b *SlackBot) sendText(ctx context.Context, channelID, text string) (*SendResult, error) {
 	return b.sendTextWithOptions(ctx, channelID, text, "")
 }
 
-func (b *SlackBot) sendTextWithOptions(ctx context.Context, channelID, text, threadTS string) error {
+func (b *SlackBot) sendTextWithOptions(ctx context.Context, channelID, text, threadTS string) (*SendResult, error) {
 	if b.apiClient == nil {
 		b.markError()
-		return errors.New("slack api client not initialized")
+		return nil, errors.New("slack api client not initialized")
 	}
 	if strings.TrimSpace(channelID) == "" {
 		b.markError()
-		return errors.New("slack channel ID is required")
+		return nil, errors.New("slack channel ID is required")
 	}
 	resolved := b.resolveSlackMentions(ctx, text)
 	msgOptions := []slack.MsgOption{
@@ -884,12 +887,16 @@ func (b *SlackBot) sendTextWithOptions(ctx context.Context, channelID, text, thr
 	if strings.TrimSpace(threadTS) != "" {
 		msgOptions = append(msgOptions, slack.MsgOptionTS(strings.TrimSpace(threadTS)))
 	}
-	_, _, err := b.apiClient.PostMessageContext(ctx, channelID, msgOptions...)
+	respChannel, respTS, err := b.apiClient.PostMessageContext(ctx, channelID, msgOptions...)
 	if err != nil {
 		b.markError()
-		return err
+		return nil, err
 	}
-	return nil
+	return &SendResult{
+		ChannelID: respChannel,
+		MessageTS: respTS,
+		ThreadTS:  strings.TrimSpace(threadTS),
+	}, nil
 }
 
 func (b *SlackBot) fetchRecentMessages(ctx context.Context, channelID string, limit int) []map[string]interface{} {

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -82,10 +82,10 @@ func TestSlackAllowlist(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: "ok"}
@@ -123,10 +123,10 @@ func TestSlackUnauthorized(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: "ok"}
@@ -160,10 +160,10 @@ func TestSlackSocketModeDMEvent(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: "ok"}
@@ -197,10 +197,10 @@ func TestSlackWhoamiRequiresAllowlist(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -222,10 +222,10 @@ func TestSlackAgentsEmptyConfigHint(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -256,10 +256,10 @@ func TestSlackDefaultAgentMissingGuidance(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -290,10 +290,10 @@ func TestSlackAgentsDedupesDefault(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -321,10 +321,10 @@ func TestSlackReplyTruncation(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: strings.Repeat("a", maxSlackReplyChars+10)}
@@ -349,10 +349,10 @@ func TestSlackIgnoreNonDMFromUnauthorized(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: "ok"}
@@ -382,9 +382,9 @@ func TestSlackIgnoreNonDMEvenFromAllowedUser(t *testing.T) {
 	handler := &fakeSlackHandler{reply: "ok"}
 	bot.SetHandler(handler)
 
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -486,10 +486,10 @@ func TestSlackStatusDoesNotLeakTokens(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -514,10 +514,10 @@ func TestSlackStatusRequiresAllowlist(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -539,10 +539,10 @@ func TestSlackAgentsRequiresAllowlist(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -575,10 +575,10 @@ func TestSlackIncompleteAgentUsageRequiresAllowlist(t *testing.T) {
 	}
 	for _, input := range tests {
 		var sent slackSendCapture
-		bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+		bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 			_ = ctx
 			sent = slackSendCapture{channelID: channelID, text: text}
-			return nil
+			return nil, nil
 		}
 
 		bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -601,10 +601,10 @@ func TestSlackAgentWithTaskStillUnauthorized(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: "ok"}
@@ -737,10 +737,10 @@ func TestSlackAppMentionAllowlisted(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleSocketEvent(context.Background(), socketmode.Event{
@@ -771,10 +771,10 @@ func TestSlackAppMentionUnauthorized(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleSocketEvent(context.Background(), socketmode.Event{
@@ -805,10 +805,10 @@ func TestSlackToolsRequiresAllowlist(t *testing.T) {
 	bot.SetHandler(handler)
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -833,10 +833,10 @@ func TestSlackToolBypassesAgentSelection(t *testing.T) {
 	bot.SetHandler(handler)
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -861,10 +861,10 @@ func TestSlackToolHandlerMissing(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -889,10 +889,10 @@ func TestSlackMonitorUnauthorized(t *testing.T) {
 	bot.SetHandler(handler)
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -917,10 +917,10 @@ func TestSlackMonitorAllowed(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -942,10 +942,10 @@ func TestSlackMonitorUsage(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -967,10 +967,10 @@ func TestSlackToolCommandUnauthorized(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -995,10 +995,10 @@ func TestSlackToolCommandAllowedRoutes(t *testing.T) {
 	bot.SetHandler(handler)
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -1020,10 +1020,10 @@ func TestSlackStatusWithMentionRequiresAllowlist(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	bot.handleMessageEvent(context.Background(), &slackInboundMessage{
@@ -1154,9 +1154,9 @@ func TestSlackMentionIncludesRecentMessages(t *testing.T) {
 	handler := &fakeSlackHandler{reply: "ok"}
 	bot.SetHandler(handler)
 
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
-		return nil
+		return nil, nil
 	}
 	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
 		_ = ctx
@@ -1196,9 +1196,9 @@ func TestSlackDMIncludesRecentMessages(t *testing.T) {
 	handler := &fakeSlackHandler{reply: "ok"}
 	bot.SetHandler(handler)
 
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
-		return nil
+		return nil, nil
 	}
 	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
 		_ = ctx
@@ -1237,10 +1237,10 @@ func TestSlackHistoryFetchErrorDoesNotBlock(t *testing.T) {
 	bot.SetHandler(handler)
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
 		_ = ctx
@@ -1369,10 +1369,10 @@ func TestSlackHandleMessageEventForwardsAttachmentsToHandler(t *testing.T) {
 	}
 
 	var sent slackSendCapture
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		sent = slackSendCapture{channelID: channelID, text: text}
-		return nil
+		return nil, nil
 	}
 
 	handler := &fakeSlackHandler{reply: "ok"}
@@ -1467,10 +1467,10 @@ func TestSlackReplyUsesThreadTSWhenPresent(t *testing.T) {
 	}
 	bot.apiClient = slack.New("xoxb-token", slack.OptionAPIURL(server.URL+"/"))
 	bot.sendMessageWithOptionsFn = bot.sendTextWithOptions
-	bot.sendMessageFn = func(ctx context.Context, channelID, text string) error {
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
 		t.Fatalf("expected reply to use thread API path, got plain sendMessage call")
-		return nil
+		return nil, nil
 	}
 
 	if err := bot.reply(context.Background(), &slackInboundMessage{
@@ -1547,14 +1547,14 @@ func TestSlackSendUsesThreadTS(t *testing.T) {
 
 	var captured slackSendCapture
 	var capturedThreadTS string
-	bot.sendMessageWithOptionsFn = func(ctx context.Context, channelID, text, threadTS string) error {
+	bot.sendMessageWithOptionsFn = func(ctx context.Context, channelID, text, threadTS string) (*SendResult, error) {
 		_ = ctx
 		captured = slackSendCapture{channelID: channelID, text: text}
 		capturedThreadTS = threadTS
-		return nil
+		return nil, nil
 	}
 
-	if err := bot.Send(
+	if _, err := bot.Send(
 		context.Background(),
 		OutboundMessage{
 			To:       "C0A8ESWV7D0",
@@ -1599,7 +1599,7 @@ func TestSlackSendTextWithOptionsPostsThreadTS(t *testing.T) {
 	}
 	bot.apiClient = slack.New("xoxb-token", slack.OptionAPIURL(server.URL+"/"))
 
-	if err := bot.sendTextWithOptions(
+	if _, err := bot.sendTextWithOptions(
 		context.Background(),
 		"C0A8ESWV7D0",
 		"thread reply",
@@ -1962,13 +1962,13 @@ func TestSendTextWithOptionsResolvesMentions(t *testing.T) {
 	}
 
 	// Override PostMessageContext by setting sendMessageWithOptionsFn to capture text.
-	bot.sendMessageWithOptionsFn = func(ctx context.Context, channelID, text, threadTS string) error {
+	bot.sendMessageWithOptionsFn = func(ctx context.Context, channelID, text, threadTS string) (*SendResult, error) {
 		sentText = text
-		return nil
+		return nil, nil
 	}
 
 	ctx := context.Background()
-	err := bot.Send(ctx, OutboundMessage{To: "C123", Text: "Hey @alice, check this"})
+	_, err := bot.Send(ctx, OutboundMessage{To: "C123", Text: "Hey @alice, check this"})
 	if err != nil {
 		t.Fatalf("Send: %v", err)
 	}
@@ -1994,7 +1994,7 @@ func TestSendTextWithOptionsResolvesMentions(t *testing.T) {
 		},
 	}
 
-	err = bot2.sendTextWithOptions(ctx, "C123", "Hey @alice, check this", "")
+	_, err = bot2.sendTextWithOptions(ctx, "C123", "Hey @alice, check this", "")
 	if err != nil {
 		t.Fatalf("sendTextWithOptions: %v", err)
 	}

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -1466,6 +1466,9 @@ func TestSlackReplyUsesThreadTSWhenPresent(t *testing.T) {
 		t.Fatalf("NewSlackBot: %v", err)
 	}
 	bot.apiClient = slack.New("xoxb-token", slack.OptionAPIURL(server.URL+"/"))
+	bot.getConvInfoFn = func(ctx context.Context, channelID string) (*slack.Channel, error) {
+		return &slack.Channel{}, nil
+	}
 	bot.sendMessageWithOptionsFn = bot.sendTextWithOptions
 	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
 		_ = ctx
@@ -1598,6 +1601,9 @@ func TestSlackSendTextWithOptionsPostsThreadTS(t *testing.T) {
 		t.Fatalf("NewSlackBot: %v", err)
 	}
 	bot.apiClient = slack.New("xoxb-token", slack.OptionAPIURL(server.URL+"/"))
+	bot.getConvInfoFn = func(ctx context.Context, channelID string) (*slack.Channel, error) {
+		return &slack.Channel{}, nil
+	}
 
 	if _, err := bot.sendTextWithOptions(
 		context.Background(),
@@ -1991,6 +1997,9 @@ func TestSendTextWithOptionsResolvesMentions(t *testing.T) {
 			return []slack.User{
 				{ID: "U111", Name: "alice"},
 			}, nil
+		},
+		getConvInfoFn: func(ctx context.Context, channelID string) (*slack.Channel, error) {
+			return &slack.Channel{}, nil
 		},
 	}
 

--- a/internal/channels/telegram.go
+++ b/internal/channels/telegram.go
@@ -1337,12 +1337,15 @@ func (b *TelegramBot) convertToProtocolMessage(msg *TelegramMessage, text, agent
 }
 
 // Send sends a message to Telegram.
-func (b *TelegramBot) Send(ctx context.Context, msg OutboundMessage) error {
+func (b *TelegramBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	chatID, err := strconv.ParseInt(strings.TrimSpace(msg.To), 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid telegram chat ID %q: %w", msg.To, err)
+		return nil, fmt.Errorf("invalid telegram chat ID %q: %w", msg.To, err)
 	}
-	return b.sendToChat(ctx, chatID, msg.Text)
+	if err := b.sendToChat(ctx, chatID, msg.Text); err != nil {
+		return nil, err
+	}
+	return &SendResult{ChannelID: msg.To}, nil
 }
 
 // IsAllowed reports whether senderID is on the allowlist.

--- a/internal/channels/telegram_telemetry_test.go
+++ b/internal/channels/telegram_telemetry_test.go
@@ -33,7 +33,7 @@ func TestTelegramTelemetry(t *testing.T) {
 			return nil, errors.New("send failed")
 		}),
 	}
-	if err := bot.Send(context.Background(), OutboundMessage{To: "1", Text: "hi"}); err == nil {
+	if _, err := bot.Send(context.Background(), OutboundMessage{To: "1", Text: "hi"}); err == nil {
 		t.Fatalf("expected send error")
 	}
 	if bot.LastError().IsZero() {

--- a/internal/channels/worker.go
+++ b/internal/channels/worker.go
@@ -177,7 +177,7 @@ func (w *channelWorker) drain(ctx context.Context) {
 	for {
 		select {
 		case msg := <-w.queue:
-			if err := w.channel.Send(ctx, msg); err != nil {
+			if _, err := w.channel.Send(ctx, msg); err != nil {
 				log.Printf("[worker/%s] drain send failed: %v", w.channel.Name(), err)
 			}
 		default:
@@ -198,7 +198,7 @@ func (w *channelWorker) sendWithRetry(ctx context.Context, msg OutboundMessage) 
 	}
 
 	for attempt := 0; attempt <= retryMaxAttempts; attempt++ {
-		err := w.channel.Send(ctx, msg)
+		_, err := w.channel.Send(ctx, msg)
 		if err == nil {
 			w.afterSend(ctx, msg)
 			return
@@ -235,6 +235,47 @@ func (w *channelWorker) sendWithRetry(ctx context.Context, msg OutboundMessage) 
 			}
 		}
 	}
+}
+
+// sendSync performs a synchronous send with rate limiting and returns the result.
+// Used by Manager.Send for bus-originated sends that need result feedback.
+func (w *channelWorker) sendSync(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
+	w.beforeSend(ctx, msg)
+
+	if err := w.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	for attempt := 0; attempt <= retryMaxAttempts; attempt++ {
+		result, err := w.channel.Send(ctx, msg)
+		if err == nil {
+			w.afterSend(ctx, msg)
+			return result, nil
+		}
+
+		ec := classifyError(err)
+		switch ec {
+		case ErrPermanent:
+			return nil, err
+		case ErrRateLimit:
+			select {
+			case <-time.After(rateLimitDelay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		case ErrTransient:
+			if attempt >= retryMaxAttempts {
+				return nil, err
+			}
+			delay := retryDelay(attempt)
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+	}
+	return nil, fmt.Errorf("channel %s: retries exhausted", w.channel.Name())
 }
 
 // retryDelay calculates exponential backoff: base * 2^attempt, capped at max.

--- a/internal/channels/worker_test.go
+++ b/internal/channels/worker_test.go
@@ -22,11 +22,13 @@ func (s *stubChannel) Start(ctx context.Context) error { s.running = true; retur
 func (s *stubChannel) Stop(ctx context.Context) error  { s.running = false; return nil }
 func (s *stubChannel) IsRunning() bool                 { return s.running }
 func (s *stubChannel) IsAllowed(senderID string) bool  { return true }
-func (s *stubChannel) Send(ctx context.Context, msg OutboundMessage) error {
+func (s *stubChannel) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
 	if s.sendFn != nil {
-		return s.sendFn(ctx, msg)
+		if err := s.sendFn(ctx, msg); err != nil {
+			return nil, err
+		}
 	}
-	return nil
+	return &SendResult{ChannelID: msg.To}, nil
 }
 
 // --- classifyError tests ---
@@ -319,17 +321,15 @@ func TestManager_Send_RoutesToWorker(t *testing.T) {
 	defer cancel()
 	w.start(ctx)
 
-	err := mgr.Send(context.Background(), "test", OutboundMessage{To: "chat1", Text: "hi"})
+	_, err := mgr.Send(context.Background(), "test", OutboundMessage{To: "chat1", Text: "hi"})
 	if err != nil {
 		t.Fatalf("Send failed: %v", err)
 	}
 
-	time.Sleep(200 * time.Millisecond)
-	w.stop()
-
 	if received.Load() != 1 {
 		t.Errorf("worker received %d messages, want 1", received.Load())
 	}
+	w.stop()
 }
 
 func TestManager_Send_FallbackDirect(t *testing.T) {
@@ -349,7 +349,7 @@ func TestManager_Send_FallbackDirect(t *testing.T) {
 	}
 	// No worker started — should fallback to direct send
 
-	err := mgr.Send(context.Background(), "test", OutboundMessage{To: "chat1", Text: "hi"})
+	_, err := mgr.Send(context.Background(), "test", OutboundMessage{To: "chat1", Text: "hi"})
 	if err != nil {
 		t.Fatalf("Send failed: %v", err)
 	}
@@ -365,7 +365,7 @@ func TestManager_Send_UnknownChannel(t *testing.T) {
 		startCancels: make(map[string]context.CancelFunc),
 	}
 
-	err := mgr.Send(context.Background(), "nonexistent", OutboundMessage{})
+	_, err := mgr.Send(context.Background(), "nonexistent", OutboundMessage{})
 	if err == nil {
 		t.Error("expected error for unknown channel")
 	}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -310,11 +310,14 @@ type messageSendRequest struct {
 }
 
 type messageSendResponse struct {
-	Status   string `json:"status"`
-	Channel  string `json:"channel,omitempty"`
-	To       string `json:"to,omitempty"`
-	ThreadTS string `json:"thread_ts,omitempty"`
-	Error    string `json:"error,omitempty"`
+	Status      string `json:"status"`
+	Channel     string `json:"channel,omitempty"`
+	To          string `json:"to,omitempty"`
+	ThreadTS    string `json:"thread_ts,omitempty"`
+	ChannelID   string `json:"channel_id,omitempty"`
+	ChannelName string `json:"channel_name,omitempty"`
+	MessageTS   string `json:"message_ts,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
@@ -355,11 +358,12 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.messageBus.PublishOutbound(r.Context(), request.Channel, channels.OutboundMessage{
+	result, err := s.messageBus.PublishOutbound(r.Context(), request.Channel, channels.OutboundMessage{
 		To:       request.To,
 		Text:     request.Text,
 		ThreadTS: request.ThreadTS,
-	}); err != nil {
+	})
+	if err != nil {
 		status := http.StatusBadGateway
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound
@@ -368,12 +372,21 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, messageSendResponse{
+	resp := messageSendResponse{
 		Status:   "ok",
 		Channel:  request.Channel,
 		To:       request.To,
 		ThreadTS: request.ThreadTS,
-	})
+	}
+	if result != nil {
+		resp.ChannelID = result.ChannelID
+		resp.ChannelName = result.ChannelName
+		resp.MessageTS = result.MessageTS
+		if result.ThreadTS != "" {
+			resp.ThreadTS = result.ThreadTS
+		}
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, payload any) {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -295,9 +295,9 @@ func (f *fakeTelemetryChannel) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (f *fakeTelemetryChannel) Send(ctx context.Context, msg channels.OutboundMessage) error {
+func (f *fakeTelemetryChannel) Send(ctx context.Context, msg channels.OutboundMessage) (*channels.SendResult, error) {
 	_ = ctx
-	return nil
+	return nil, nil
 }
 
 func (f *fakeTelemetryChannel) IsRunning() bool {
@@ -594,12 +594,15 @@ func (f *fakeSendChannel) Stop(ctx context.Context) error {
 	return nil
 }
 
-func (f *fakeSendChannel) Send(ctx context.Context, msg channels.OutboundMessage) error {
+func (f *fakeSendChannel) Send(ctx context.Context, msg channels.OutboundMessage) (*channels.SendResult, error) {
 	_ = ctx
 	f.lastChat = msg.To
 	f.lastText = msg.Text
 	f.lastThread = msg.ThreadTS
-	return f.sendErr
+	if f.sendErr != nil {
+		return nil, f.sendErr
+	}
+	return &channels.SendResult{ChannelID: msg.To}, nil
 }
 
 func (f *fakeSendChannel) IsRunning() bool { return f.running }


### PR DESCRIPTION
## Summary

Implements all 3 open fractalbot issues in a single cohesive branch:

- **#341** — `Channel.Send()` now returns `*SendResult` with structured metadata (channel_id, channel_name, message_ts, thread_ts). Propagated through worker → manager → bus → gateway API response.
- **#339** — Slack inbound messages include `conversation_type` (channel/im/mpim/group) and `channel_name` via `conversations.info` API with 30-min TTL cache.
- **#340** — Channel-agnostic body wrapping: short messages stay `body_mode=inline`, long messages (≥12 lines or ≥1800 chars) are written to a temp file with `body_mode=file_pointer` + SHA-256 hash. Routing metadata always stays inline. Task prompt builder references file-backed bodies by path and instructs downstream to skip double file-wrap.

## Key changes

- `internal/channels/channel.go` — New `SendResult` struct; `Channel.Send()` returns `(*SendResult, error)`
- `internal/channels/slack.go` — conversations.info cache, `resolveChannelInfo()`, enriched `toProtocolMessage()` and `sendTextWithOptions()`
- `internal/channels/{telegram,discord,feishu,imessage}.go` — Updated `Send()` signatures
- `internal/channels/worker.go` — New `sendSync()` method for synchronous sends with rate limiting
- `internal/channels/manager.go` — `Send()` returns `(*SendResult, error)` via `sendSync`
- `internal/channels/body_wrap.go` — `WrapMessageBody()`, `IsLongBody()` (new file)
- `internal/bus/bus.go` — `PublishOutbound()` returns `(*channels.SendResult, error)`
- `internal/gateway/server.go` — Send response includes channel_id, channel_name, message_ts
- `internal/agent/manager.go` — Body wrapping in `HandleIncoming`, file-pointer aware prompt builder

## Test plan

- [x] All existing tests pass (no regressions)
- [x] New `body_wrap_test.go` covers inline, file_pointer, empty text, and fallback on bad dir
- [x] New manager tests cover body_mode in prompt builder and HandleIncoming wrapping
- [x] `go test ./... -count=1` all green
- [ ] Manual: verify fractalbot sends/receives messages on local instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)