### PR TITLE
feat: WeChat channel support (polling + callback dual mode)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -53,6 +53,45 @@ channels:
     # If true, FractalBot will call Telegram deleteWebhook() on shutdown.
     webhookDeleteOnStop: false
 
+  # WeChat official channel configuration (optional; KR2 scaffold)
+  wechat:
+    enabled: false
+    # Official capability provider: wecom | mp_service
+    provider: "wecom"
+    # Inbound mode: callback | polling
+    mode: "callback"
+
+    # Polling-first placeholders (for future KR2 slices)
+    baseURL: ""
+    token: ""
+    stateFile: "./workspace/wechat.polling.state.json"
+    pollIntervalSeconds: 3
+
+    # Inbound callback server
+    callbackListenAddr: "127.0.0.1:18810"
+    callbackPath: "/wechat/callback"
+    callbackToken: "replace-me"
+    callbackEncodingAESKey: "replace-me-if-required"
+
+    # WeCom credentials
+    corpId: ""
+    corpSecret: ""
+    agentId: ""
+
+    # MP Service Account credentials
+    appId: ""
+    appSecret: ""
+
+    # Optional routing defaults for future wechat channel support
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+
+    # Reply behavior
+    syncReplyTimeoutSeconds: 4
+    asyncSendEnabled: true
+    accessTokenCacheFile: "./workspace/wechat.token.json"
+
   # Slack channel configuration (optional)
   slack:
     enabled: false

--- a/docs/wechat-clawbot-ai-design.md
+++ b/docs/wechat-clawbot-ai-design.md
@@ -1,0 +1,229 @@
+# WeChat Official Support for ClawBot AI — KR1 初版设计
+
+> Status: draft
+> Updated: 2026-03-23 (UTC+8)
+> Scope: 为 `fractalmind-ai/fractalbot` 设计“微信官方能力”接入方案，支撑 ClawBot AI 最小可用闭环。
+
+## 1. 目标
+
+让 FractalBot 新增 1 条基于**微信官方能力**的通道，满足：
+
+1. 能接收微信侧消息并标准化成 FractalBot `protocol.Message`
+2. 能将 Agent 回复回写到微信侧
+3. 能把微信用户身份、会话上下文、路由目标注入给 oh-my-code / agent-manager
+4. 能处理官方鉴权、回调验证、异步回复、失败重试
+
+## 2. 已核验的官方资料（用于 KR1 边界判断）
+
+### 微信服务号 / 公众号
+- `Receiving_standard_messages`：微信服务号文档《文本消息》
+- `Passive_user_reply_message`：微信服务号文档《回复文本消息》
+
+这两份文档至少确认了以下接口形态：
+- 存在**HTTP 回调接收消息**模式
+- 入站消息包含 `ToUserName / FromUserName / MsgType / MsgId / CreateTime` 等字段
+- 平台支持**被动回复**文本消息
+
+### 企业微信
+- 企业微信开发者中心《概述》
+- 企业微信开发者中心《基本概念介绍》
+- 企业微信开发者中心《消息推送配置说明》
+
+这三份文档至少确认了以下接入形态：
+- 企业微信存在**服务器回调 / 消息推送配置**
+- 官方能力是“企业应用 / 组织内账号”导向，而不是个人微信号自动化
+
+## 3. 初步边界判断
+
+### 3.1 支持范围
+优先支持两类官方能力：
+
+1. **企业微信应用（WeCom）**
+   - 适合组织内部使用、员工/运营/团队场景
+   - 更符合 FractalBot 当前“agent routing / 运维控制 / 内部协作”定位
+
+2. **微信服务号 / 公众号（MP Service Account）**
+   - 适合对外用户咨询、客服、AI 助手入口
+   - 更适合 “ClawBot AI 面向外部用户” 的场景
+
+### 3.2 不支持范围
+- **个人微信号自动化**不纳入官方支持方案
+- 若用户需求是“个人号机器人”，应单独定义为非官方实验能力，不进入本 OKR 成功标准
+
+> 说明：上面这条是当前设计判断，后续仍需基于官方文档逐条核验。
+
+## 4. 推荐路线
+
+### 推荐顺序
+
+#### 路线 A：先做企业微信应用
+原因：
+- 与 FractalBot 现有“工作流 / agent-manager / allowlist / 组织内协作”更一致
+- 官方回调 + 服务端 API 形态更接近现有 Telegram webhook / Feishu / Slack 通道模型
+- 对“ClawBot AI 先内部用起来”更现实
+
+#### 路线 B：再扩展服务号 / 公众号
+原因：
+- 对外触达更强
+- 但通常需要补充菜单、客服、消息模板、关注关系等平台约束设计
+
+## 5. FractalBot 抽象设计
+
+## 5.1 Channel 命名策略
+推荐不要直接把 channel 名死写成 `wecom` 或 `mp`，而是抽象为：
+
+- **外部统一名**：`wechat`
+- **内部 provider**：`wecom` / `mp_service`
+
+好处：
+- 对 Agent / 网关 / 路由层保持一个稳定 channel 名
+- 允许后续在同一 channel 下扩展多个微信官方 provider
+
+## 5.2 配置草案
+
+```yaml
+channels:
+  wechat:
+    enabled: false
+    provider: "wecom" # wecom | mp_service
+
+    # inbound callback
+    callbackListenAddr: "127.0.0.1:18810"
+    callbackPath: "/wechat/callback"
+    callbackToken: "replace-me"
+    callbackEncodingAESKey: "replace-me-if-required"
+
+    # outbound auth
+    corpId: ""
+    corpSecret: ""
+    agentId: ""
+    appId: ""
+    appSecret: ""
+
+    # routing
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+      - "qa-1"
+
+    # reply policy
+    syncReplyTimeoutSeconds: 4
+    asyncSendEnabled: true
+    accessTokenCacheFile: "./workspace/wechat.token.json"
+```
+
+说明：
+- `provider` 决定具体官方实现
+- `callback*` 统一微信官方回调入口配置
+- `corpId/corpSecret/agentId` 面向企业微信
+- `appId/appSecret` 面向服务号/公众号
+- `syncReplyTimeoutSeconds` 用于区分快速被动回复与异步回写
+
+## 5.3 标准化消息结构
+
+对齐现有 Telegram / Feishu / iMessage 的 `protocol.Message` 数据约定，建议入站转换为：
+
+```json
+{
+  "channel": "wechat",
+  "provider": "wecom",
+  "text": "用户消息",
+  "agent": "main",
+  "chat_id": "conversation-or-external-user-id",
+  "user_id": "wechat-user-id",
+  "username": "optional-display-name",
+  "message_id": "official-message-id",
+  "chatType": "dm",
+  "event": "message|subscribe|menu_click"
+}
+```
+
+补充字段建议：
+- `open_id` / `union_id` / `external_userid` / `from_user_name`
+- `raw_payload`
+- `reply_mode`：`passive` / `async_api`
+- `provider_agent_id`
+
+## 6. 路由与身份映射
+
+### 6.1 路由策略
+沿用当前 FractalBot inbound routing contract：
+- 微信入口消息 → 解析出文本 / 事件 / 身份
+- 根据命令前缀或默认配置解析 `selected_agent`
+- 将 `channel/chat_id/user_id/username/selected_agent` 注入 assign prompt
+
+### 6.2 身份映射原则
+- `chat_id`：优先使用“可稳定标识会话”的官方会话 ID / 用户 ID
+- `user_id`：使用平台原生用户标识
+- `username`：仅作展示，不参与权限判断
+- 权限控制：继续沿用 allowlist / default-deny 思路
+
+## 7. 收发模型
+
+### 7.1 入站
+- 不做 polling
+- 统一采用**官方回调推送**
+- FractalBot 内部起一个 HTTP handler，模式参考现有 Telegram webhook server
+
+### 7.2 出站
+- 若 Agent 在 `syncReplyTimeoutSeconds` 内返回，优先走同步回复
+- 若超时：
+  1. 先返回“处理中”或平台允许的兜底应答
+  2. Agent 完成后走官方发送 API 异步回写
+
+### 7.3 失败处理
+- access token 获取失败：记录 telemetry + 指数退避
+- 回调签名失败：拒绝处理并记安全日志
+- 下游 Agent 超时：返回统一 fallback 文案
+- 微信 API 失败：重试有限次数，必要时写入 dead-letter / 本地待补发队列
+
+## 8. 与现有代码的贴合点
+
+当前 FractalBot 已有可复用模式：
+- `internal/channels/manager.go`：通道注册与启动
+- `internal/channels/telegram.go`：webhook / polling 双模式与路由注入
+- `internal/channels/feishu.go`：官方平台 SDK / 事件转协议消息
+- `internal/channels/imessage.go`：将外部消息标准化为统一 `protocol.Message`
+- `pkg/protocol/message.go`：统一消息协议
+
+因此新增 `internal/channels/wechat.go` 是最自然路径。
+
+## 9. KR2 最小实现切片建议
+
+按最短闭环拆成 4 步：
+
+1. **配置 + status 暴露**
+   - 配置解析
+   - `/status` 显示 wechat channel 状态
+
+2. **企业微信 callback 收消息**
+   - 启动 callback server
+   - 验证签名 / 基础参数
+   - 解析文本消息并转 `protocol.Message`
+
+3. **异步发消息**
+   - access token 获取与缓存
+   - 调用官方发送 API
+
+4. **Agent 路由闭环**
+   - 注入 routing context
+   - 完成“微信消息 → agent → 微信回写”
+
+## 10. 待确认问题
+
+1. 本项目的“ClawBot AI”目标用户是**内部团队**还是**外部用户**？
+   - 内部优先：先做企业微信
+   - 外部优先：先做服务号
+
+2. 是否接受“首版只支持文本消息 + 单轮会话”？
+   - 建议接受，便于尽快闭环
+
+3. 是否需要把“菜单点击 / 订阅事件 / 图片消息”纳入首版？
+   - 建议首版不做，只做文本消息
+
+## 11. 当前结论
+
+- **KR1 推荐结论**：先按 `wechat(provider=wecom)` 设计落地，优先完成企业微信官方通道闭环
+- **实现策略**：复用 Telegram webhook server + Feishu 官方 SDK / 事件处理模式 + 现有 routing contract
+- **首版范围**：文本消息、组织内 DM、agent 路由、异步回写、最小权限控制
+- **后续扩展**：在同一 `wechat` channel 下增加 `mp_service` provider

--- a/docs/wechat-kr2-evidence-template.md
+++ b/docs/wechat-kr2-evidence-template.md
@@ -1,0 +1,87 @@
+# O7 KR2 运行证据模板（callback-first）
+
+> Status: draft
+> Updated: 2026-03-23 03:00 PDT
+> Purpose: 为下一轮 O7-KR2 正式执行准备统一证据模板，确保启动、状态、GET/POST callback 结果都能一次性归档。
+
+## 1. 环境信息
+
+- Date:
+- Host:
+- Working tree / branch:
+- FractalBot config path:
+- WeChat provider:
+
+## 2. 启动命令
+
+```bash
+cd projects/fractalmind-ai/fractalbot
+fractalbot --config <config-path>
+```
+
+### 记录
+- Command:
+- Exit / running status:
+- Key log lines:
+
+## 3. Gateway 状态证据
+
+```bash
+curl -s http://127.0.0.1:18789/status | jq '.'
+```
+
+### 记录
+- Time:
+- Whether `wechat` appears in channels:
+- Channel state / telemetry:
+- Raw output snippet:
+
+## 4. GET callback 证据
+
+### 签名计算
+
+```bash
+python3 - <<'PY2'
+import hashlib
+items = sorted(["<token>", "1", "2"])
+print(hashlib.sha1("".join(items).encode()).hexdigest())
+PY2
+```
+
+### 请求
+
+```bash
+curl -i "http://127.0.0.1:18810/wechat/callback?signature=<sha1>&timestamp=1&nonce=2&echostr=hello"
+```
+
+### 记录
+- Request:
+- Expected: HTTP 200 + `hello`
+- Actual status:
+- Actual body:
+
+## 5. POST callback 证据
+
+```bash
+curl -i   -X POST "http://127.0.0.1:18810/wechat/callback?signature=<sha1>&timestamp=1&nonce=2"   -H 'Content-Type: application/xml'   --data '<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>'
+```
+
+### 记录
+- Request:
+- Expected: scaffold returns structured response
+- Actual status:
+- Actual body:
+- Whether `protocol_message` / `handler_*` fields are present:
+
+## 6. 结论
+
+- Did we prove listener startup?
+- Did we prove `/status` visibility?
+- Did we prove GET callback handshake?
+- Did we prove POST callback parsing / routing?
+- Remaining gap to real official capability:
+
+## 7. 后续动作
+
+- If all above pass: advance KR2 from “checklist” to “local runtime evidence exists”
+- If any step fails: record exact error, retry count, and whether blocker is config / code / runtime

--- a/docs/wechat-kr2-first-validation-path.md
+++ b/docs/wechat-kr2-first-validation-path.md
@@ -1,0 +1,93 @@
+# O7 KR2 第一条验证路径决策
+
+> Status: draft
+> Updated: 2026-03-23 08:55 PDT
+> Purpose: 基于用户最新要求，把 KR2 第一条验证路径从 callback-first 切换为 polling-first。
+> Supersedes: 本文件此前关于 “callback-first” 的结论。
+
+## 1. 结论
+
+**KR2 的第一条验证路径，改为优先选择 `polling-first`，`callback` 放到第二期。**
+
+也就是说，下一步最小闭环不再优先围绕本地 callback listener，而是优先围绕：
+
+1. iLink / 类 iLink API 的接入边界
+2. 登录态 / token / baseUrl / account state
+3. polling loop（`GetUpdates` / 等价接口）
+4. cursor / state persistence
+5. 将 polling 消息映射到当前 FractalBot channel manager / handler 抽象
+
+`callback` 相关实现与文档继续保留，但降级为：
+
+- 第二阶段方案
+- 对照参考
+- 备用验证路径
+
+## 2. 为什么现在改成 polling-first
+
+### 2.1 用户已经明确要求
+
+本次切换不是推测，而是用户的明确纠偏：
+
+- **先做 polling**
+- **callback 放第二期**
+
+因此，KR2 的默认推进方向必须立即调整。
+
+### 2.2 更贴近 `picoclaw` 已验证的现实路径
+
+`https://github.com/sipeed/picoclaw` 已证明：
+
+- 腾讯 iLink API + 二维码登录
+- long polling (`GetUpdates`)
+- cursor / state persistence
+
+是一条真实存在、且更接近“个人微信/扫码登录/持续收消息”语义的路径。
+
+### 2.3 callback-first 虽然更贴近当前 scaffold，但不再是默认业务优先级
+
+此前选择 callback-first 的原因是：
+
+- 当前 repo 里已有 `wechat` callback scaffold
+- 更容易快速产出 listener / GET / POST 的运行证据
+
+但用户已经明确希望优先验证 polling 方向，因此：
+
+- callback-first 不再是默认主路径
+- 这些已有产物只作为“第二阶段备选”保留
+
+## 3. KR2 当前新的第一阶段目标
+
+### Phase 1: polling-first 最小设计闭环
+- 明确 `picoclaw` 路线里哪些结构可以映射到当前运行时
+- 定义最小登录态 / token / baseUrl / cursor / state 模型
+- 定义 polling loop 如何挂接到 FractalBot channel manager
+
+### Phase 2: polling-first 本地验证
+- 给出本地最小配置草案
+- 给出轮询启动命令 / 模拟输入 / 状态证据模板
+- 补第一次 polling proof
+
+### Phase 3: callback 作为第二期
+- 仅当需要补官方 callback 语义或做架构对照时再推进
+
+## 4. 对已有 callback 文档的处理原则
+
+以下内容不删除，但默认降级：
+
+- `wechat-kr2-local-validation-checklist.md`
+- `wechat-kr2-evidence-template.md`
+- `wechat-local-config-overlay.example.yaml`
+- `wechat-kr2-local-proof-commands.sh`
+
+它们当前的定位改为：
+
+- callback 第二期材料
+- 备用验证路径
+- 架构对照资料
+
+## 5. 下一步
+
+1. 新增 polling-first 的最小设计说明
+2. 新增 polling-first 的本地验证 checklist
+3. 更新 Memory Bank / heartbeat 状态，避免继续误报 callback-first

--- a/docs/wechat-kr2-local-proof-commands.sh
+++ b/docs/wechat-kr2-local-proof-commands.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# O7 KR2 callback-first local proof helper
+# This script prints the exact commands for the first runtime proof.
+# It does not edit your real config automatically.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_OVERLAY="$REPO_ROOT/docs/wechat-local-config-overlay.example.yaml"
+STATUS_URL="http://127.0.0.1:18789/status"
+CALLBACK_URL="http://127.0.0.1:18810/wechat/callback"
+TOKEN="local-test-token"
+TIMESTAMP="1"
+NONCE="2"
+ECHOSTR="hello"
+
+SIG=$(python3 - <<'PY2'
+import hashlib
+items = sorted(["local-test-token", "1", "2"])
+print(hashlib.sha1("".join(items).encode()).hexdigest())
+PY2
+)
+
+cat <<EOF
+[1] Review local overlay:
+  cat "$CONFIG_OVERLAY"
+
+[2] Prepare a local config by copying the overlay fields into your private config.
+
+[3] Start FractalBot with your local config:
+  cd "$REPO_ROOT"
+  fractalbot --config ./config.yaml
+
+[4] Check gateway status:
+  curl -s "$STATUS_URL" | jq '.'
+
+[5] GET callback handshake proof:
+  curl -i "$CALLBACK_URL?signature=$SIG&timestamp=$TIMESTAMP&nonce=$NONCE&echostr=$ECHOSTR"
+
+[6] POST callback proof:
+  curl -i     -X POST "$CALLBACK_URL?signature=$SIG&timestamp=$TIMESTAMP&nonce=$NONCE"     -H 'Content-Type: application/xml'     --data '<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>'
+
+[7] Record outputs into:
+  docs/wechat-kr2-evidence-template.md
+EOF

--- a/docs/wechat-kr2-local-validation-checklist.md
+++ b/docs/wechat-kr2-local-validation-checklist.md
@@ -1,0 +1,120 @@
+# O7 KR2 本地验证清单（callback-first）
+
+> Status: draft
+> Updated: 2026-03-23 02:00 PDT
+> Purpose: 把 KR2 的 callback-first 路线落到一套最小可执行的本地验证步骤，方便后续直接补运行证据。
+
+## 1. 目标
+
+在 **不安装/升级 OpenClaw core** 的前提下，基于当前 `fractalmind-ai/fractalbot` 运行时，完成如下最小验证：
+
+1. wechat channel 能在当前 gateway 中被启用
+2. callback listener 能真正启动
+3. 本地 GET / POST 请求能打到 callback 路径
+4. 留下启动命令、状态输出、请求响应作为 KR2 证据
+
+## 2. 最小配置草案
+
+可基于 `config.example.yaml` 的 `channels.wechat` 段落，准备一份本地临时配置：
+
+```yaml
+channels:
+  wechat:
+    enabled: true
+    provider: "wecom"
+    callbackListenAddr: "127.0.0.1:18810"
+    callbackPath: "/wechat/callback"
+    callbackToken: "local-test-token"
+    callbackEncodingAESKey: ""
+    corpId: ""
+    corpSecret: ""
+    agentId: ""
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+    syncReplyTimeoutSeconds: 4
+    asyncSendEnabled: true
+    accessTokenCacheFile: "./workspace/wechat.token.json"
+```
+
+说明：
+- 这里只是 **本地 listener / path / handler 验证配置**
+- 不等于已接通真实官方账号
+- 首轮验证不需要先填真实企业微信密钥
+
+## 3. 推荐验证步骤
+
+### Step 1: 启动 gateway
+
+```bash
+cd projects/fractalmind-ai/fractalbot
+fractalbot --config ./config.yaml
+```
+
+或使用本地临时配置文件启动。
+
+### Step 2: 检查状态输出
+
+```bash
+curl -s http://127.0.0.1:18789/status | jq '.'
+```
+
+理想证据：
+- `wechat` 出现在 channels 列表中
+- 状态为 running / initialized（或等价状态）
+
+### Step 3: 验证 GET callback 握手路径
+
+按当前 helper 逻辑，构造：
+
+```bash
+python3 - <<'PY2'
+import hashlib
+items = sorted(["local-test-token", "1", "2"])
+print(hashlib.sha1("".join(items).encode()).hexdigest())
+PY2
+```
+
+然后请求：
+
+```bash
+curl -i "http://127.0.0.1:18810/wechat/callback?signature=<sha1>&timestamp=1&nonce=2&echostr=hello"
+```
+
+理想证据：
+- 返回 `200`
+- body 直接回 `hello`
+
+### Step 4: 验证 POST callback 路径
+
+```bash
+curl -i   -X POST "http://127.0.0.1:18810/wechat/callback?signature=<sha1>&timestamp=1&nonce=2"   -H 'Content-Type: application/xml'   --data '<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>'
+```
+
+理想证据：
+- 能得到当前 scaffold 的结构化响应
+- 能看到 `protocol_message` / handler 路由相关字段
+
+## 4. 本轮先不做什么
+
+当前 checklist 明确**不包含**：
+
+- 真实微信账号登录
+- OpenClaw 安装/升级
+- polling loop 实现
+- iLink API 登录态验证
+
+这些动作要么超出 callback-first 第一阶段目标，要么与当前用户约束冲突。
+
+## 5. KR2 证据清单模板
+
+后续正式执行时，建议至少保留：
+
+1. 启动命令
+2. 使用的本地配置片段
+3. `/status` 输出
+4. GET callback 响应
+5. POST callback 响应
+6. 必要日志摘录
+
+只要这 6 类证据齐，就能把 KR2 从“路线分析”推进到“当前运行时内的最小运行证据”。

--- a/docs/wechat-kr2-polling-evidence-template.md
+++ b/docs/wechat-kr2-polling-evidence-template.md
@@ -1,0 +1,63 @@
+# O7 KR2 polling-first 运行证据模板
+
+> Status: draft
+> Updated: 2026-03-23 11:00 PDT
+> Purpose: 为 polling-first 第一轮验证准备统一证据模板，确保配置、轮询启动、state/cursor 与消息映射都能一次性归档。
+
+## 1. 环境信息
+- Date:
+- Host:
+- Working tree / branch:
+- FractalBot config path:
+- WeChat mode: polling
+- baseURL source:
+- token source:
+- state file path:
+
+## 2. 启动命令
+```bash
+cd projects/fractalmind-ai/fractalbot
+fractalbot --config <config-path>
+```
+
+## 3. 轮询配置证据
+- Config snippet:
+- Poll interval:
+- State file path:
+- defaultAgent / allowedAgents:
+
+## 4. `/status` 证据
+- Raw `/status` JSON:
+- `channels.wechat.mode`:
+- `channels.wechat.polling.base_url_configured`:
+- `channels.wechat.polling.token_configured`:
+- `channels.wechat.polling.state_file_configured`:
+- `channels.wechat.polling.cursor_present`:
+- `channels.wechat.polling.cursor_preview`:
+- `channels.wechat.polling.state_file_exists`:
+- `channels.wechat.polling.last_poll_at`:
+- `channels.wechat.polling.last_poll_messages`:
+
+## 5. 启动日志证据
+- Did polling channel initialize?
+- Did it enter poll loop?
+- Key log lines:
+
+## 6. updates / mock updates 证据
+- Request or mock input:
+- Raw output:
+- Whether message was mapped into `protocol.Message`:
+- Whether handler received it:
+
+## 7. state / cursor 证据
+- State file exists?
+- Cursor field name:
+- Before:
+- After:
+
+## 8. 结论
+- Did we prove polling channel startup?
+- Did `/status` expose runtime polling telemetry?
+- Did we prove one update can enter the handler path?
+- Did we prove state persistence?
+- Remaining gap to full official capability:

--- a/docs/wechat-kr2-polling-first-plan.md
+++ b/docs/wechat-kr2-polling-first-plan.md
@@ -1,0 +1,66 @@
+# O7 KR2 polling-first 最小方案
+
+> Status: draft
+> Updated: 2026-03-23 08:55 PDT
+> Purpose: 以 `picoclaw` 的 weixin channel 为主要参考，收敛当前运行时里的 polling-first 第一阶段方案。
+
+## 1. 参考来源
+
+优先参考：
+
+- `projects/fractalmind-ai/fractalbot/docs/wechat-picoclaw-reference.md`
+- `sipeed/picoclaw/pkg/channels/weixin/weixin.go`
+- `sipeed/picoclaw/pkg/channels/weixin/api.go`
+- `sipeed/picoclaw/pkg/channels/weixin/auth.go`
+- `sipeed/picoclaw/pkg/channels/weixin/state.go`
+
+## 2. 第一阶段最小对象模型
+
+建议先定义以下最小结构：
+
+### 2.1 Auth / session
+- `base_url`
+- `bot_token`
+- `user_id`
+- `account_id`
+- `session_updated_at`
+
+### 2.2 Polling state
+- `get_updates_buf` / 等价 cursor
+- `last_poll_at`
+- `last_message_id`
+- `last_error_at`
+
+### 2.3 Runtime config
+- `enabled`
+- `mode: polling`
+- `baseURL`
+- `token`
+- `stateFile`
+- `defaultAgent`
+- `allowedAgents`
+
+## 3. 第一阶段最小运行流程
+
+1. 启动 FractalBot gateway
+2. 初始化 wechat polling channel
+3. 读取本地 token/baseUrl/state
+4. 进入 poll loop
+5. 把 updates 映射为 `protocol.Message`
+6. 交给现有 handler / agent manager
+
+## 4. 第一阶段不追求的东西
+
+- callback listener 证明
+- 真实企业微信 / 服务号回调
+- 多账号并发
+- 完整媒体能力
+- 生产级重试策略
+
+## 5. 第一阶段需要的证据
+
+- polling 配置片段
+- 轮询启动日志
+- 一次成功的 updates 拉取或等价模拟证据
+- 一次消息映射到 handler 的证据
+- state file / cursor 更新证据

--- a/docs/wechat-kr2-polling-gap-audit.md
+++ b/docs/wechat-kr2-polling-gap-audit.md
@@ -1,0 +1,97 @@
+# O7 KR2 polling-first gap audit
+
+> Status: draft
+> Updated: 2026-04-04 05:01 PDT
+> Purpose: 把当前 polling-first 阻塞从“缺私有配置”收敛为更精确的实现缺口，避免下一轮 heartbeat 继续误判为只差 token/baseURL。
+
+## 结论
+
+当前 `fractalmind-ai/fractalbot` 仓库里，wechat 代码路径仍是 **callback-first scaffold**，还没有真正进入 polling-first 最小闭环。
+
+因此 O7 KR2 当前第一阻塞 **不只是** 私有 `config.yaml` / `baseURL` 映射缺失，而是：
+
+1. `WeChatConfig` 里还没有 polling-first 所需字段
+2. `ChannelManager` 还没有把 wechat 按 polling 模式初始化
+3. `WeChatBot` 还没有 poll loop / state persistence / update→handler 路径
+
+## 代码证据
+
+### 1. 配置结构仍是 callback-only
+
+`internal/config/config.go` 的 `WeChatConfig` 当前只有：
+- `provider`
+- `callbackListenAddr`
+- `callbackPath`
+- `callbackToken`
+- `callbackEncodingAESKey`
+- `corpId/corpSecret/agentId`
+- `appId/appSecret`
+- `defaultAgent/allowedAgents`
+- `syncReplyTimeoutSeconds/asyncSendEnabled/accessTokenCacheFile`
+
+未见 polling-first 文档里提到的字段：
+- `mode`
+- `baseURL`
+- `token`
+- `stateFile`
+- `pollIntervalSeconds`
+
+### 2. manager 初始化仍只配置 callback
+
+`internal/channels/manager.go` 当前对 wechat 只做：
+- `NewWeChatBot(provider)`
+- `ConfigureCallback(...)`
+- `Register(bot)`
+
+未见 polling 模式分支，也未见任何 `baseURL/stateFile/pollInterval` 注入。
+
+### 3. wechat bot 仍是 callback listener scaffold
+
+`internal/channels/wechat.go` 当前能力集中在：
+- callback server lifecycle
+- callback request parsing
+- handshake / signature verification
+- XML → `protocol.Message` 映射草稿
+
+未见：
+- polling client
+- updates 拉取循环
+- cursor/state 文件写入
+- polling update → handler 的最小闭环
+
+## 对现有文档的影响
+
+`docs/wechat-polling-config-overlay.example.yaml` 与 `docs/wechat-kr2-polling-proof-commands.sh` 现在更像是 **目标配置草案**，而不是可直接运行的现状说明。
+
+下一轮执行 KR2 时，不能再把“补私有 token/baseURL”当成唯一前置条件；否则会继续卡在代码路径不支持 polling。
+
+## 建议的最小下一刀
+
+按最小闭环拆成 3 步：
+
+### Slice 1 — 配置层
+补齐 `WeChatConfig` polling-first 字段：
+- `mode`
+- `baseURL`
+- `token`
+- `stateFile`
+- `pollIntervalSeconds`
+
+### Slice 2 — 初始化层
+让 `ChannelManager` 能根据 `channels.wechat.mode` 决定：
+- callback-first
+- polling-first
+
+### Slice 3 — 运行证据层
+在 `WeChatBot` 中补最小 polling loop：
+- 读取 updates / 或 mock updates
+- 产出一条进入 handler 的证据
+- 写出 `stateFile`
+- 留下 before/after cursor 证据
+
+## 当前 heartbeat 应如何表述
+
+更准确的 blocker 应为：
+- wechat config schema 仍缺 polling-first 字段
+- wechat runtime 仍未实现 poll loop / state persistence
+- 私有 token/baseURL 仍需要，但不是唯一缺口

--- a/docs/wechat-kr2-polling-proof-commands.sh
+++ b/docs/wechat-kr2-polling-proof-commands.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# O7 KR2 polling-first local proof helper
+# This script prints the commands to collect the first polling proof.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_OVERLAY="$REPO_ROOT/docs/wechat-polling-config-overlay.example.yaml"
+STATUS_URL="http://127.0.0.1:18789/status"
+STATE_FILE="./workspace/wechat.polling.state.json"
+
+cat <<EOF
+[1] Review local polling overlay:
+  cat "$CONFIG_OVERLAY"
+
+[2] Merge overlay fields into your private local config.
+
+[3] Start FractalBot with your local config:
+  cd "$REPO_ROOT"
+  fractalbot --config ./config.yaml
+
+[4] Check gateway status:
+  curl -s "$STATUS_URL" | jq '.'
+
+[4.1] Extract WeChat polling runtime telemetry:
+  curl -s "$STATUS_URL" | jq '.channels[] | select(.name=="wechat") | {mode, provider, polling}'
+
+[5] Check polling state file:
+  test -f "$STATE_FILE" && cat "$STATE_FILE" || echo "state file not created yet"
+
+[6] Record outputs into:
+  docs/wechat-kr2-polling-evidence-template.md
+EOF

--- a/docs/wechat-kr2-polling-validation-checklist.md
+++ b/docs/wechat-kr2-polling-validation-checklist.md
@@ -1,0 +1,38 @@
+# O7 KR2 polling-first 本地验证清单
+
+> Status: draft
+> Updated: 2026-03-23 08:55 PDT
+> Purpose: 为 KR2 的 polling-first 第一阶段准备本地验证步骤。
+
+## 1. 目标
+
+在不安装/升级 OpenClaw core 的前提下，验证：
+
+1. 当前运行时能挂接 polling 型 wechat channel
+2. 能读取 token/baseUrl/state
+3. 能运行 poll loop 或等价模拟轮询
+4. 能把 polling 消息映射进现有 handler
+5. 能留下 state / cursor 更新证据
+
+## 2. 本地验证步骤（第一版）
+
+### Step 1
+准备最小 polling 配置草案
+
+### Step 2
+确认 channel manager 能识别 polling 模式的 wechat channel
+
+### Step 3
+补一个最小 poll loop / mock updates 入口
+
+### Step 4
+记录一次消息进入 handler 的证据
+
+### Step 5
+记录 state file / cursor 更新证据
+
+## 3. 当前不做
+
+- callback GET/POST 证明
+- 真实官方账号完整登录闭环
+- 多账号与媒体能力

--- a/docs/wechat-local-config-overlay.example.yaml
+++ b/docs/wechat-local-config-overlay.example.yaml
@@ -1,0 +1,29 @@
+# WeChat local validation overlay for O7-KR2 (callback-first)
+# Usage: merge these fields into your local FractalBot config when preparing
+# the first runtime proof. Do not commit real secrets.
+
+channels:
+  wechat:
+    enabled: true
+    provider: "wecom"
+
+    # local callback listener used for runtime proof
+    callbackListenAddr: "127.0.0.1:18810"
+    callbackPath: "/wechat/callback"
+    callbackToken: "local-test-token"
+    callbackEncodingAESKey: ""
+
+    # first proof does not require real official credentials yet
+    corpId: ""
+    corpSecret: ""
+    agentId: ""
+    appId: ""
+    appSecret: ""
+
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+
+    syncReplyTimeoutSeconds: 4
+    asyncSendEnabled: true
+    accessTokenCacheFile: "./workspace/wechat.token.json"

--- a/docs/wechat-openclaw-route-decision.md
+++ b/docs/wechat-openclaw-route-decision.md
@@ -1,0 +1,228 @@
+# 微信 ClawBot / OpenClaw 官方路线决策
+
+> Status: draft
+> Updated: 2026-03-23 (UTC+8)
+> Purpose: 纠正 O7 技术路线，避免继续沿着错误的 FractalBot 自研微信 callback 方向投入。
+> Supersedes: `docs/wechat-clawbot-ai-design.md` 中“FractalBot 直接实现微信官方通道”为默认主路线的假设。
+
+## 1. 结论先行
+
+**修正后主路线：当前环境以 `https://github.com/fractalmind-ai` 驱动运行为准；腾讯官方 `@tencent-weixin/openclaw-weixin` / `@tencent-weixin/openclaw-weixin-cli` 只作为能力边界与实现参考，不再默认要求安装 OpenClaw core。**
+
+在完成官方插件最小闭环验证前，**不再把 FractalBot 自研微信 callback / channel 作为默认推进方向**。
+
+FractalBot 后续只保留两种可能角色，且都必须在官方方案验证后再决定：
+
+1. **适配层**：把官方 OpenClaw 微信插件与现有 FractalBot / agent-manager 工作流对接起来
+2. **归档对象**：若官方方案已充分满足需求，则停止继续扩展当前自研 wechat 通道草稿
+
+## 2. 已核实事实
+
+### 2.1 官方包与发布时间
+已核实腾讯官方 npm scope 在 **2026-03-21** 发布：
+
+- `@tencent-weixin/openclaw-weixin@1.0.2`
+- `@tencent-weixin/openclaw-weixin-cli@1.0.2`
+
+### 2.2 官方元数据
+已核实包元数据：
+
+- `author = Tencent`
+- maintainers 使用多个 `@tencent.com` 邮箱
+
+### 2.3 官方参考接法（仅作边界参考）
+README 给出的官方路径为：
+
+```bash
+npx -y @tencent-weixin/openclaw-weixin-cli install
+```
+
+或手动：
+
+```bash
+openclaw plugins install "@tencent-weixin/openclaw-weixin"
+openclaw config set plugins.entries.openclaw-weixin.enabled true
+openclaw channels login --channel openclaw-weixin
+openclaw gateway restart
+```
+
+### 2.4 官方能力边界（当前已知）
+从官方 README 可确认：
+
+- 支持扫码登录
+- 支持多个微信账号同时在线
+- 支持通过 HTTP JSON API 与后端通信
+- 默认接入点是 **OpenClaw 插件体系**，而不是 FractalBot channel 抽象
+
+
+### 2.5 用户最新运行时约束（2026-03-23）
+用户已明确说明：
+
+- 当前助手是 **`https://github.com/fractalmind-ai` 驱动运行**
+- **不要再安装 OpenClaw**
+- 之前已经卸载过 OpenClaw
+
+因此，后续所有实施与验证都必须遵守以下约束：
+
+1. 不再把“安装/升级 OpenClaw core”作为默认操作
+2. 不再把 upstream OpenClaw runtime 视为当前环境的真实宿主
+3. 官方 `openclaw-weixin` 包主要用于确认官方能力边界、接口形态与兼容性要求
+4. 真正的落地验证必须回到 `fractalmind-ai` 当前运行时与仓库边界内完成
+
+### 2.6 开源参考补充：`sipeed/picoclaw` 已有微信渠道实现
+
+已核实 `https://github.com/sipeed/picoclaw` 在 **2026-03-23（UTC+8）** 时，仓库中存在完整 `pkg/channels/weixin/` 实现，而不是仅有文档占位。
+
+当前已确认的关键特征：
+
+- 渠道已在框架中注册并启用
+- 认证方式是 **腾讯 iLink API + 二维码登录**
+- 收消息机制是 **long polling (`GetUpdates`)**，而不是 webhook / callback
+- 存在状态持久化、媒体上传、typing 等配套实现
+
+这条证据的重要性在于：**现有开源“微信渠道”实现并不一定走 callback 路线，也可能走扫码登录后的 API polling 路线。**
+
+因此，O7 后续在 `fractalmind-ai` 当前运行时中确认“真实微信接入入口”时，必须同时评估：
+
+1. callback 型接入
+2. polling 型接入
+3. 二者混合的桥接层设计
+
+详细参考见：`projects/fractalmind-ai/fractalbot/docs/wechat-picoclaw-reference.md`
+
+## 3. 为什么原路线有偏差
+
+原来的默认假设是：
+
+- 在 `fractalmind-ai/fractalbot` 内新增 `channels.wechat`
+- 直接复刻 Telegram / Feishu 模式，实现 callback、签名校验、消息解析、发送 API、回写闭环
+
+这个方向的问题在于：
+
+1. **忽略了官方已经给出的现成插件入口**
+   - 如果官方已有 OpenClaw 微信插件，自研通道不应再被默认视为 MVP
+
+2. **抽象层级可能不对**
+   - 官方插件的宿主是 OpenClaw，而不是 FractalBot
+   - FractalBot 继续做微信 channel，可能是在错误层级重复造轮子
+
+3. **验证顺序倒置**
+   - 正确顺序应是：先验证官方方案能不能跑通，再决定是否需要适配层
+   - 而不是先实现一套自研 callback，再回头看官方方案
+
+## 4. 两条可选路线对比
+
+### 路线 A：直接依赖 upstream OpenClaw 插件直连（不再默认推荐）
+
+**描述**
+- 直接采用腾讯官方 `openclaw-weixin` 插件
+- 通过 upstream OpenClaw CLI / gateway 完成安装、登录、收发消息
+
+**优点**
+- 与官方发布路径一致，方向风险最低
+- 接入成本更低，能最快验证真实可用性
+- 避免在签名校验、扫码登录、会话维护、协议细节上重复造轮子
+
+**缺点**
+- 当前工作流若强依赖 FractalBot，需要补一层系统集成
+- 我们对官方插件内部可扩展性还缺少一手验证
+
+**何时采用**
+- 仅在确认当前环境确实回到 upstream OpenClaw runtime 时采用
+- 在当前用户约束下，不作为默认起点
+
+### 路线 B：FractalBot 适配层
+
+**描述**
+- 不让 FractalBot 直接实现微信官方通道
+- 而是在官方 OpenClaw 微信插件之上，补一个 FractalBot/agent-manager 的桥接层
+
+**优点**
+- 复用已有 FractalBot 路由、agent-manager、状态观测能力
+- 保持现有内部工作流连续性
+
+**缺点**
+- 必须以官方方案已经验证可用为前提
+- 适配层边界如果设计不好，仍可能重复实现官方能力
+
+**何时采用**
+- 只有在官方插件验证通过后，且确认确有 FractalBot 集成需求时才采用
+
+
+### 路线 C：fractalmind-ai 驱动运行时内适配官方微信能力（当前默认推荐）
+
+**描述**
+- 以当前 `fractalmind-ai` 驱动运行时为宿主
+- 参考腾讯官方微信插件/CLI 暴露出来的能力边界、协议与登录流程
+- 在现有仓库和运行边界内完成最小闭环验证
+
+**优点**
+- 符合用户最新运行时约束
+- 不再误把安装 OpenClaw core 当成前提
+- 能更准确回答“当前系统到底如何接微信”
+
+**缺点**
+- 需要重新界定官方包在当前架构中的角色：参考实现、协议参考还是直接可复用组件
+- 目前还缺少一份面向 fractalmind-ai 运行时的明确接入草图
+
+**何时采用**
+- 当前立即采用
+- 作为 O7 后续推进的默认起点
+
+## 5. 当前决策
+
+### 5.1 立即生效的默认决策
+- **默认主路线 = fractalmind-ai 驱动运行时内适配官方微信能力（路线 C）**
+- **不再默认安装 OpenClaw core**
+- **暂停继续扩展 FractalBot 自研微信 callback 的范围**
+
+### 5.2 当前自研草稿的处理原则
+对 `fractalmind-ai/fractalbot` 中现有未提交 wechat 草稿代码：
+
+- 可保留为“已探索实现草稿”
+- 但 **不再作为 O7 当前成功标准的主路径**
+- 是否继续保留、重构为适配层，推迟到 KR3 决定
+
+## 6. O7 的正确推进顺序
+
+1. **KR1**：完成路线决策文档
+   - 说明为什么默认采用官方插件
+   - 说明 FractalBot 是否还需要介入
+
+2. **KR2**：完成基于当前运行时的最小闭环验证
+   - 明确实际宿主与接入入口
+   - 登录或等价鉴权
+   - 收消息
+   - 回消息
+   - 留下命令/日志/截图证据
+
+3. **KR3**：收敛系统边界
+   - 如果官方方案足够：归档或冻结自研通道草稿
+   - 如果确有内部集成需求：把 FractalBot 定义为适配层，而不是微信协议实现层
+
+## 7. 需要重点验证的问题
+
+### 7.1 功能问题
+- 官方插件是否能稳定完成消息接收与回复？
+- 多账号同时在线是否真的可用？
+- 上下文隔离是否满足我们的 agent routing 需求？
+
+### 7.2 集成问题
+- OpenClaw 与现有 FractalBot / agent-manager 的关系如何定义？
+- 是否需要统一 outbound / routing / observability？
+- 是否存在从 OpenClaw 向现有工作流桥接的最小接口？
+
+### 7.3 风险问题
+- 官方插件更新节奏如何？
+- 登录态与协议稳定性如何？
+- 若官方插件不可用，是否需要回退到适配层或其他方案？
+
+## 8. 对 heartbeat 的约束
+
+后续 heartbeat 在 O7 上只能优先做以下事情：
+
+1. 补官方路线文档
+2. 做官方插件验证
+3. 做路线收敛
+
+**不得再默认把“继续写 FractalBot 自研微信 callback”当作 O7 的主推进动作。**

--- a/docs/wechat-openclaw-validation-log.md
+++ b/docs/wechat-openclaw-validation-log.md
@@ -1,0 +1,110 @@
+# 微信 OpenClaw 官方插件验证记录
+
+> Status: in progress
+> Updated: 2026-03-23 (UTC+8)
+> Goal: 留下本轮错误路径与纠偏证据，避免后续再次把“安装 OpenClaw”当成默认动作。
+
+## 0. 纠偏说明（2026-03-23）
+
+用户已明确说明：
+
+- 当前环境是 **`https://github.com/fractalmind-ai` 驱动运行**
+- **不要再安装 OpenClaw**
+- 之前已经卸载过 OpenClaw
+
+因此，本文档中的 3 次尝试应视为：
+
+- **一次错误路径的排查记录**
+- 不是后续 heartbeat 应继续复现的默认步骤
+
+后续验证必须改为：
+
+1. 先确认 fractalmind-ai 当前运行时中，微信能力应接入的真实宿主
+2. 只把官方 `openclaw-weixin` 包作为能力边界/兼容性参考
+3. 不再继续执行新的 OpenClaw 安装或升级动作
+
+## 1. 本地环境基线
+
+- `openclaw --version` → `2026.2.6-3`
+- `npm view openclaw version` → `2026.3.13`
+- `node -v` → `v22.21.0`
+- `npm -v` → `10.9.4`
+
+初步判断：本地 OpenClaw 版本**落后于 npm 最新版**，存在插件 SDK 兼容性风险。
+
+## 2. 尝试记录
+
+### 尝试 1：官方一键安装
+命令：
+
+```bash
+npx -y @tencent-weixin/openclaw-weixin-cli install
+```
+
+结果：
+- 成功下载并安装插件到 `~/.openclaw/extensions/openclaw-weixin`
+- 安装阶段出现安全提示：
+  - `WARNING: Plugin "openclaw-weixin" contains dangerous code patterns: Environment variable access combined with network send`
+- 安装后自动首次连接失败：
+  - `TypeError: (0 , _pluginSdk.resolvePreferredOpenClawTmpDir) is not a function`
+  - `Channel login failed: Error: Unsupported channel: openclaw-weixin`
+
+### 尝试 2：检查插件加载状态
+命令：
+
+```bash
+openclaw plugins list
+```
+
+结果：
+- `@tencent-weixin/openclaw-weixin` 已出现在插件列表中
+- 状态为 `error`
+- 关键报错：
+
+```text
+openclaw-weixin failed to load ... TypeError: (0 , _pluginSdk.resolvePreferredOpenClawTmpDir) is not a function
+```
+
+### 尝试 3：手动登录 channel
+命令：
+
+```bash
+openclaw channels login --channel openclaw-weixin
+```
+
+结果：
+- 失败
+- 报错：
+
+```text
+Channel login failed: Error: Unsupported channel: openclaw-weixin
+```
+
+## 3. 当前结论
+
+当前已经确认：
+
+1. **官方插件安装成功，但加载失败**
+2. 失败点出现在插件运行期，而不是 npm 下载/解压阶段
+3. 错误特征强烈指向 **OpenClaw core 与插件 SDK 的版本不兼容**
+   - 插件调用了 `resolvePreferredOpenClawTmpDir`
+   - 当前本地 OpenClaw 版本未提供该函数
+
+## 4. 对 O7 的意义
+
+- 这 3 次尝试证明：**把 OpenClaw 当作当前环境宿主是有偏差的**
+- 本轮更重要的产出不是兼容性结论本身，而是确认了需要按用户约束收敛路线
+- 后续 KR2 必须切换到：**在 fractalmind-ai 当前运行时内验证微信能力，而不是继续围绕 OpenClaw 安装/升级打转**
+
+## 5. 下一步建议
+
+优先级顺序：
+
+1. 先确认当前 `fractalmind-ai` 驱动运行时中，微信能力应挂接的真实入口
+2. 把官方 `openclaw-weixin` 包保留为能力边界与兼容性参考，而不是默认执行路径
+3. 基于当前运行时重新设计 KR2 的最小闭环验证步骤
+4. 若后续仍需引用 upstream OpenClaw，只能作为例外场景单独说明，不能再默认执行安装/升级
+
+## 6. 当前不做的事
+
+在用户重新明确允许之前，**不再执行新的 OpenClaw 安装/升级动作，也不继续扩大 FractalBot 自研 wechat callback 的实现范围**。

--- a/docs/wechat-picoclaw-reference.md
+++ b/docs/wechat-picoclaw-reference.md
@@ -1,0 +1,129 @@
+# sipeed/picoclaw 微信渠道参考笔记
+
+> Status: draft
+> Updated: 2026-03-23 (UTC+8)
+> Purpose: 记录 `https://github.com/sipeed/picoclaw` 已接入微信渠道的证据，作为 O7 后续在 `fractalmind-ai` 当前运行时内适配官方微信能力的外部参考。
+
+## 1. 结论
+
+`picoclaw` **已经接入微信渠道**，而且不是文档占位，而是包含完整的可运行实现。
+
+## 2. 关键证据
+
+### 2.1 渠道源码目录完整存在
+
+仓库下存在完整 `pkg/channels/weixin/` 目录：
+
+- `pkg/channels/weixin/weixin.go`
+- `pkg/channels/weixin/api.go`
+- `pkg/channels/weixin/auth.go`
+- `pkg/channels/weixin/media.go`
+- `pkg/channels/weixin/state.go`
+- `pkg/channels/weixin/types.go`
+- `pkg/channels/weixin/weixin_test.go`
+
+这说明其微信能力已经落到正式 channel 实现、状态管理、媒体处理与测试层，而不是 README 草稿。
+
+### 2.2 渠道已在框架中注册
+
+`pkg/channels/weixin/weixin.go` 中注册了 `weixin` factory，并在 `Start()` 中启动轮询逻辑。
+
+这表明：
+
+- 微信渠道是框架正式支持的一部分
+- 不是孤立的示例代码
+- 运行时预期会真实拉取消息并进入统一 channel 抽象
+
+### 2.3 接入方式是腾讯 iLink API + 扫码登录
+
+从 `pkg/channels/weixin/api.go` 与 `pkg/channels/weixin/auth.go` 可确认：
+
+- 默认 `BaseURL = https://ilinkai.weixin.qq.com/`
+- 提供 `GetUpdates`、`SendMessage`、`GetUploadUrl`、`GetConfig`、`SendTyping`、`GetQRCode`、`GetQRCodeStatus` 等 API 封装
+- 登录流程是终端展示二维码 + 轮询扫码状态，最终拿到 `botToken / userID / accountID / baseUrl`
+
+这意味着它采用的是：
+
+**腾讯 iLink API + 原生扫码登录**
+
+而不是公众号/企业微信 callback 回调模型。
+
+### 2.4 收消息机制是 long polling，不是 webhook
+
+从 `pkg/channels/weixin/weixin.go` 可确认：
+
+- `Start()` 会启动 `pollLoop()`
+- `pollLoop()` 持续调用 `GetUpdates(...)`
+- 使用 `get_updates_buf` 维护游标
+- `pkg/channels/weixin/state.go` 持久化轮询状态
+
+所以它的消息接入模型是：
+
+**REST API + long polling + cursor state**
+
+而不是传统 webhook / callback 推送。
+
+### 2.5 配置与文档都是正式形态
+
+`pkg/config/config.go` 与 `pkg/config/defaults.go` 中存在 `WeixinConfig`：
+
+- `Enabled`
+- `Token`
+- `BaseURL`
+- `CDNBaseURL`
+- `Proxy`
+- `AllowFrom`
+- `ReasoningChannelID`
+
+默认值里直接包含：
+
+- `BaseURL: https://ilinkai.weixin.qq.com/`
+- `CDNBaseURL: https://novac2c.cdn.weixin.qq.com/c2c`
+
+文档层也明确列出微信渠道：
+
+- `README.md`
+- `docs/channels/weixin/README.md`
+- `docs/channels/weixin/README.zh.md`
+- `docs/chat-apps.md`
+- `docs/zh/chat-apps.md`
+
+## 3. 对 O7 的启发
+
+`picoclaw` 的实现给出一个很重要的信号：
+
+1. **微信渠道不一定只能走 webhook / callback**
+   - 还可以走扫码登录后的 API polling 路线
+
+2. **“当前运行时内适配官方微信能力”可以参考成熟 channel 分层**
+   - 认证层：扫码 / token / baseUrl
+   - API 层：updates / send / media / typing
+   - 状态层：cursor / persistence
+   - 渠道路由层：统一映射到现有 message/channel 抽象
+
+3. **此前 FractalBot 自研 callback 草稿并不覆盖这一路线**
+   - 说明 O7-KR2 需要补做“polling 型微信接入”的设计判断
+   - 不能只围绕 callback 能力推进
+
+## 4. 当前可直接参考的代码点
+
+建议后续重点参考：
+
+- `pkg/channels/weixin/weixin.go`：渠道生命周期、poll loop、消息分发
+- `pkg/channels/weixin/api.go`：iLink REST API 封装
+- `pkg/channels/weixin/auth.go`：二维码登录与 token 获取
+- `pkg/channels/weixin/state.go`：游标与状态持久化
+- `pkg/config/config.go`：配置结构设计
+
+## 5. 当前边界
+
+该参考结论的意义是：
+
+- 证明已有开源项目在真实实现“微信渠道”时采用了 **iLink API + QR login + long polling**
+- 为 O7 提供架构参考
+
+但它**不自动等于**我们当前运行时可以直接复用同一路线；后续仍需单独确认：
+
+1. `fractalmind-ai` 当前运行时是否更适合 callback 模式、polling 模式，或两者混合
+2. 是否能直接对接同类 API / 鉴权能力
+3. 是否需要把 FractalBot 定义为桥接层而非微信协议层

--- a/docs/wechat-polling-config-overlay.example.yaml
+++ b/docs/wechat-polling-config-overlay.example.yaml
@@ -1,0 +1,21 @@
+# WeChat polling-first local validation overlay for O7-KR2
+# Usage: merge these fields into a private local FractalBot config when
+# preparing the first polling proof. Do not commit real secrets.
+
+channels:
+  wechat:
+    enabled: true
+    mode: "polling"
+    # Runtime currently only accepts "wecom" / "mp_service".
+    # Keep "wecom" here so the local proof config matches the actual parser.
+    provider: "wecom"
+
+    # polling runtime
+    baseURL: "https://ilinkai.weixin.qq.com/"
+    token: "replace-with-local-bot-token"
+    stateFile: "./workspace/wechat.polling.state.json"
+    pollIntervalSeconds: 3
+
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"

--- a/docs/wechat-runtime-entrypoint.md
+++ b/docs/wechat-runtime-entrypoint.md
@@ -1,0 +1,122 @@
+# 微信当前运行时接入入口（fractalmind-ai）
+
+> Status: draft
+> Updated: 2026-03-22 23:00 PDT
+> Purpose: 在不重新安装 OpenClaw core 的前提下，确认 `fractalmind-ai` 当前运行时中微信能力应挂接的真实宿主与入口。
+
+## 1. 结论
+
+基于当前工作区代码与本机正在运行的 FractalBot 实例，可确认：
+
+- **当前运行时宿主是 FractalBot gateway 进程**，不是额外的 OpenClaw core 进程
+- 若后续要在当前系统内接入微信，**现成的挂接入口位于 FractalBot 的 channel manager / gateway 层**
+- 也就是说，O7-KR2 下一步要验证的“真实入口”，当前应优先围绕：
+  - `cmd/fractalbot/main.go`
+  - `internal/gateway/server.go`
+  - `internal/channels/manager.go`
+  - `internal/channels/wechat.go`
+
+这是一份**运行时入口确认记录**，不是微信最小闭环已经跑通的证明。
+
+## 2. 代码证据
+
+### 2.1 启动入口是 FractalBot gateway
+
+`cmd/fractalbot/main.go` 中：
+
+- 读取 `config.yaml`
+- 调用 `gateway.NewServer(cfg)`
+- 再执行 `server.Start(ctx)`
+
+说明当前主进程的宿主模型是：
+
+**FractalBot CLI / gateway server → channel manager → agent manager**
+
+### 2.2 channel 挂接点在 gateway.NewServer
+
+`internal/gateway/server.go` 中：
+
+- `channelManager := channels.NewManager(cfg.Channels, cfg.Agents)`
+- `agentManager := agent.NewManager(cfg.Agents)`
+- `agentManager.ChannelManager = channelManager`
+- `channelManager.SetHandler(agentManager)`
+- `Start()` 时执行 `s.agentManager.ChannelManager.Start(ctx)`
+
+说明：
+
+- 所有 channel 都是在 **FractalBot gateway 启动流程** 中被创建和启动
+- inbound message 的统一进入点是 channel manager → agent manager
+- 因此，若微信要在当前运行时中接入，最自然的宿主就是这个 channel 抽象层
+
+### 2.3 wechat 已有待接入 scaffold
+
+`internal/channels/manager.go` 与 `internal/channels/wechat.go` 表明：
+
+- `wechat` 已被纳入 channel manager 的注册/启动范围
+- 当前已存在 callback listener scaffold、query precheck、XML parsing、protocol mapping、handler routing 等 KR2 草稿实现
+
+因此从代码结构上说：
+
+**当前运行时不是“没有微信入口”，而是“已有 FractalBot 内部入口，但最小闭环还未完成验证”。**
+
+## 3. 运行时证据（本机当前实例）
+
+### 3.1 当前 gateway 绑定
+
+从本机 `~/.config/fractalbot/config.yaml` 读取到的非敏感配置显示：
+
+- `gateway.bind = 127.0.0.1`
+- `gateway.port = 18789`
+
+### 3.2 当前已启用 channel
+
+同一份本地配置的非敏感字段显示：
+
+- `telegram.enabled = true`
+- `imessage.enabled = true`
+- `slack / feishu / discord = false`
+- 当前配置中**尚未启用 wechat channel**
+
+### 3.3 当前运行中的 gateway 状态
+
+本机 `curl http://127.0.0.1:18789/status` 返回：
+
+- `telegram` 运行中
+- `imessage` 运行中
+- agent workspace 已配置
+- 当前没有 `wechat` 运行实例出现在 `/status`
+
+这进一步说明：
+
+1. 当前真实宿主确实是本地 FractalBot gateway
+2. 当前环境下微信还未被配置/启用
+3. O7-KR2 的下一步不是“寻找另一个宿主”，而是在这个运行时里补齐微信最小闭环验证
+
+## 4. 对 O7-KR2 的直接意义
+
+这次确认把问题收敛为更具体的下一步：
+
+1. **宿主已确认**：FractalBot gateway / channel manager
+2. **当前缺口已确认**：wechat 尚未在当前配置中启用，也未完成 end-to-end 证据
+3. **下一步验证动作应聚焦**：
+   - 明确采用 callback 还是 polling 作为当前运行时内的第一条验证路径
+   - 若继续走 FractalBot scaffold，则补“真实启动 + 状态可见 + 单次收消息/回消息证据”
+   - 若转为参考 `picoclaw` 的 polling 模型，则需先定义该模型如何接入现有 channel manager
+
+## 5. 当前边界
+
+本记录只证明：
+
+- 当前 `fractalmind-ai` 运行时里，微信能力应优先挂接到 **FractalBot gateway/channel** 层
+
+本记录**不证明**：
+
+- callback 模式一定是最终路线
+- polling 模式无法接入当前架构
+- 微信最小闭环已经完成
+
+后续仍需继续补：
+
+- 真实启动/配置证据
+- inbound/outbound 最小闭环证据
+- route 收敛说明（FractalBot 适配层 vs 其他桥接方式）

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -218,6 +218,32 @@ func (m *Manager) registerConfiguredChannels() error {
 		}
 	}
 
+	if m.cfg.WeChat != nil && m.cfg.WeChat.Enabled {
+		if m.Get("wechat") != nil {
+			return nil
+		}
+		bot, err := NewWeChatBot(m.cfg.WeChat.Provider)
+		if err != nil {
+			return fmt.Errorf("failed to init wechat bot: %w", err)
+		}
+		bot.ConfigurePolling(
+			m.cfg.WeChat.BaseURL,
+			m.cfg.WeChat.Token,
+			m.cfg.WeChat.StateFile,
+			m.cfg.WeChat.PollIntervalSeconds,
+		)
+		bot.ConfigureCallback(
+			m.cfg.WeChat.CallbackListenAddr,
+			m.cfg.WeChat.CallbackPath,
+			m.cfg.WeChat.CallbackToken,
+			m.cfg.WeChat.CallbackEncodingAESKey,
+		)
+		bot.ConfigureMode(m.cfg.WeChat.Mode)
+		if err := m.Register(bot); err != nil {
+			return fmt.Errorf("failed to register wechat bot: %w", err)
+		}
+	}
+
 	if m.cfg.Feishu != nil && m.cfg.Feishu.Enabled {
 		if m.Get("feishu") != nil {
 			return nil

--- a/internal/channels/manager_wechat_test.go
+++ b/internal/channels/manager_wechat_test.go
@@ -1,0 +1,111 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+func TestManagerRegistersWeChatChannel(t *testing.T) {
+	manager := NewManager(&config.ChannelsConfig{
+		WeChat: &config.WeChatConfig{
+			Enabled:              true,
+			Provider:             "wecom",
+			CallbackPath:         "/wechat/callback",
+			CallbackToken:        "token-123",
+			AccessTokenCacheFile: "./workspace/wechat.token.json",
+		},
+	}, nil)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = manager.Stop() }()
+
+	waitForCondition(t, time.Second, func() bool {
+		channel := manager.Get("wechat")
+		return channel != nil && channel.IsRunning()
+	})
+}
+
+func TestManagerRegistersWeChatPollingMode(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_ = json.NewEncoder(w).Encode(wechatPollingResponse{Ret: 0, Errcode: 0})
+	}))
+	defer server.Close()
+
+	manager := NewManager(&config.ChannelsConfig{
+		WeChat: &config.WeChatConfig{
+			Enabled:             true,
+			Provider:            "wecom",
+			Mode:                "polling",
+			BaseURL:             server.URL,
+			Token:               "bot-token-123",
+			StateFile:           "./workspace/wechat.polling.state.json",
+			PollIntervalSeconds: 3,
+			CallbackListenAddr:  "127.0.0.1:18810",
+		},
+	}, nil)
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer func() { _ = manager.Stop() }()
+
+	waitForCondition(t, time.Second, func() bool {
+		channel := manager.Get("wechat")
+		return channel != nil && channel.IsRunning()
+	})
+	waitForCondition(t, time.Second, func() bool {
+		return requests > 0
+	})
+
+	channel := manager.Get("wechat")
+	bot, ok := channel.(*WeChatBot)
+	if !ok {
+		t.Fatalf("expected WeChatBot, got %T", channel)
+	}
+	if bot.mode != wechatModePolling {
+		t.Fatalf("mode=%q want %q", bot.mode, wechatModePolling)
+	}
+	if bot.pollingBaseURL != server.URL {
+		t.Fatalf("pollingBaseURL=%q", bot.pollingBaseURL)
+	}
+	if bot.pollingToken != "bot-token-123" {
+		t.Fatalf("pollingToken=%q", bot.pollingToken)
+	}
+	if bot.pollingStateFile != "./workspace/wechat.polling.state.json" {
+		t.Fatalf("pollingStateFile=%q", bot.pollingStateFile)
+	}
+	if bot.pollingIntervalSeconds != 3 {
+		t.Fatalf("pollingIntervalSeconds=%d want 3", bot.pollingIntervalSeconds)
+	}
+	if bot.callbackServer != nil {
+		t.Fatalf("expected polling mode to skip callback server startup")
+	}
+}
+
+func TestManagerRejectsInvalidWeChatProvider(t *testing.T) {
+	manager := NewManager(&config.ChannelsConfig{
+		WeChat: &config.WeChatConfig{
+			Enabled:  true,
+			Provider: "bad-provider",
+		},
+	}, nil)
+
+	err := manager.Start(context.Background())
+	if err == nil {
+		t.Fatalf("expected invalid provider error")
+	}
+	if !strings.Contains(err.Error(), "invalid wechat provider") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/channels/wechat.go
+++ b/internal/channels/wechat.go
@@ -1,0 +1,981 @@
+package channels
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+const (
+	wechatProviderWeCom        = "wecom"
+	wechatProviderMPService    = "mp_service"
+	wechatModeCallback         = "callback"
+	wechatModePolling          = "polling"
+	defaultWeChatPath          = "/wechat/callback"
+	defaultWeChatPollInterval  = 3 * time.Second
+	maxWeChatBodyBytes         = 1 << 20
+	wechatIlinkAppID           = "bot"
+	wechatIlinkChannelVersion  = "2.1.1"
+	wechatIlinkClientVersion   = 131329
+	wechatPollEndpoint         = "ilink/bot/getupdates"
+	wechatMessageItemTypeText  = 1
+	wechatMessageItemTypeImage = 2
+	wechatMessageItemTypeVoice = 3
+	wechatMessageItemTypeFile  = 4
+	wechatMessageItemTypeVideo = 5
+)
+
+// WeChatBot is a minimal lifecycle scaffold for WeChat official providers.
+// It currently brings up an optional callback listener so KR2 can progress
+// incrementally before inbound parsing/outbound send are implemented.
+type WeChatBot struct {
+	provider string
+
+	handler IncomingMessageHandler
+
+	mode string
+
+	httpClient *http.Client
+
+	pollingBaseURL         string
+	pollingToken           string
+	pollingStateFile       string
+	pollingIntervalSeconds int
+	pollingFetchFn         func(ctx context.Context, cursor string) ([]*protocol.Message, string, error)
+	pollingCursorMu        sync.RWMutex
+	pollingCursor          string
+
+	callbackListenAddr     string
+	callbackPath           string
+	callbackToken          string
+	callbackEncodingAESKey string
+	callbackServer         *http.Server
+	callbackServerErr      error
+
+	runningMu sync.RWMutex
+	running   bool
+
+	telemetryMu  sync.RWMutex
+	lastActivity time.Time
+	lastError    time.Time
+	lastPollAt   time.Time
+	lastPollMsgs int
+
+	stopMu     sync.Mutex
+	stopCancel context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+type WeChatPollingRuntimeStatus struct {
+	CursorPresent   bool
+	CursorPreview   string
+	StateFileExists bool
+	LastPollAt      time.Time
+	LastPollMsgs    int
+}
+
+type wechatPollingState struct {
+	NextCursor string `json:"next_cursor,omitempty"`
+}
+
+type wechatPollingBaseInfo struct {
+	ChannelVersion string `json:"channel_version,omitempty"`
+}
+
+type wechatPollingGetUpdatesRequest struct {
+	GetUpdatesBuf string                `json:"get_updates_buf,omitempty"`
+	BaseInfo      wechatPollingBaseInfo `json:"base_info,omitempty"`
+}
+
+type wechatPollingResponse struct {
+	Ret                  int                    `json:"ret,omitempty"`
+	Errcode              int                    `json:"errcode,omitempty"`
+	Errmsg               string                 `json:"errmsg,omitempty"`
+	Msgs                 []wechatPollingMessage `json:"msgs,omitempty"`
+	GetUpdatesBuf        string                 `json:"get_updates_buf,omitempty"`
+	LongpollingTimeoutMs int                    `json:"longpolling_timeout_ms,omitempty"`
+}
+
+type wechatPollingMessage struct {
+	MessageID    int64                      `json:"message_id,omitempty"`
+	ClientID     string                     `json:"client_id,omitempty"`
+	FromUserID   string                     `json:"from_user_id,omitempty"`
+	ToUserID     string                     `json:"to_user_id,omitempty"`
+	SessionID    string                     `json:"session_id,omitempty"`
+	ContextToken string                     `json:"context_token,omitempty"`
+	ItemList     []wechatPollingMessageItem `json:"item_list,omitempty"`
+}
+
+type wechatPollingMessageItem struct {
+	Type      int                     `json:"type,omitempty"`
+	TextItem  *wechatPollingTextItem  `json:"text_item,omitempty"`
+	VoiceItem *wechatPollingVoiceItem `json:"voice_item,omitempty"`
+	FileItem  *wechatPollingFileItem  `json:"file_item,omitempty"`
+	ImageItem *wechatPollingImageItem `json:"image_item,omitempty"`
+	VideoItem *wechatPollingVideoItem `json:"video_item,omitempty"`
+}
+
+type wechatPollingTextItem struct {
+	Text string `json:"text,omitempty"`
+}
+
+type wechatPollingVoiceItem struct {
+	Text string `json:"text,omitempty"`
+}
+
+type wechatPollingFileItem struct {
+	FileName string `json:"file_name,omitempty"`
+}
+
+type wechatPollingImageItem struct{}
+
+type wechatPollingVideoItem struct{}
+
+type wechatCallbackEnvelope struct {
+	XMLName      xml.Name `xml:"xml"`
+	ToUserName   string   `xml:"ToUserName"`
+	FromUserName string   `xml:"FromUserName"`
+	CreateTime   string   `xml:"CreateTime"`
+	MsgType      string   `xml:"MsgType"`
+	Content      string   `xml:"Content"`
+	MsgID        string   `xml:"MsgId"`
+	Event        string   `xml:"Event"`
+	EventKey     string   `xml:"EventKey"`
+	Encrypt      string   `xml:"Encrypt"`
+	AgentID      string   `xml:"AgentID"`
+}
+
+type wechatCallbackPayload struct {
+	Method            string                  `json:"method"`
+	Provider          string                  `json:"provider"`
+	Path              string                  `json:"path"`
+	RequestType       string                  `json:"request_type,omitempty"`
+	Query             map[string]string       `json:"query,omitempty"`
+	SignatureParam    string                  `json:"signature_param,omitempty"`
+	SignaturePresent  bool                    `json:"signature_present"`
+	SignatureVerified bool                    `json:"signature_verified"`
+	EchostrPresent    bool                    `json:"echostr_present"`
+	Envelope          *wechatCallbackEnvelope `json:"envelope,omitempty"`
+	ProtocolMessage   *protocol.Message       `json:"protocol_message,omitempty"`
+	BodyPreview       string                  `json:"body_preview,omitempty"`
+	BodyBytes         int                     `json:"body_bytes,omitempty"`
+	TokenConfigured   bool                    `json:"token_configured"`
+	AESConfigured     bool                    `json:"aes_key_configured"`
+}
+
+func NewWeChatBot(provider string) (*WeChatBot, error) {
+	resolved := strings.ToLower(strings.TrimSpace(provider))
+	if resolved == "" {
+		resolved = wechatProviderWeCom
+	}
+	switch resolved {
+	case wechatProviderWeCom, wechatProviderMPService:
+	default:
+		return nil, fmt.Errorf("invalid wechat provider: %q", provider)
+	}
+
+	bot := &WeChatBot{
+		provider:     resolved,
+		mode:         wechatModeCallback,
+		callbackPath: defaultWeChatPath,
+		httpClient:   &http.Client{Timeout: 40 * time.Second},
+	}
+	bot.pollingFetchFn = bot.fetchPollingUpdates
+	return bot, nil
+}
+
+func (b *WeChatBot) Name() string { return "wechat" }
+
+func (b *WeChatBot) SetHandler(handler IncomingMessageHandler) {
+	b.handler = handler
+}
+
+func (b *WeChatBot) IsRunning() bool {
+	b.runningMu.RLock()
+	defer b.runningMu.RUnlock()
+	return b.running
+}
+
+func (b *WeChatBot) setRunning(running bool) {
+	b.runningMu.Lock()
+	b.running = running
+	b.runningMu.Unlock()
+}
+
+func (b *WeChatBot) LastActivity() time.Time {
+	b.telemetryMu.RLock()
+	defer b.telemetryMu.RUnlock()
+	return b.lastActivity
+}
+
+func (b *WeChatBot) LastError() time.Time {
+	b.telemetryMu.RLock()
+	defer b.telemetryMu.RUnlock()
+	return b.lastError
+}
+
+func (b *WeChatBot) markActivity() {
+	b.telemetryMu.Lock()
+	b.lastActivity = time.Now().UTC()
+	b.telemetryMu.Unlock()
+}
+
+func (b *WeChatBot) markError() {
+	b.telemetryMu.Lock()
+	b.lastError = time.Now().UTC()
+	b.telemetryMu.Unlock()
+}
+
+func (b *WeChatBot) markPoll(msgCount int) {
+	b.telemetryMu.Lock()
+	b.lastPollAt = time.Now().UTC()
+	b.lastPollMsgs = msgCount
+	b.telemetryMu.Unlock()
+}
+
+func (b *WeChatBot) ConfigureCallback(listenAddr, path, token, encodingAESKey string) {
+	b.callbackListenAddr = strings.TrimSpace(listenAddr)
+	if trimmedPath := strings.TrimSpace(path); trimmedPath != "" {
+		b.callbackPath = trimmedPath
+	}
+	b.callbackToken = strings.TrimSpace(token)
+	b.callbackEncodingAESKey = strings.TrimSpace(encodingAESKey)
+}
+
+func (b *WeChatBot) ConfigurePolling(baseURL, token, stateFile string, intervalSeconds int) {
+	b.pollingBaseURL = strings.TrimSpace(baseURL)
+	b.pollingToken = strings.TrimSpace(token)
+	b.pollingStateFile = strings.TrimSpace(stateFile)
+	b.pollingIntervalSeconds = intervalSeconds
+}
+
+func (b *WeChatBot) ConfigureMode(mode string) {
+	resolved := strings.ToLower(strings.TrimSpace(mode))
+	switch resolved {
+	case "", "auto":
+		if b.pollingBaseURL != "" || b.pollingToken != "" || b.pollingStateFile != "" || b.pollingIntervalSeconds > 0 {
+			b.mode = wechatModePolling
+			return
+		}
+		b.mode = wechatModeCallback
+	case wechatModeCallback, wechatModePolling:
+		b.mode = resolved
+	default:
+		b.mode = wechatModeCallback
+	}
+}
+
+func (b *WeChatBot) getPollingCursor() string {
+	b.pollingCursorMu.RLock()
+	defer b.pollingCursorMu.RUnlock()
+	return b.pollingCursor
+}
+
+func (b *WeChatBot) setPollingCursor(cursor string) {
+	b.pollingCursorMu.Lock()
+	b.pollingCursor = strings.TrimSpace(cursor)
+	b.pollingCursorMu.Unlock()
+}
+
+func (b *WeChatBot) Start(ctx context.Context) error {
+	if b.IsRunning() {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	b.stopMu.Lock()
+	b.stopCancel = cancel
+	b.stopMu.Unlock()
+
+	if b.mode == wechatModePolling {
+		if err := b.validatePollingConfig(); err != nil {
+			b.markError()
+			return err
+		}
+		if err := b.loadPollingState(); err != nil {
+			b.markError()
+			return err
+		}
+		b.setRunning(true)
+		b.wg.Add(1)
+		go b.pollLoop(ctx)
+		return nil
+	}
+
+	if b.callbackListenAddr == "" {
+		b.setRunning(true)
+		return nil
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(b.callbackPath, b.handleCallback)
+	server := &http.Server{
+		Addr:              b.callbackListenAddr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	b.callbackServer = server
+	b.callbackServerErr = nil
+	b.setRunning(true)
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	go func() {
+		if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			b.callbackServerErr = err
+			b.markError()
+			b.setRunning(false)
+		}
+	}()
+
+	return nil
+}
+
+func (b *WeChatBot) validatePollingConfig() error {
+	if strings.TrimSpace(b.pollingBaseURL) == "" {
+		return errors.New("wechat polling baseURL is required")
+	}
+	if strings.TrimSpace(b.pollingToken) == "" {
+		return errors.New("wechat polling token is required")
+	}
+	return nil
+}
+
+func (b *WeChatBot) Stop() error {
+	b.stopMu.Lock()
+	cancel := b.stopCancel
+	b.stopCancel = nil
+	b.stopMu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	b.wg.Wait()
+	if b.callbackServer != nil {
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+		if err := b.callbackServer.Shutdown(shutdownCtx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			b.markError()
+			return err
+		}
+	}
+	b.setRunning(false)
+	return nil
+}
+
+func (b *WeChatBot) pollLoop(ctx context.Context) {
+	defer b.wg.Done()
+
+	b.pollOnce(ctx)
+	ticker := time.NewTicker(b.pollInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			b.pollOnce(ctx)
+		}
+	}
+}
+
+func (b *WeChatBot) pollInterval() time.Duration {
+	if b.pollingIntervalSeconds > 0 {
+		return time.Duration(b.pollingIntervalSeconds) * time.Second
+	}
+	return defaultWeChatPollInterval
+}
+
+func (b *WeChatBot) pollOnce(ctx context.Context) {
+	cursor := b.getPollingCursor()
+	msgs, nextCursor, err := b.pollingFetchFn(ctx, cursor)
+	if err != nil {
+		b.markError()
+		return
+	}
+	b.markPoll(len(msgs))
+
+	if strings.TrimSpace(nextCursor) != "" && nextCursor != cursor {
+		b.setPollingCursor(nextCursor)
+		if err := b.persistPollingState(); err != nil {
+			b.markError()
+		}
+	}
+
+	if b.handler == nil {
+		return
+	}
+
+	for _, msg := range msgs {
+		if msg == nil {
+			continue
+		}
+		if _, err := b.handler.HandleIncoming(ctx, msg); err != nil {
+			b.markError()
+			continue
+		}
+		b.markActivity()
+	}
+}
+
+func (b *WeChatBot) PollingRuntimeStatus() WeChatPollingRuntimeStatus {
+	stateExists := false
+	if path := strings.TrimSpace(b.pollingStateFile); path != "" {
+		if _, err := os.Stat(path); err == nil {
+			stateExists = true
+		}
+	}
+
+	b.telemetryMu.RLock()
+	lastPollAt := b.lastPollAt
+	lastPollMsgs := b.lastPollMsgs
+	b.telemetryMu.RUnlock()
+
+	cursor := b.getPollingCursor()
+	return WeChatPollingRuntimeStatus{
+		CursorPresent:   strings.TrimSpace(cursor) != "",
+		CursorPreview:   truncateForPreview(cursor, 64),
+		StateFileExists: stateExists,
+		LastPollAt:      lastPollAt,
+		LastPollMsgs:    lastPollMsgs,
+	}
+}
+
+func (b *WeChatBot) fetchPollingUpdates(ctx context.Context, cursor string) ([]*protocol.Message, string, error) {
+	resp, err := b.doPollingGetUpdates(ctx, cursor)
+	if err != nil {
+		return nil, cursor, err
+	}
+	if resp.Errcode != 0 || resp.Ret != 0 {
+		return nil, cursor, fmt.Errorf(
+			"wechat getupdates failed: ret=%d errcode=%d errmsg=%s",
+			resp.Ret,
+			resp.Errcode,
+			strings.TrimSpace(resp.Errmsg),
+		)
+	}
+
+	nextCursor := strings.TrimSpace(resp.GetUpdatesBuf)
+	if nextCursor == "" {
+		nextCursor = cursor
+	}
+
+	msgs := make([]*protocol.Message, 0, len(resp.Msgs))
+	for _, inbound := range resp.Msgs {
+		if mapped := b.pollingMessageToProtocolMessage(inbound); mapped != nil {
+			msgs = append(msgs, mapped)
+		}
+	}
+	return msgs, nextCursor, nil
+}
+
+func (b *WeChatBot) doPollingGetUpdates(ctx context.Context, cursor string) (*wechatPollingResponse, error) {
+	endpoint, err := b.pollingEndpointURL(wechatPollEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := json.Marshal(wechatPollingGetUpdatesRequest{
+		GetUpdatesBuf: strings.TrimSpace(cursor),
+		BaseInfo: wechatPollingBaseInfo{
+			ChannelVersion: wechatIlinkChannelVersion,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal wechat getupdates payload: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create wechat getupdates request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("iLink-App-Id", wechatIlinkAppID)
+	req.Header.Set("iLink-App-ClientVersion", strconv.Itoa(wechatIlinkClientVersion))
+	req.Header.Set("AuthorizationType", "ilink_bot_token")
+	req.Header.Set("X-WECHAT-UIN", randomWeChatPollingUIN())
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(b.pollingToken))
+
+	client := b.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 40 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("call wechat getupdates: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read wechat getupdates response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("wechat getupdates returned status %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	var parsed wechatPollingResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("parse wechat getupdates response: %w", err)
+	}
+	return &parsed, nil
+}
+
+func (b *WeChatBot) pollingEndpointURL(endpoint string) (string, error) {
+	base := strings.TrimSpace(b.pollingBaseURL)
+	if base == "" {
+		return "", errors.New("wechat polling baseURL is required")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse wechat polling baseURL: %w", err)
+	}
+	u.Path = path.Join(u.Path, endpoint)
+	return u.String(), nil
+}
+
+func randomWeChatPollingUIN() string {
+	var raw [4]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return base64.StdEncoding.EncodeToString([]byte(strconv.FormatInt(time.Now().UnixNano(), 10)))
+	}
+	value := binary.BigEndian.Uint32(raw[:])
+	return base64.StdEncoding.EncodeToString([]byte(strconv.FormatUint(uint64(value), 10)))
+}
+
+func (b *WeChatBot) pollingMessageToProtocolMessage(msg wechatPollingMessage) *protocol.Message {
+	fromUserID := strings.TrimSpace(msg.FromUserID)
+	if fromUserID == "" {
+		return nil
+	}
+
+	text, msgType, attachments := flattenWeChatPollingItems(msg.ItemList)
+	if text == "" && len(attachments) == 0 {
+		return nil
+	}
+
+	messageID := strings.TrimSpace(msg.ClientID)
+	if messageID == "" && msg.MessageID != 0 {
+		messageID = strconv.FormatInt(msg.MessageID, 10)
+	}
+	if messageID == "" {
+		messageID = fmt.Sprintf("wechat-%d", time.Now().UnixNano())
+	}
+
+	data := map[string]interface{}{
+		"channel":       "wechat",
+		"provider":      b.provider,
+		"text":          text,
+		"agent":         "",
+		"chat_id":       fromUserID,
+		"user_id":       fromUserID,
+		"username":      fromUserID,
+		"message_id":    messageID,
+		"chatType":      "dm",
+		"msg_type":      msgType,
+		"from_user_id":  fromUserID,
+		"to_user_id":    strings.TrimSpace(msg.ToUserID),
+		"session_id":    strings.TrimSpace(msg.SessionID),
+		"context_token": strings.TrimSpace(msg.ContextToken),
+	}
+	if msg.MessageID != 0 {
+		data["upstream_message_id"] = msg.MessageID
+	}
+	if len(attachments) > 0 {
+		data["attachments"] = attachments
+	}
+
+	return &protocol.Message{
+		Kind:   protocol.MessageKindChannel,
+		Action: protocol.ActionCreate,
+		Data:   data,
+	}
+}
+
+func flattenWeChatPollingItems(items []wechatPollingMessageItem) (string, string, []string) {
+	parts := make([]string, 0, len(items))
+	attachments := make([]string, 0, len(items))
+	msgType := "text"
+
+	for _, item := range items {
+		switch item.Type {
+		case wechatMessageItemTypeText:
+			if item.TextItem != nil && strings.TrimSpace(item.TextItem.Text) != "" {
+				parts = append(parts, strings.TrimSpace(item.TextItem.Text))
+			}
+		case wechatMessageItemTypeVoice:
+			msgType = "voice"
+			if item.VoiceItem != nil && strings.TrimSpace(item.VoiceItem.Text) != "" {
+				parts = append(parts, strings.TrimSpace(item.VoiceItem.Text))
+			} else {
+				parts = append(parts, "[audio]")
+			}
+		case wechatMessageItemTypeImage:
+			msgType = "image"
+			parts = append(parts, "[image]")
+			attachments = append(attachments, "image")
+		case wechatMessageItemTypeFile:
+			msgType = "file"
+			name := ""
+			if item.FileItem != nil {
+				name = strings.TrimSpace(item.FileItem.FileName)
+			}
+			if name != "" {
+				parts = append(parts, fmt.Sprintf("[file: %s]", name))
+			} else {
+				parts = append(parts, "[file]")
+			}
+			attachments = append(attachments, "file")
+		case wechatMessageItemTypeVideo:
+			msgType = "video"
+			parts = append(parts, "[video]")
+			attachments = append(attachments, "video")
+		}
+	}
+
+	return strings.TrimSpace(strings.Join(parts, "\n")), msgType, attachments
+}
+
+func (b *WeChatBot) loadPollingState() error {
+	if b.pollingStateFile == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(b.pollingStateFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("failed to read wechat polling state file: %w", err)
+	}
+
+	var state wechatPollingState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return fmt.Errorf("failed to parse wechat polling state file: %w", err)
+	}
+	b.setPollingCursor(state.NextCursor)
+	return nil
+}
+
+func (b *WeChatBot) persistPollingState() error {
+	if b.pollingStateFile == "" {
+		return nil
+	}
+
+	dir := filepath.Dir(b.pollingStateFile)
+	if dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create wechat polling state dir: %w", err)
+		}
+	}
+
+	tmp, err := os.CreateTemp(dir, ".wechat-polling-state-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp wechat polling state file: %w", err)
+	}
+	defer func() {
+		_ = os.Remove(tmp.Name())
+	}()
+
+	payload, err := json.MarshalIndent(wechatPollingState{
+		NextCursor: b.getPollingCursor(),
+	}, "", "  ")
+	if err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to marshal wechat polling state: %w", err)
+	}
+
+	if _, err := tmp.Write(append(payload, '\n')); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write temp wechat polling state file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp wechat polling state file: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), b.pollingStateFile); err != nil {
+		return fmt.Errorf("failed to rename temp wechat polling state file: %w", err)
+	}
+	return nil
+}
+
+func (b *WeChatBot) SendMessage(ctx context.Context, target string, text string) error {
+	_ = ctx
+	_ = target
+	_ = text
+	b.markError()
+	return errors.New("wechat sender not configured yet")
+}
+
+func (b *WeChatBot) handleCallback(w http.ResponseWriter, r *http.Request) {
+	payload, err := b.parseCallbackRequest(r)
+	if err != nil {
+		b.markError()
+		writeWeChatJSON(w, http.StatusBadRequest, map[string]any{
+			"status":   "error",
+			"channel":  "wechat",
+			"provider": b.provider,
+			"error":    err.Error(),
+		})
+		return
+	}
+
+	b.markActivity()
+	if payload != nil && payload.RequestType == "handshake" {
+		writeWeChatText(w, http.StatusOK, payload.Query["echostr"])
+		return
+	}
+
+	response := map[string]any{
+		"status":   "not_implemented",
+		"channel":  "wechat",
+		"provider": b.provider,
+		"callback": payload,
+	}
+	if payload != nil && payload.ProtocolMessage != nil && b.handler != nil && r.Method == http.MethodPost {
+		reply, handlerErr := b.handler.HandleIncoming(r.Context(), payload.ProtocolMessage)
+		if handlerErr != nil {
+			b.markError()
+			response["handler_error"] = handlerErr.Error()
+		} else if strings.TrimSpace(reply) != "" {
+			response["handler_reply"] = reply
+		}
+	}
+	writeWeChatJSON(w, http.StatusNotImplemented, response)
+}
+
+func (b *WeChatBot) parseCallbackRequest(r *http.Request) (*wechatCallbackPayload, error) {
+	query := firstQueryValues(r)
+	sigParam, sigValue := detectWeChatSignature(query)
+	payload := &wechatCallbackPayload{
+		Method:           r.Method,
+		Provider:         b.provider,
+		Path:             r.URL.Path,
+		Query:            query,
+		SignatureParam:   sigParam,
+		SignaturePresent: strings.TrimSpace(sigValue) != "",
+		EchostrPresent:   strings.TrimSpace(query["echostr"]) != "",
+		TokenConfigured:  b.callbackToken != "",
+		AESConfigured:    b.callbackEncodingAESKey != "",
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		payload.RequestType = "handshake"
+		if err := b.validateCallbackQuery(payload); err != nil {
+			return nil, err
+		}
+		payload.SignatureVerified = true
+		return payload, nil
+	case http.MethodPost:
+		payload.RequestType = "message"
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxWeChatBodyBytes))
+		if err != nil {
+			return nil, fmt.Errorf("read callback body: %w", err)
+		}
+		payload.BodyBytes = len(body)
+		payload.BodyPreview = truncateForPreview(string(body), 240)
+		trimmed := strings.TrimSpace(string(body))
+		if trimmed != "" {
+			var env wechatCallbackEnvelope
+			if err := xml.Unmarshal(body, &env); err != nil {
+				return nil, fmt.Errorf("parse callback xml: %w", err)
+			}
+			payload.Envelope = &env
+			payload.ProtocolMessage = b.envelopeToProtocolMessage(&env)
+		}
+		if err := b.validateCallbackQuery(payload); err != nil {
+			return nil, err
+		}
+		payload.SignatureVerified = true
+		return payload, nil
+	default:
+		return nil, fmt.Errorf("unsupported callback method: %s", r.Method)
+	}
+}
+
+func (b *WeChatBot) validateCallbackQuery(payload *wechatCallbackPayload) error {
+	if payload == nil {
+		return errors.New("callback payload is required")
+	}
+	query := payload.Query
+	if payload.RequestType == "handshake" && !payload.EchostrPresent {
+		return errors.New("missing echostr query parameter")
+	}
+	if !payload.TokenConfigured {
+		return nil
+	}
+	if !payload.SignaturePresent {
+		return errors.New("missing signature query parameter")
+	}
+	timestamp := strings.TrimSpace(query["timestamp"])
+	if timestamp == "" {
+		return errors.New("missing timestamp query parameter")
+	}
+	nonce := strings.TrimSpace(query["nonce"])
+	if nonce == "" {
+		return errors.New("missing nonce query parameter")
+	}
+	expected, err := b.expectedCallbackSignature(payload, timestamp, nonce)
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(strings.TrimSpace(query[payload.SignatureParam]), expected) {
+		return errors.New("invalid callback signature")
+	}
+	return nil
+}
+
+func (b *WeChatBot) expectedCallbackSignature(payload *wechatCallbackPayload, timestamp, nonce string) (string, error) {
+	if payload == nil {
+		return "", errors.New("callback payload is required")
+	}
+	var pieces []string
+	switch payload.SignatureParam {
+	case "msg_signature":
+		messagePart := ""
+		switch payload.RequestType {
+		case "handshake":
+			messagePart = strings.TrimSpace(payload.Query["echostr"])
+		case "message":
+			if payload.Envelope != nil {
+				messagePart = strings.TrimSpace(payload.Envelope.Encrypt)
+			}
+		}
+		if messagePart == "" {
+			return "", errors.New("missing encrypted payload for msg_signature validation")
+		}
+		pieces = []string{b.callbackToken, timestamp, nonce, messagePart}
+	case "signature":
+		pieces = []string{b.callbackToken, timestamp, nonce}
+		if payload.RequestType == "message" && payload.Envelope != nil && strings.TrimSpace(payload.Envelope.Encrypt) != "" {
+			return "", errors.New("signature query parameter is incompatible with encrypted payload")
+		}
+	default:
+		return "", errors.New("missing signature query parameter")
+	}
+	return computeWeChatSignature(pieces...), nil
+}
+
+func detectWeChatSignature(query map[string]string) (string, string) {
+	if len(query) == 0 {
+		return "", ""
+	}
+	for _, key := range []string{"msg_signature", "signature"} {
+		if value, ok := query[key]; ok {
+			return key, value
+		}
+	}
+	return "", ""
+}
+
+func computeWeChatSignature(parts ...string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		filtered = append(filtered, strings.TrimSpace(part))
+	}
+	sort.Strings(filtered)
+	hash := sha1.Sum([]byte(strings.Join(filtered, "")))
+	return hex.EncodeToString(hash[:])
+}
+
+func (b *WeChatBot) envelopeToProtocolMessage(env *wechatCallbackEnvelope) *protocol.Message {
+	if env == nil {
+		return nil
+	}
+	data := map[string]interface{}{
+		"channel":        "wechat",
+		"provider":       b.provider,
+		"text":           env.Content,
+		"agent":          "",
+		"chat_id":        strings.TrimSpace(env.FromUserName),
+		"user_id":        strings.TrimSpace(env.FromUserName),
+		"username":       strings.TrimSpace(env.FromUserName),
+		"message_id":     strings.TrimSpace(env.MsgID),
+		"chatType":       "dm",
+		"to_user_name":   strings.TrimSpace(env.ToUserName),
+		"from_user_name": strings.TrimSpace(env.FromUserName),
+		"msg_type":       strings.TrimSpace(env.MsgType),
+	}
+	if strings.TrimSpace(env.Event) != "" {
+		data["event"] = strings.TrimSpace(env.Event)
+	}
+	if strings.TrimSpace(env.EventKey) != "" {
+		data["event_key"] = strings.TrimSpace(env.EventKey)
+	}
+	if strings.TrimSpace(env.AgentID) != "" {
+		data["agent_id"] = strings.TrimSpace(env.AgentID)
+	}
+	if strings.TrimSpace(env.Encrypt) != "" {
+		data["encrypted"] = true
+	}
+	return &protocol.Message{
+		Kind:   protocol.MessageKindChannel,
+		Action: protocol.ActionCreate,
+		Data:   data,
+	}
+}
+
+func firstQueryValues(r *http.Request) map[string]string {
+	if r == nil || r.URL == nil {
+		return nil
+	}
+	q := r.URL.Query()
+	if len(q) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(q))
+	for key, values := range q {
+		if len(values) == 0 {
+			out[key] = ""
+			continue
+		}
+		out[key] = values[0]
+	}
+	return out
+}
+
+func truncateForPreview(text string, limit int) string {
+	trimmed := strings.TrimSpace(text)
+	if limit <= 0 || len(trimmed) <= limit {
+		return trimmed
+	}
+	return trimmed[:limit] + "…"
+}
+
+func writeWeChatJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeWeChatText(w http.ResponseWriter, status int, text string) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, text)
+}

--- a/internal/channels/wechat_test.go
+++ b/internal/channels/wechat_test.go
@@ -1,0 +1,524 @@
+package channels
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+type fakeWeChatHandler struct {
+	reply string
+	err   error
+	last  *protocol.Message
+}
+
+func (f *fakeWeChatHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	_ = ctx
+	f.last = msg
+	if f.err != nil {
+		return "", f.err
+	}
+	return f.reply, nil
+}
+
+func TestWeChatCallbackGETHandshakeEchoesEchostrWhenSignatureValid(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "aes-key-123")
+
+	echostr := "hello"
+	sig := computeWeChatSignature("token-123", "1", "2", echostr)
+	req := httptest.NewRequest(http.MethodGet, "/wechat/callback?msg_signature="+sig+"&timestamp=1&nonce=2&echostr="+echostr, nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusOK)
+	}
+	if body := rr.Body.String(); body != echostr {
+		t.Fatalf("body=%q want %q", body, echostr)
+	}
+	if got := rr.Header().Get("Content-Type"); !strings.Contains(got, "text/plain") {
+		t.Fatalf("unexpected content type: %s", got)
+	}
+}
+
+func TestWeChatCallbackGETRejectsInvalidSignature(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/wechat/callback?signature=bad&timestamp=1&nonce=2&echostr=hello", nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), `"error":"invalid callback signature"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatCallbackPOSTParsesXMLPayload(t *testing.T) {
+	bot, err := NewWeChatBot("mp_service")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+
+	xmlBody := `<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>`
+	req := httptest.NewRequest(http.MethodPost, "/wechat/callback", strings.NewReader(xmlBody))
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusNotImplemented)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"\"provider\":\"mp_service\"", "\"MsgType\":\"text\"", "\"Content\":\"this is a test\"", "\"ToUserName\":\"toUser\"", "\"protocol_message\"", "\"channel\":\"wechat\"", "\"msg_type\":\"text\""} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("missing %q in body %s", want, body)
+		}
+	}
+}
+
+func TestWeChatCallbackRejectsUnsupportedMethod(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPut, "/wechat/callback", nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), "unsupported callback method") {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatEnvelopeToProtocolMessageMapsEventFields(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+
+	msg := bot.envelopeToProtocolMessage(&wechatCallbackEnvelope{
+		ToUserName:   "toUser",
+		FromUserName: "fromUser",
+		MsgType:      "event",
+		Event:        "subscribe",
+		EventKey:     "qrscene_123",
+		AgentID:      "1000001",
+	})
+	if msg == nil {
+		t.Fatalf("expected protocol message")
+	}
+	data, ok := msg.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %#v", msg.Data)
+	}
+	if data["channel"] != "wechat" || data["provider"] != "wecom" {
+		t.Fatalf("unexpected base fields: %#v", data)
+	}
+	if data["event"] != "subscribe" || data["event_key"] != "qrscene_123" {
+		t.Fatalf("unexpected event fields: %#v", data)
+	}
+	if data["agent_id"] != "1000001" {
+		t.Fatalf("unexpected agent_id: %#v", data)
+	}
+}
+
+func TestWeChatCallbackPOSTInvokesHandlerWithProtocolMessage(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	handler := &fakeWeChatHandler{reply: "agent-ack"}
+	bot.SetHandler(handler)
+
+	xmlBody := `<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>`
+	req := httptest.NewRequest(http.MethodPost, "/wechat/callback", strings.NewReader(xmlBody))
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if handler.last == nil {
+		t.Fatalf("expected handler to receive protocol message")
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `"handler_reply":"agent-ack"`) {
+		t.Fatalf("expected handler reply in body: %s", body)
+	}
+}
+
+func TestWeChatCallbackPOSTIncludesHandlerError(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.SetHandler(&fakeWeChatHandler{err: errors.New("boom")})
+
+	xmlBody := `<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>`
+	req := httptest.NewRequest(http.MethodPost, "/wechat/callback", strings.NewReader(xmlBody))
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusNotImplemented {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusNotImplemented)
+	}
+	if !strings.Contains(rr.Body.String(), `"handler_error":"boom"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatCallbackGETRequiresEchostr(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "")
+
+	sig := computeWeChatSignature("token-123", "1", "2", "hello")
+	req := httptest.NewRequest(http.MethodGet, "/wechat/callback?msg_signature="+sig+"&timestamp=1&nonce=2", nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), `"error":"missing echostr query parameter"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatCallbackGETRequiresSignatureWhenTokenConfigured(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/wechat/callback?timestamp=1&nonce=2&echostr=hello", nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), `"error":"missing signature query parameter"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatCallbackGETRequiresTimestampWhenTokenConfigured(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/wechat/callback?signature=abc&nonce=2&echostr=hello", nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), `"error":"missing timestamp query parameter"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatCallbackGETRequiresNonceWhenTokenConfigured(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "")
+
+	req := httptest.NewRequest(http.MethodGet, "/wechat/callback?signature=abc&timestamp=1&echostr=hello", nil)
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), `"error":"missing nonce query parameter"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatCallbackPOSTRequiresSignatureWhenTokenConfigured(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigureCallback("", "/wechat/callback", "token-123", "")
+
+	xmlBody := `<xml><ToUserName><![CDATA[toUser]]></ToUserName><FromUserName><![CDATA[fromUser]]></FromUserName><CreateTime>1348831860</CreateTime><MsgType><![CDATA[text]]></MsgType><Content><![CDATA[this is a test]]></Content><MsgId>1234567890123456</MsgId></xml>`
+	req := httptest.NewRequest(http.MethodPost, "/wechat/callback", strings.NewReader(xmlBody))
+	rr := httptest.NewRecorder()
+	bot.handleCallback(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d", rr.Code, http.StatusBadRequest)
+	}
+	if !strings.Contains(rr.Body.String(), `"error":"missing signature query parameter"`) {
+		t.Fatalf("unexpected body: %s", rr.Body.String())
+	}
+}
+
+func TestWeChatPollingStateLoadMissingFile(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.pollingStateFile = filepath.Join(t.TempDir(), "wechat.state.json")
+
+	if err := bot.loadPollingState(); err != nil {
+		t.Fatalf("loadPollingState: %v", err)
+	}
+	if got := bot.getPollingCursor(); got != "" {
+		t.Fatalf("polling cursor=%q want empty", got)
+	}
+}
+
+func TestWeChatPollingStatePersistsCursor(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "state", "wechat.state.json")
+	bot.pollingStateFile = path
+	bot.setPollingCursor("cursor-42")
+
+	if err := bot.persistPollingState(); err != nil {
+		t.Fatalf("persistPollingState: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	var state wechatPollingState
+	if err := json.Unmarshal(data, &state); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if state.NextCursor != "cursor-42" {
+		t.Fatalf("NextCursor=%q want cursor-42", state.NextCursor)
+	}
+}
+
+func TestWeChatPollingFetchUsesRealUpstreamAPI(t *testing.T) {
+	var gotAuth string
+	var gotAuthType string
+	var gotAppID string
+	var gotClientVersion string
+	var gotUIN string
+	var gotPayload wechatPollingGetUpdatesRequest
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method=%s want POST", r.Method)
+		}
+		if r.URL.Path != "/gateway/ilink/bot/getupdates" {
+			t.Fatalf("path=%q", r.URL.Path)
+		}
+		gotAuth = r.Header.Get("Authorization")
+		gotAuthType = r.Header.Get("AuthorizationType")
+		gotAppID = r.Header.Get("iLink-App-Id")
+		gotClientVersion = r.Header.Get("iLink-App-ClientVersion")
+		gotUIN = r.Header.Get("X-WECHAT-UIN")
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(wechatPollingResponse{
+			Ret:           0,
+			Errcode:       0,
+			GetUpdatesBuf: "cursor-2",
+			Msgs: []wechatPollingMessage{
+				{
+					MessageID:    101,
+					ClientID:     "client-101",
+					FromUserID:   "wx-user",
+					ToUserID:     "wx-bot",
+					SessionID:    "session-1",
+					ContextToken: "context-1",
+					ItemList: []wechatPollingMessageItem{
+						{
+							Type:     wechatMessageItemTypeText,
+							TextItem: &wechatPollingTextItem{Text: "hello from ilink"},
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+	bot.ConfigurePolling(server.URL+"/gateway", "bot-token", "", 1)
+
+	msgs, nextCursor, err := bot.fetchPollingUpdates(context.Background(), "cursor-1")
+	if err != nil {
+		t.Fatalf("fetchPollingUpdates: %v", err)
+	}
+	if nextCursor != "cursor-2" {
+		t.Fatalf("nextCursor=%q want cursor-2", nextCursor)
+	}
+	if gotPayload.GetUpdatesBuf != "cursor-1" {
+		t.Fatalf("get_updates_buf=%q want cursor-1", gotPayload.GetUpdatesBuf)
+	}
+	if gotPayload.BaseInfo.ChannelVersion != wechatIlinkChannelVersion {
+		t.Fatalf("channel_version=%q want %q", gotPayload.BaseInfo.ChannelVersion, wechatIlinkChannelVersion)
+	}
+	if gotAuth != "Bearer bot-token" {
+		t.Fatalf("authorization=%q", gotAuth)
+	}
+	if gotAuthType != "ilink_bot_token" {
+		t.Fatalf("authorizationType=%q", gotAuthType)
+	}
+	if gotAppID != wechatIlinkAppID {
+		t.Fatalf("appID=%q want %q", gotAppID, wechatIlinkAppID)
+	}
+	if gotClientVersion != "131329" {
+		t.Fatalf("clientVersion=%q", gotClientVersion)
+	}
+	if strings.TrimSpace(gotUIN) == "" {
+		t.Fatalf("expected X-WECHAT-UIN header")
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("len(msgs)=%d want 1", len(msgs))
+	}
+	data, ok := msgs[0].Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", msgs[0].Data)
+	}
+	if data["text"] != "hello from ilink" {
+		t.Fatalf("text=%#v", data["text"])
+	}
+	if data["context_token"] != "context-1" {
+		t.Fatalf("context_token=%#v", data["context_token"])
+	}
+	if data["session_id"] != "session-1" {
+		t.Fatalf("session_id=%#v", data["session_id"])
+	}
+}
+
+func TestWeChatPollingModeLoadsStateAndDispatchesToHandler(t *testing.T) {
+	bot, err := NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot: %v", err)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wechat.state.json")
+	if err := os.WriteFile(path, []byte("{\"next_cursor\":\"cursor-1\"}\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	handler := &fakeWeChatHandler{reply: "ok"}
+	bot.SetHandler(handler)
+	bot.ConfigurePolling("https://ilinkai.weixin.qq.com/", "bot-token", path, 1)
+	bot.ConfigureMode("polling")
+
+	calls := 0
+	bot.pollingFetchFn = func(ctx context.Context, cursor string) ([]*protocol.Message, string, error) {
+		calls++
+		if cursor != "cursor-1" {
+			t.Fatalf("cursor=%q want cursor-1", cursor)
+		}
+		return []*protocol.Message{{
+			Kind:   protocol.MessageKindChannel,
+			Action: protocol.ActionCreate,
+			Data: map[string]interface{}{
+				"channel": "wechat",
+				"text":    "hello",
+			},
+		}}, "cursor-2", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := bot.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer func() { _ = bot.Stop() }()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if handler.last != nil && bot.getPollingCursor() == "cursor-2" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if calls == 0 {
+		t.Fatalf("expected polling fetch to be called")
+	}
+	if handler.last == nil {
+		t.Fatalf("expected handler to receive polling message")
+	}
+	if bot.callbackServer != nil {
+		t.Fatalf("expected polling mode to skip callback server")
+	}
+	if got := bot.getPollingCursor(); got != "cursor-2" {
+		t.Fatalf("polling cursor=%q want cursor-2", got)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "cursor-2") {
+		t.Fatalf("expected persisted cursor in file: %s", string(data))
+	}
+}
+
+func TestWeChatPollingModeRequiresBaseURLAndToken(t *testing.T) {
+	t.Run("missing baseURL", func(t *testing.T) {
+		bot, err := NewWeChatBot("wecom")
+		if err != nil {
+			t.Fatalf("NewWeChatBot: %v", err)
+		}
+		bot.ConfigurePolling("", "bot-token", "", 1)
+		bot.ConfigureMode("polling")
+
+		err = bot.Start(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "baseURL is required") {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		bot, err := NewWeChatBot("wecom")
+		if err != nil {
+			t.Fatalf("NewWeChatBot: %v", err)
+		}
+		bot.ConfigurePolling("https://ilinkai.weixin.qq.com/", "", "", 1)
+		bot.ConfigureMode("polling")
+
+		err = bot.Start(context.Background())
+		if err == nil || !strings.Contains(err.Error(), "token is required") {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,10 +30,58 @@ type GatewayConfig struct {
 // ChannelsConfig contains channel configurations.
 type ChannelsConfig struct {
 	Telegram *TelegramConfig `yaml:"telegram,omitempty"`
+	WeChat   *WeChatConfig   `yaml:"wechat,omitempty"`
 	Feishu   *FeishuConfig   `yaml:"feishu,omitempty"`
 	Slack    *SlackConfig    `yaml:"slack,omitempty"`
 	Discord  *DiscordConfig  `yaml:"discord,omitempty"`
 	IMessage *IMessageConfig `yaml:"imessage,omitempty"`
+}
+
+// WeChatConfig contains WeChat official channel settings.
+type WeChatConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+	// Provider selects the concrete official capability. Supported: "wecom", "mp_service".
+	Provider string `yaml:"provider,omitempty"`
+
+	// Mode controls how FractalBot receives WeChat updates.
+	// Supported values: "callback", "polling". Empty means auto.
+	Mode string `yaml:"mode,omitempty"`
+
+	// BaseURL overrides the upstream polling API base URL when polling mode is used.
+	BaseURL string `yaml:"baseURL,omitempty"`
+	// Token carries the polling API credential / session token when polling mode is used.
+	Token string `yaml:"token,omitempty"`
+	// StateFile persists polling cursor / session state for reconnects and restarts.
+	StateFile string `yaml:"stateFile,omitempty"`
+	// PollIntervalSeconds sets the polling loop interval. Default will be decided by runtime.
+	PollIntervalSeconds int `yaml:"pollIntervalSeconds,omitempty"`
+
+	// CallbackListenAddr is the local bind address for inbound callbacks.
+	CallbackListenAddr string `yaml:"callbackListenAddr,omitempty"`
+	// CallbackPath is the HTTP path mounted on the callback server.
+	CallbackPath string `yaml:"callbackPath,omitempty"`
+	// CallbackToken is used to verify callback requests when the provider requires it.
+	CallbackToken string `yaml:"callbackToken,omitempty"`
+	// CallbackEncodingAESKey configures encrypted callback payload verification/decryption when required.
+	CallbackEncodingAESKey string `yaml:"callbackEncodingAESKey,omitempty"`
+
+	// WeCom outbound auth.
+	CorpID     string `yaml:"corpId,omitempty"`
+	CorpSecret string `yaml:"corpSecret,omitempty"`
+	AgentID    string `yaml:"agentId,omitempty"`
+
+	// MP Service Account outbound auth.
+	AppID     string `yaml:"appId,omitempty"`
+	AppSecret string `yaml:"appSecret,omitempty"`
+
+	// Routing defaults.
+	DefaultAgent  string   `yaml:"defaultAgent,omitempty"`
+	AllowedAgents []string `yaml:"allowedAgents,omitempty"`
+
+	// Reply policy.
+	SyncReplyTimeoutSeconds int    `yaml:"syncReplyTimeoutSeconds,omitempty"`
+	AsyncSendEnabled        bool   `yaml:"asyncSendEnabled,omitempty"`
+	AccessTokenCacheFile    string `yaml:"accessTokenCacheFile,omitempty"`
 }
 
 // TelegramConfig contains Telegram channel settings.
@@ -204,9 +252,72 @@ func DefaultConfig() *Config {
 }
 
 func validateConfig(cfg *Config) error {
+	if err := validateWeChatConfig(cfg); err != nil {
+		return err
+	}
 	if err := validateOhMyCodeConfig(cfg); err != nil {
 		return err
 	}
+	return nil
+}
+
+func validateWeChatConfig(cfg *Config) error {
+	if cfg == nil || cfg.Channels == nil || cfg.Channels.WeChat == nil {
+		return nil
+	}
+
+	wechat := cfg.Channels.WeChat
+	provider := strings.ToLower(strings.TrimSpace(wechat.Provider))
+	switch provider {
+	case "", "wecom", "mp_service":
+	default:
+		return fmt.Errorf("channels.wechat.provider: unsupported value %q", wechat.Provider)
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(wechat.Mode))
+	switch mode {
+	case "", "auto", "callback", "polling":
+	default:
+		return fmt.Errorf("channels.wechat.mode: unsupported value %q", wechat.Mode)
+	}
+
+	if mode == "polling" {
+		if strings.TrimSpace(wechat.BaseURL) == "" {
+			return fmt.Errorf("channels.wechat.baseURL: required when channels.wechat.mode is polling")
+		}
+		if strings.TrimSpace(wechat.Token) == "" {
+			return fmt.Errorf("channels.wechat.token: required when channels.wechat.mode is polling")
+		}
+	}
+
+	defaultAgent := strings.TrimSpace(wechat.DefaultAgent)
+	if defaultAgent != "" {
+		if err := validateAgentName(defaultAgent); err != nil {
+			return fmt.Errorf("channels.wechat.defaultAgent: %w", err)
+		}
+	}
+
+	allowed := make(map[string]struct{})
+	for idx, name := range wechat.AllowedAgents {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			return fmt.Errorf("channels.wechat.allowedAgents[%d]: agent name is required", idx)
+		}
+		if err := validateAgentName(trimmed); err != nil {
+			return fmt.Errorf("channels.wechat.allowedAgents[%d]: %w", idx, err)
+		}
+		allowed[trimmed] = struct{}{}
+	}
+
+	if len(allowed) > 0 {
+		if defaultAgent == "" {
+			return fmt.Errorf("channels.wechat.defaultAgent: required when channels.wechat.allowedAgents is configured")
+		}
+		if _, ok := allowed[defaultAgent]; !ok {
+			return fmt.Errorf("channels.wechat.defaultAgent: must be in channels.wechat.allowedAgents")
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -211,3 +211,156 @@ func TestLoadConfigAcceptsIMessagePollingConfig(t *testing.T) {
 		t.Fatalf("pollingLimit=%d want 25", cfg.Channels.IMessage.PollingLimit)
 	}
 }
+
+func TestLoadConfigAcceptsWeChatConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`channels:
+  wechat:
+    enabled: true
+    provider: "wecom"
+    mode: "polling"
+    baseURL: "https://ilinkai.weixin.qq.com/"
+    token: "bot-token-123"
+    stateFile: "./workspace/wechat.polling.state.json"
+    pollIntervalSeconds: 3
+    callbackListenAddr: "127.0.0.1:18810"
+    callbackPath: "/wechat/callback"
+    callbackToken: "token-123"
+    callbackEncodingAESKey: "aes-key-123"
+    corpId: "ww123"
+    corpSecret: "secret-123"
+    agentId: "1000001"
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+      - "qa-1"
+    syncReplyTimeoutSeconds: 4
+    asyncSendEnabled: true
+    accessTokenCacheFile: "./workspace/wechat.token.json"
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Channels == nil || cfg.Channels.WeChat == nil {
+		t.Fatalf("expected channels.wechat config")
+	}
+	if cfg.Channels.WeChat.Provider != "wecom" {
+		t.Fatalf("provider=%q want wecom", cfg.Channels.WeChat.Provider)
+	}
+	if cfg.Channels.WeChat.Mode != "polling" {
+		t.Fatalf("mode=%q want polling", cfg.Channels.WeChat.Mode)
+	}
+	if cfg.Channels.WeChat.BaseURL != "https://ilinkai.weixin.qq.com/" {
+		t.Fatalf("baseURL=%q", cfg.Channels.WeChat.BaseURL)
+	}
+	if cfg.Channels.WeChat.Token != "bot-token-123" {
+		t.Fatalf("token=%q", cfg.Channels.WeChat.Token)
+	}
+	if cfg.Channels.WeChat.StateFile != "./workspace/wechat.polling.state.json" {
+		t.Fatalf("stateFile=%q", cfg.Channels.WeChat.StateFile)
+	}
+	if cfg.Channels.WeChat.PollIntervalSeconds != 3 {
+		t.Fatalf("pollIntervalSeconds=%d want 3", cfg.Channels.WeChat.PollIntervalSeconds)
+	}
+	if cfg.Channels.WeChat.CallbackPath != "/wechat/callback" {
+		t.Fatalf("callbackPath=%q", cfg.Channels.WeChat.CallbackPath)
+	}
+	if !cfg.Channels.WeChat.AsyncSendEnabled {
+		t.Fatalf("expected asyncSendEnabled=true")
+	}
+	if cfg.Channels.WeChat.SyncReplyTimeoutSeconds != 4 {
+		t.Fatalf("syncReplyTimeoutSeconds=%d want 4", cfg.Channels.WeChat.SyncReplyTimeoutSeconds)
+	}
+}
+
+func TestLoadConfigRejectsInvalidWeChatProvider(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`channels:
+  wechat:
+    enabled: true
+    provider: "weixin_ilink"
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected invalid provider error")
+	}
+	if !strings.Contains(err.Error(), "channels.wechat.provider") {
+		t.Fatalf("expected error to mention channels.wechat.provider, got %v", err)
+	}
+}
+
+func TestLoadConfigRejectsWeChatPollingWithoutBaseURLOrToken(t *testing.T) {
+	t.Run("missing baseURL", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		content := []byte(`channels:
+  wechat:
+    enabled: true
+    provider: "wecom"
+    mode: "polling"
+    token: "bot-token-123"
+`)
+		if err := os.WriteFile(path, content, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		_, err := LoadConfig(path)
+		if err == nil {
+			t.Fatal("expected missing baseURL error")
+		}
+		if !strings.Contains(err.Error(), "channels.wechat.baseURL") {
+			t.Fatalf("expected error to mention channels.wechat.baseURL, got %v", err)
+		}
+	})
+
+	t.Run("missing token", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "config.yaml")
+		content := []byte(`channels:
+  wechat:
+    enabled: true
+    provider: "wecom"
+    mode: "polling"
+    baseURL: "https://ilinkai.weixin.qq.com/"
+`)
+		if err := os.WriteFile(path, content, 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+
+		_, err := LoadConfig(path)
+		if err == nil {
+			t.Fatal("expected missing token error")
+		}
+		if !strings.Contains(err.Error(), "channels.wechat.token") {
+			t.Fatalf("expected error to mention channels.wechat.token, got %v", err)
+		}
+	})
+}
+
+func TestLoadConfigRejectsWeChatAllowlistWithoutDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`channels:
+  wechat:
+    enabled: true
+    allowedAgents:
+      - "main"
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected missing defaultAgent error")
+	}
+	if !strings.Contains(err.Error(), "channels.wechat.defaultAgent") || !strings.Contains(err.Error(), "channels.wechat.allowedAgents") {
+		t.Fatalf("expected error to mention both config keys, got %v", err)
+	}
+}

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -346,9 +346,31 @@ type channelStatus struct {
 	Enabled      bool                            `json:"enabled"`
 	Running      bool                            `json:"running"`
 	Mode         string                          `json:"mode,omitempty"`
+	Provider     string                          `json:"provider,omitempty"`
 	Webhook      *channels.TelegramWebhookStatus `json:"webhook,omitempty"`
+	Callback     *callbackStatus                 `json:"callback,omitempty"`
+	Polling      *pollingStatus                  `json:"polling,omitempty"`
 	LastError    string                          `json:"last_error"`
 	LastActivity string                          `json:"last_activity"`
+}
+
+type callbackStatus struct {
+	ListenAddrConfigured bool `json:"listen_addr_configured"`
+	PathConfigured       bool `json:"path_configured"`
+	TokenConfigured      bool `json:"token_configured"`
+	AESKeyConfigured     bool `json:"aes_key_configured"`
+}
+
+type pollingStatus struct {
+	BaseURLConfigured   bool   `json:"base_url_configured"`
+	TokenConfigured     bool   `json:"token_configured"`
+	StateFileConfigured bool   `json:"state_file_configured"`
+	IntervalSeconds     int    `json:"interval_seconds,omitempty"`
+	CursorPresent       bool   `json:"cursor_present,omitempty"`
+	CursorPreview       string `json:"cursor_preview,omitempty"`
+	StateFileExists     bool   `json:"state_file_exists,omitempty"`
+	LastPollAt          string `json:"last_poll_at,omitempty"`
+	LastPollMessages    int    `json:"last_poll_messages,omitempty"`
 }
 
 type agentStatus struct {
@@ -390,6 +412,31 @@ func (s *Server) channelStatus() []channelStatus {
 			return formatStatusTime(provider.LastError()), formatStatusTime(provider.LastActivity())
 		}
 		return "", ""
+	}
+
+	if s.config.Channels.WeChat != nil {
+		ch := getChannel("wechat")
+		lastError, lastActivity := telemetry(ch)
+		polling := wechatPollingStatusFromConfig(s.config.Channels.WeChat)
+		if bot, ok := ch.(*channels.WeChatBot); ok && polling != nil {
+			runtime := bot.PollingRuntimeStatus()
+			polling.CursorPresent = runtime.CursorPresent
+			polling.CursorPreview = runtime.CursorPreview
+			polling.StateFileExists = runtime.StateFileExists
+			polling.LastPollAt = formatStatusTime(runtime.LastPollAt)
+			polling.LastPollMessages = runtime.LastPollMsgs
+		}
+		statuses = append(statuses, channelStatus{
+			Name:         "wechat",
+			Enabled:      s.config.Channels.WeChat.Enabled,
+			Running:      isRunning(ch),
+			Mode:         wechatModeFromConfig(s.config.Channels.WeChat),
+			Provider:     wechatProviderFromConfig(s.config.Channels.WeChat),
+			Callback:     wechatCallbackStatusFromConfig(s.config.Channels.WeChat),
+			Polling:      polling,
+			LastError:    lastError,
+			LastActivity: lastActivity,
+		})
 	}
 
 	if s.config.Channels.Telegram != nil {
@@ -474,6 +521,55 @@ func telegramModeFromConfig(cfg *config.TelegramConfig) string {
 		return "polling"
 	}
 	return mode
+}
+
+func wechatProviderFromConfig(cfg *config.WeChatConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
+	if provider == "" {
+		return "wecom"
+	}
+	return provider
+}
+
+func wechatModeFromConfig(cfg *config.WeChatConfig) string {
+	if cfg == nil {
+		return ""
+	}
+	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if mode != "" && mode != "auto" {
+		return mode
+	}
+	if strings.TrimSpace(cfg.BaseURL) != "" || strings.TrimSpace(cfg.Token) != "" || strings.TrimSpace(cfg.StateFile) != "" || cfg.PollIntervalSeconds > 0 {
+		return "polling"
+	}
+	return "callback"
+}
+
+func wechatCallbackStatusFromConfig(cfg *config.WeChatConfig) *callbackStatus {
+	if cfg == nil {
+		return nil
+	}
+	return &callbackStatus{
+		ListenAddrConfigured: strings.TrimSpace(cfg.CallbackListenAddr) != "",
+		PathConfigured:       strings.TrimSpace(cfg.CallbackPath) != "",
+		TokenConfigured:      strings.TrimSpace(cfg.CallbackToken) != "",
+		AESKeyConfigured:     strings.TrimSpace(cfg.CallbackEncodingAESKey) != "",
+	}
+}
+
+func wechatPollingStatusFromConfig(cfg *config.WeChatConfig) *pollingStatus {
+	if cfg == nil {
+		return nil
+	}
+	return &pollingStatus{
+		BaseURLConfigured:   strings.TrimSpace(cfg.BaseURL) != "",
+		TokenConfigured:     strings.TrimSpace(cfg.Token) != "",
+		StateFileConfigured: strings.TrimSpace(cfg.StateFile) != "",
+		IntervalSeconds:     cfg.PollIntervalSeconds,
+	}
 }
 
 func telegramWebhookStatusFromConfig(cfg *config.TelegramConfig) *channels.TelegramWebhookStatus {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -108,17 +108,35 @@ type statusPayload struct {
 	ActiveClients int    `json:"active_clients"`
 	Uptime        string `json:"uptime"`
 	Channels      []struct {
-		Name    string `json:"name"`
-		Enabled bool   `json:"enabled"`
-		Running bool   `json:"running"`
-		Mode    string `json:"mode"`
-		Webhook *struct {
+		Name     string `json:"name"`
+		Enabled  bool   `json:"enabled"`
+		Running  bool   `json:"running"`
+		Mode     string `json:"mode"`
+		Provider string `json:"provider"`
+		Webhook  *struct {
 			RegisterOnStart      bool `json:"register_on_start"`
 			DeleteOnStop         bool `json:"delete_on_stop"`
 			PublicURLConfigured  bool `json:"public_url_configured"`
 			ListenAddrConfigured bool `json:"listen_addr_configured"`
 			Registered           bool `json:"registered"`
 		} `json:"webhook"`
+		Callback *struct {
+			ListenAddrConfigured bool `json:"listen_addr_configured"`
+			PathConfigured       bool `json:"path_configured"`
+			TokenConfigured      bool `json:"token_configured"`
+			AESKeyConfigured     bool `json:"aes_key_configured"`
+		} `json:"callback"`
+		Polling *struct {
+			BaseURLConfigured   bool   `json:"base_url_configured"`
+			TokenConfigured     bool   `json:"token_configured"`
+			StateFileConfigured bool   `json:"state_file_configured"`
+			IntervalSeconds     int    `json:"interval_seconds"`
+			CursorPresent       bool   `json:"cursor_present"`
+			CursorPreview       string `json:"cursor_preview"`
+			StateFileExists     bool   `json:"state_file_exists"`
+			LastPollAt          string `json:"last_poll_at"`
+			LastPollMessages    int    `json:"last_poll_messages"`
+		} `json:"polling"`
 		LastError    string `json:"last_error"`
 		LastActivity string `json:"last_activity"`
 	} `json:"channels"`
@@ -178,6 +196,19 @@ func TestStatusIncludesChannelAndAgentInfo(t *testing.T) {
 				WebhookRegisterOnStart: true,
 				WebhookDeleteOnStop:    true,
 			},
+			WeChat: &config.WeChatConfig{
+				Enabled:                true,
+				Provider:               "wecom",
+				Mode:                   "polling",
+				BaseURL:                "https://ilinkai.weixin.qq.com/",
+				Token:                  "bot-token-123",
+				StateFile:              "./workspace/wechat.polling.state.json",
+				PollIntervalSeconds:    3,
+				CallbackListenAddr:     "127.0.0.1:18810",
+				CallbackPath:           "/wechat/callback",
+				CallbackToken:          "token-123",
+				CallbackEncodingAESKey: "aes-key-123",
+			},
 		},
 		Agents: &config.AgentsConfig{
 			Workspace:     "/tmp/agents",
@@ -207,35 +238,132 @@ func TestStatusIncludesChannelAndAgentInfo(t *testing.T) {
 		t.Fatalf("status request failed: %v", err)
 	}
 
-	if len(statusResp.Channels) != 1 {
-		t.Fatalf("expected 1 channel, got %d", len(statusResp.Channels))
+	if len(statusResp.Channels) != 2 {
+		t.Fatalf("expected 2 channels, got %d", len(statusResp.Channels))
 	}
-	if statusResp.Channels[0].Name != "telegram" {
-		t.Fatalf("unexpected channel name: %s", statusResp.Channels[0].Name)
+	channelsByName := map[string]struct {
+		Enabled  bool
+		Running  bool
+		Mode     string
+		Provider string
+		Webhook  *struct {
+			RegisterOnStart      bool `json:"register_on_start"`
+			DeleteOnStop         bool `json:"delete_on_stop"`
+			PublicURLConfigured  bool `json:"public_url_configured"`
+			ListenAddrConfigured bool `json:"listen_addr_configured"`
+			Registered           bool `json:"registered"`
+		}
+		Callback *struct {
+			ListenAddrConfigured bool `json:"listen_addr_configured"`
+			PathConfigured       bool `json:"path_configured"`
+			TokenConfigured      bool `json:"token_configured"`
+			AESKeyConfigured     bool `json:"aes_key_configured"`
+		}
+		Polling *struct {
+			BaseURLConfigured   bool   `json:"base_url_configured"`
+			TokenConfigured     bool   `json:"token_configured"`
+			StateFileConfigured bool   `json:"state_file_configured"`
+			IntervalSeconds     int    `json:"interval_seconds"`
+			CursorPresent       bool   `json:"cursor_present"`
+			CursorPreview       string `json:"cursor_preview"`
+			StateFileExists     bool   `json:"state_file_exists"`
+			LastPollAt          string `json:"last_poll_at"`
+			LastPollMessages    int    `json:"last_poll_messages"`
+		}
+	}{}
+	for _, ch := range statusResp.Channels {
+		channelsByName[ch.Name] = struct {
+			Enabled  bool
+			Running  bool
+			Mode     string
+			Provider string
+			Webhook  *struct {
+				RegisterOnStart      bool `json:"register_on_start"`
+				DeleteOnStop         bool `json:"delete_on_stop"`
+				PublicURLConfigured  bool `json:"public_url_configured"`
+				ListenAddrConfigured bool `json:"listen_addr_configured"`
+				Registered           bool `json:"registered"`
+			}
+			Callback *struct {
+				ListenAddrConfigured bool `json:"listen_addr_configured"`
+				PathConfigured       bool `json:"path_configured"`
+				TokenConfigured      bool `json:"token_configured"`
+				AESKeyConfigured     bool `json:"aes_key_configured"`
+			}
+			Polling *struct {
+				BaseURLConfigured   bool   `json:"base_url_configured"`
+				TokenConfigured     bool   `json:"token_configured"`
+				StateFileConfigured bool   `json:"state_file_configured"`
+				IntervalSeconds     int    `json:"interval_seconds"`
+				CursorPresent       bool   `json:"cursor_present"`
+				CursorPreview       string `json:"cursor_preview"`
+				StateFileExists     bool   `json:"state_file_exists"`
+				LastPollAt          string `json:"last_poll_at"`
+				LastPollMessages    int    `json:"last_poll_messages"`
+			}
+		}{
+			Enabled:  ch.Enabled,
+			Running:  ch.Running,
+			Mode:     ch.Mode,
+			Provider: ch.Provider,
+			Webhook:  ch.Webhook,
+			Callback: ch.Callback,
+			Polling:  ch.Polling,
+		}
 	}
-	if !statusResp.Channels[0].Enabled {
+	telegram := channelsByName["telegram"]
+	if !telegram.Enabled {
 		t.Fatalf("expected telegram to be enabled")
 	}
-	if statusResp.Channels[0].Running {
+	if telegram.Running {
 		t.Fatalf("expected telegram running=false before start")
 	}
-	if statusResp.Channels[0].Mode != "webhook" {
-		t.Fatalf("unexpected telegram mode: %s", statusResp.Channels[0].Mode)
+	if telegram.Mode != "webhook" {
+		t.Fatalf("unexpected telegram mode: %s", telegram.Mode)
 	}
-	if statusResp.Channels[0].Webhook == nil {
+	if telegram.Webhook == nil {
 		t.Fatalf("expected webhook status")
 	}
-	if !statusResp.Channels[0].Webhook.RegisterOnStart {
+	if !telegram.Webhook.RegisterOnStart {
 		t.Fatalf("expected webhook register_on_start true")
 	}
-	if !statusResp.Channels[0].Webhook.DeleteOnStop {
+	if !telegram.Webhook.DeleteOnStop {
 		t.Fatalf("expected webhook delete_on_stop true")
 	}
-	if !statusResp.Channels[0].Webhook.PublicURLConfigured {
+	if !telegram.Webhook.PublicURLConfigured {
 		t.Fatalf("expected webhook public_url_configured true")
 	}
-	if !statusResp.Channels[0].Webhook.ListenAddrConfigured {
+	if !telegram.Webhook.ListenAddrConfigured {
 		t.Fatalf("expected webhook listen_addr_configured true")
+	}
+
+	wechat := channelsByName["wechat"]
+	if !wechat.Enabled {
+		t.Fatalf("expected wechat to be enabled")
+	}
+	if wechat.Running {
+		t.Fatalf("expected wechat running=false before start")
+	}
+	if wechat.Provider != "wecom" {
+		t.Fatalf("unexpected wechat provider: %s", wechat.Provider)
+	}
+	if wechat.Mode != "polling" {
+		t.Fatalf("unexpected wechat mode: %s", wechat.Mode)
+	}
+	if wechat.Callback == nil {
+		t.Fatalf("expected callback status")
+	}
+	if !wechat.Callback.ListenAddrConfigured || !wechat.Callback.PathConfigured || !wechat.Callback.TokenConfigured || !wechat.Callback.AESKeyConfigured {
+		t.Fatalf("unexpected wechat callback status: %#v", wechat.Callback)
+	}
+	if wechat.Polling == nil {
+		t.Fatalf("expected polling status")
+	}
+	if !wechat.Polling.BaseURLConfigured || !wechat.Polling.TokenConfigured || !wechat.Polling.StateFileConfigured || wechat.Polling.IntervalSeconds != 3 {
+		t.Fatalf("unexpected wechat polling status: %#v", wechat.Polling)
+	}
+	if wechat.Polling.CursorPresent || wechat.Polling.CursorPreview != "" || wechat.Polling.StateFileExists || wechat.Polling.LastPollAt != "" || wechat.Polling.LastPollMessages != 0 {
+		t.Fatalf("expected empty runtime polling status before start: %#v", wechat.Polling)
 	}
 
 	if statusResp.Agents == nil {
@@ -258,6 +386,90 @@ func TestStatusIncludesChannelAndAgentInfo(t *testing.T) {
 	}
 	if len(statusResp.Agents.OhMyCode.AllowedAgents) != 2 {
 		t.Fatalf("unexpected allowed_agents: %v", statusResp.Agents.OhMyCode.AllowedAgents)
+	}
+}
+
+func TestStatusIncludesWeChatPollingRuntimeInfo(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"ret":0,"errcode":0,"get_updates_buf":"cursor-abc-123","msgs":[{"client_id":"client-1","from_user_id":"wx-user","to_user_id":"wx-bot","session_id":"session-1","context_token":"ctx-1","item_list":[{"type":1,"text_item":{"text":"hello"}}]}]}`)
+	}))
+	defer upstream.Close()
+
+	stateFile := t.TempDir() + "/wechat.polling.state.json"
+	cfg := &config.Config{
+		Gateway: &config.GatewayConfig{Bind: "127.0.0.1", Port: 0},
+		Channels: &config.ChannelsConfig{
+			WeChat: &config.WeChatConfig{
+				Enabled:             true,
+				Provider:            "wecom",
+				Mode:                "polling",
+				BaseURL:             upstream.URL,
+				Token:               "bot-token-123",
+				StateFile:           stateFile,
+				PollIntervalSeconds: 3,
+			},
+		},
+		Agents: &config.AgentsConfig{},
+	}
+
+	server, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	bot, err := channels.NewWeChatBot("wecom")
+	if err != nil {
+		t.Fatalf("NewWeChatBot failed: %v", err)
+	}
+	bot.ConfigurePolling(upstream.URL, "bot-token-123", stateFile, 3)
+	bot.ConfigureMode("polling")
+	if err := server.agentManager.ChannelManager.Register(bot); err != nil {
+		t.Fatalf("register wechat bot failed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := bot.Start(ctx); err != nil {
+		t.Fatalf("bot.Start failed: %v", err)
+	}
+	defer func() { _ = bot.Stop() }()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		status := bot.PollingRuntimeStatus()
+		if status.CursorPresent && status.StateFileExists && !status.LastPollAt.IsZero() {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", server.handleStatus)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	statusResp, err := fetchStatus(ts.URL + "/status")
+	if err != nil {
+		t.Fatalf("status request failed: %v", err)
+	}
+	if len(statusResp.Channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(statusResp.Channels))
+	}
+	polling := statusResp.Channels[0].Polling
+	if polling == nil {
+		t.Fatalf("expected polling status")
+	}
+	if !polling.CursorPresent || !polling.StateFileExists {
+		t.Fatalf("expected runtime polling state, got %#v", polling)
+	}
+	if polling.CursorPreview != "cursor-abc-123" {
+		t.Fatalf("unexpected cursor_preview: %q", polling.CursorPreview)
+	}
+	if polling.LastPollAt == "" {
+		t.Fatalf("expected last_poll_at")
+	}
+	if polling.LastPollMessages != 1 {
+		t.Fatalf("unexpected last_poll_messages: %d", polling.LastPollMessages)
 	}
 }
 


### PR DESCRIPTION
## Summary

为 FractalBot 网关添加完整的微信通道支持，支持回调（WeChat/WeCom XML webhook）和轮询（iLink getupdates）双模式。

## 已完成

- **WeChatBot 结构体**：双模式操作（回调 + 轮询），支持 `wecom` 和 `mp_service` 两种 provider
- **轮询模式**：iLink getupdates HTTP 获取器，游标状态持久化，可配置轮询间隔
- **回调模式**：HTTP 服务器处理 GET 握手 + POST 消息接收，SHA1 签名验证
- **消息映射**：微信消息（文本/语音/图片/文件/视频）→ `protocol.Message`
- **配置体系**：完整的 `WeChatConfig` 结构体 + 验证逻辑 + 示例 YAML
- **通道注册**：在 `manager.go` 中注册 + `/status` 端点遥测
- **测试覆盖**：525+ 行单元/集成测试
- **文档**：16 份设计和验证文档

## 待完成（见 #346）

- [ ] `SendMessage()` 出站消息实现
- [ ] AccessToken 获取/缓存
- [ ] 端到端真实凭证验证

## 文件变更统计

- 25 files changed, +3781 lines
- 新增核心文件：`internal/channels/wechat.go` (982行), `wechat_test.go` (525行)
- 新增文档：`docs/wechat-*.md` (16份)

## 关联

- 跟进 Issue: #346
- 路线决策文档: `docs/wechat-openclaw-route-decision.md`