### PR TITLE
fix(feishu): auto-refresh expired access tokens on send failure

### DIFF
--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -251,11 +251,20 @@ func (b *FeishuBot) sendText(ctx context.Context, receiveIDType, receiveID, text
 	resp, err := b.apiClient.Im.V1.Message.Create(ctx, req)
 	if err != nil {
 		b.markError()
+		if isFeishuTokenError(err) {
+			log.Printf("feishu: token error, refreshing API client: %v", err)
+			b.refreshAPIClient()
+		}
 		return err
 	}
 	if !resp.Success() {
 		b.markError()
-		return fmt.Errorf("feishu send failed: code=%d msg=%s", resp.Code, resp.Msg)
+		sendErr := fmt.Errorf("feishu send failed: code=%d msg=%s", resp.Code, resp.Msg)
+		if isFeishuTokenError(sendErr) {
+			log.Printf("feishu: token error in response, refreshing API client: %v", sendErr)
+			b.refreshAPIClient()
+		}
+		return sendErr
 	}
 	b.markActivity()
 	return nil
@@ -647,4 +656,22 @@ func (a FeishuAllowlist) Allowed(openID, userID string) bool {
 		}
 	}
 	return false
+}
+
+func isFeishuTokenError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, pattern := range []string{"access token", "99991663", "99991664", "99991671"} {
+		if containsLower(msg, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *FeishuBot) refreshAPIClient() {
+	domainURL := resolveFeishuDomain(b.domain)
+	b.apiClient = lark.NewClient(b.appID, b.appSecret, lark.WithOpenBaseUrl(domainURL))
 }

--- a/internal/channels/worker.go
+++ b/internal/channels/worker.go
@@ -35,6 +35,14 @@ func classifyError(err error) ErrorClass {
 			return ErrRateLimit
 		}
 	}
+	// Token expiration is transient — recoverable by refreshing credentials.
+	// Must be checked before the "invalid" permanent pattern below,
+	// because "Invalid access token" contains "invalid".
+	for _, pattern := range []string{"access token", "token expired", "99991663", "99991664", "99991671"} {
+		if containsLower(msg, pattern) {
+			return ErrTransient
+		}
+	}
 	// Permanent failures — no point retrying
 	for _, pattern := range []string{"not running", "not configured", "invalid", "unauthorized", "forbidden", "not found"} {
 		if containsLower(msg, pattern) {

--- a/internal/channels/worker_test.go
+++ b/internal/channels/worker_test.go
@@ -75,6 +75,10 @@ func TestClassifyError_Transient(t *testing.T) {
 		"timeout",
 		"temporary failure",
 		"server error",
+		"Invalid access token",
+		"feishu send failed: code=99991663 msg=Invalid access token",
+		"feishu send failed: code=99991664 msg=Invalid app access token",
+		"feishu send failed: code=99991671 msg=access token expired",
 	}
 	for _, msg := range tests {
 		if got := classifyError(errors.New(msg)); got != ErrTransient {


### PR DESCRIPTION
## Summary
- Token expiration errors (Feishu codes 99991663/99991664/99991671) were classified as permanent because `classifyError()` matched "Invalid access token" against the `"invalid"` permanent pattern — no retry was attempted
- The lark SDK caches tokens internally and its 2-iteration retry loop doesn't invalidate the cache on token errors, so the second attempt uses the same stale token
- **worker.go**: Add token error patterns (`"access token"`, SDK error codes) as transient checks before the permanent `"invalid"` pattern, so the worker retries with exponential backoff
- **feishu.go**: Re-create the `lark.Client` when a token error is detected during send, forcing a fresh token on the worker's next retry attempt

## Test plan
- [x] Added token error strings to `TestClassifyError_Transient` (99991663, 99991664, 99991671)
- [x] Verified existing permanent patterns still match (`"invalid telegram chat ID"` still permanent)
- [x] All existing tests pass (`go test ./...`)