### PR TITLE
feat: add Codex App CDP readiness guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,27 @@ agents:
     cdpEndpoint: "http://127.0.0.1:9222"
     targetSelector: "Codex"
     hostId: "local"
-    # Empty means use the active /local/<conversationId> in Codex App.
+    # Recommended: route by stable project + named session. The gateway resolves
+    # the current conversation id before each delivery.
+    targetProject:
+      name: "CloudBank"
+      cwd: "/Users/you/Develop/SuLabsOrg/CloudBank"
+      session: "main"
+    # Advanced override: pin to a specific /local/<conversationId>. Empty uses
+    # targetProject when configured, then the active Codex App thread.
     conversationId: ""
-    inboxPath: "/Users/you/work-assistant/.fractalbot/inbox"
+    inboxPath: "/Users/you/Develop/SuLabsOrg/CloudBank/.fractalbot/inbox"
     fallbackToInbox: true
+    # CDP readiness / repair. Empty repairPolicy defaults to "relaunch".
+    # Supported values: "off", "status-only", "new-instance", "relaunch".
+    # With codexAppCDP enabled, the gateway starts the watchdog by default and
+    # relaunches Codex App with --remote-debugging-port when CDP is unavailable.
+    repairPolicy: "relaunch"
+    checkOnIncomingMessage: true
+    watch:
+      enabled: true
+      intervalSeconds: 60
+      cooldownSeconds: 90
     defaultAgent: "main"
     allowedAgents:
       - "main"
@@ -193,11 +210,23 @@ The `codexAppCDP` router delivers through CDP into the running Codex App rendere
    open -na /Applications/Codex.app --args --remote-debugging-port=9222
    ```
 
-2. Open the target work-assistant main thread in Codex App, or set `agents.codexAppCDP.conversationId` to its `/local/<conversationId>` value.
-3. Set `agents.router: codexAppCDP`, `agents.codexAppCDP.enabled: true`, and `agents.codexAppCDP.inboxPath`.
-4. Verify `/status`: it reports `agents.router`, `agents.codex_app_cdp`, and `agents.last_routing` with `backend`, `status`, `envelope_id`, `inbox_path`, and any CDP error.
+2. Configure `agents.codexAppCDP.targetProject.cwd` plus `targetProject.session` so the gateway resolves the current Codex App conversation before each delivery. `session: "main"` uses an exact `agent_nickname` or title match when present, and otherwise resolves to the latest non-archived thread for that project cwd.
+3. Set `agents.router: codexAppCDP`, `agents.codexAppCDP.enabled: true`, and `agents.codexAppCDP.inboxPath`. Leave `conversationId` empty unless you intentionally want a pinned thread override.
+4. By default, `agents.codexAppCDP.repairPolicy` is `relaunch` and `watch.enabled` is true when `codexAppCDP` is enabled. If CDP is unavailable, FractalBot asks Codex App to quit and reopens it with `--remote-debugging-port`. Set `repairPolicy: "status-only"` or `watch.enabled: false` if you only want reporting.
+5. Keep `checkOnIncomingMessage: true` so each inbound Codex App route checks `/json/version` and `/json/list` before delivery. `cooldownSeconds` prevents repeated repair attempts.
+6. Verify `/status`: it reports `agents.router`, `agents.codex_app_cdp`, `agents.codex_app_cdp.target_project`, `agents.codex_app_cdp.resolved_conversation`, `agents.codex_app_cdp.readiness`, and `agents.last_routing` with `backend`, `status`, `envelope_id`, `inbox_path`, and any CDP error.
 
 If CDP is unavailable and `fallbackToInbox` is true, FractalBot atomically writes the normalized envelope to `inboxPath` so the Codex App-side consumer can process it later.
+
+Troubleshooting CDP readiness:
+
+```bash
+curl -fsS http://127.0.0.1:9222/json/version
+curl -fsS http://127.0.0.1:9222/json/list
+curl -sS http://127.0.0.1:18789/status | python3 -m json.tool
+```
+
+The gateway intentionally does not fall back to `codex app-server proxy` or temporary `codex app-server --listen` delivery. Messages that cannot reach the visible Codex App renderer are either reported as errors or queued to `inboxPath` when `fallbackToInbox` is enabled.
 
 Additional lifecycle commands:
 - `/agents` (list allowed agent names)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -145,11 +145,31 @@ agents:
     targetSelector: "Codex"
     # Codex App local host id. Defaults to "local".
     hostId: "local"
-    # Optional: pin to a specific /local/<conversationId>. Empty uses the active Codex App thread.
+    # Recommended: resolve the current target thread by project + named session.
+    targetProject:
+      name: "CloudBank"
+      cwd: "/Users/you/Develop/SuLabsOrg/CloudBank"
+      session: "main"
+      # Optional: pin state DB lookup. Empty uses newest ~/.codex/state_*.sqlite.
+      # stateDb: "/Users/you/.codex/state_5.sqlite"
+    # Advanced override: pin to a specific /local/<conversationId>.
+    # Empty uses targetProject when configured, then the active Codex App thread.
     conversationId: ""
     # Durable MVP queue and fallback when CDP delivery is unavailable.
-    inboxPath: "/Users/you/work-assistant/.fractalbot/inbox"
+    inboxPath: "/Users/you/Develop/SuLabsOrg/CloudBank/.fractalbot/inbox"
     fallbackToInbox: true
+    # CDP readiness policy:
+    # - off: do not check or repair CDP.
+    # - status-only: check and report only.
+    # - new-instance: launch a new Codex App instance with --remote-debugging-port when CDP is down.
+    # - relaunch: quit Codex App and relaunch it with --remote-debugging-port when CDP is down.
+    # Empty defaults to "relaunch"; watch.enabled defaults to true when codexAppCDP is enabled.
+    repairPolicy: "relaunch"
+    checkOnIncomingMessage: true
+    watch:
+      enabled: true
+      intervalSeconds: 60
+      cooldownSeconds: 90
     defaultAgent: "main"
     allowedAgents:
       - "main"

--- a/internal/agent/codex_app_cdp.go
+++ b/internal/agent/codex_app_cdp.go
@@ -117,6 +117,12 @@ type codexAppThreadRecord struct {
 	UpdatedAtMS   int64  `json:"updated_at_ms"`
 }
 
+type codexAppSidebarThreadRecord struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Active bool   `json:"active"`
+}
+
 func (m *Manager) isCodexAppCDPEnabled() bool {
 	if m.config == nil || m.config.CodexAppCDP == nil {
 		return false
@@ -678,7 +684,74 @@ func queryCodexAppThreadsFromStateDB(ctx context.Context, cfg *config.CodexAppCD
 	if err := json.Unmarshal(output, &threads); err != nil {
 		return nil, "state-db", fmt.Errorf("decode Codex App state DB threads: %w", err)
 	}
-	return threads, "state-db", nil
+	source := "state-db"
+	sidebarThreads, sidebarErr := queryCodexAppSidebarThreads(ctx, cfg)
+	if sidebarErr == nil && len(sidebarThreads) > 0 {
+		mergeCodexAppSidebarThreads(threads, sidebarThreads)
+		source = "state-db+sidebar"
+	}
+	return threads, source, nil
+}
+
+func queryCodexAppSidebarThreads(ctx context.Context, cfg *config.CodexAppCDPConfig) ([]codexAppSidebarThreadRecord, error) {
+	if cfg == nil || strings.TrimSpace(cfg.CDPEndpoint) == "" {
+		return nil, nil
+	}
+	target, err := selectCodexAppCDPTarget(ctx, cfg.CDPEndpoint, cfg.TargetSelector)
+	if err != nil {
+		return nil, err
+	}
+	value, err := evaluateCDPValue(ctx, target.WebSocketDebuggerURL, `(() => {
+  return Array.from(document.querySelectorAll("[data-app-action-sidebar-thread-row]")).map((row) => {
+    const rawId = row.getAttribute("data-app-action-sidebar-thread-id") || "";
+    return {
+      id: rawId.replace(/^local:/, ""),
+      title: row.getAttribute("data-app-action-sidebar-thread-title") || "",
+      active: row.getAttribute("data-app-action-sidebar-thread-active") === "true"
+    };
+  }).filter((row) => row.id && row.title);
+})()`)
+	if err != nil {
+		return nil, err
+	}
+	rawRows, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("Codex App sidebar returned %T, expected array", value)
+	}
+	rows := make([]codexAppSidebarThreadRecord, 0, len(rawRows))
+	for _, raw := range rawRows {
+		rowMap, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := rowMap["id"].(string)
+		title, _ := rowMap["title"].(string)
+		active, _ := rowMap["active"].(bool)
+		id = strings.TrimSpace(id)
+		title = strings.TrimSpace(title)
+		if id == "" || title == "" {
+			continue
+		}
+		rows = append(rows, codexAppSidebarThreadRecord{ID: id, Title: title, Active: active})
+	}
+	return rows, nil
+}
+
+func mergeCodexAppSidebarThreads(threads []codexAppThreadRecord, sidebarThreads []codexAppSidebarThreadRecord) {
+	sidebarByID := make(map[string]codexAppSidebarThreadRecord, len(sidebarThreads))
+	for _, row := range sidebarThreads {
+		sidebarByID[row.ID] = row
+	}
+	for i := range threads {
+		row, ok := sidebarByID[threads[i].ID]
+		if !ok {
+			continue
+		}
+		threads[i].AgentNickname = row.Title
+		if row.Active {
+			threads[i].Source = strings.Trim(strings.Join([]string{threads[i].Source, "sidebar-active"}, ":"), ":")
+		}
+	}
 }
 
 func codexAppStateDBPath(cfg *config.CodexAppCDPConfig) (string, error) {
@@ -987,9 +1060,17 @@ func preferredCodexAppCDPTarget(targets []cdpTarget) (cdpTarget, bool) {
 }
 
 func evaluateCDPExpression(ctx context.Context, wsURL, expression, expectedConversationID string) error {
+	value, err := evaluateCDPValue(ctx, wsURL, expression)
+	if err != nil {
+		return err
+	}
+	return validateCodexAppDeliveryValue(value, expectedConversationID)
+}
+
+func evaluateCDPValue(ctx context.Context, wsURL, expression string) (interface{}, error) {
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
-		return fmt.Errorf("connect CDP websocket: %w", err)
+		return nil, fmt.Errorf("connect CDP websocket: %w", err)
 	}
 	defer conn.Close()
 
@@ -1008,23 +1089,23 @@ func evaluateCDPExpression(ctx context.Context, wsURL, expression, expectedConve
 		},
 	}
 	if err := conn.WriteJSON(request); err != nil {
-		return fmt.Errorf("send CDP Runtime.evaluate: %w", err)
+		return nil, fmt.Errorf("send CDP Runtime.evaluate: %w", err)
 	}
 	for {
 		var response cdpEvaluateResponse
 		if err := conn.ReadJSON(&response); err != nil {
-			return fmt.Errorf("read CDP Runtime.evaluate response: %w", err)
+			return nil, fmt.Errorf("read CDP Runtime.evaluate response: %w", err)
 		}
 		if response.ID != 1 {
 			continue
 		}
 		if response.Error != nil {
-			return fmt.Errorf("CDP Runtime.evaluate failed: %s", response.Error.Message)
+			return nil, fmt.Errorf("CDP Runtime.evaluate failed: %s", response.Error.Message)
 		}
 		if response.Result.ExceptionDetails != nil {
-			return fmt.Errorf("Codex App delivery script failed: %s", response.Result.ExceptionDetails.Text)
+			return nil, fmt.Errorf("Codex App delivery script failed: %s", response.Result.ExceptionDetails.Text)
 		}
-		return validateCodexAppDeliveryValue(response.Result.Result.Value, expectedConversationID)
+		return response.Result.Result.Value, nil
 	}
 }
 
@@ -1177,7 +1258,13 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
   }
 
   const signals = await import(signalsUrl);
-  const sendRequest = typeof signals.Kn === "function" ? signals.Kn : (typeof signals.rn === "function" ? signals.rn : null);
+  const requestCandidates = [
+    ["on", signals.on],
+    ["Kn", signals.Kn],
+    ["rn", signals.rn]
+  ];
+  const candidate = requestCandidates.find(([, fn]) => typeof fn === "function");
+  const sendRequest = candidate ? candidate[1] : null;
   if (typeof sendRequest !== "function") {
     throw new Error("Codex App app-server request bridge is unavailable.");
   }
@@ -1195,6 +1282,6 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
       throw new Error("Codex App start-turn-for-host failed: " + detail);
     }
   }
-  return { ok: true, conversationId, result };
+  return { ok: true, conversationId, bridge: candidate[0], result };
 })()`, string(encoded))
 }

--- a/internal/agent/codex_app_cdp.go
+++ b/internal/agent/codex_app_cdp.go
@@ -917,7 +917,7 @@ func (liveCodexAppCDPClient) Deliver(ctx context.Context, cfg *config.CodexAppCD
 		return err
 	}
 	expr := buildCodexAppDeliveryScript(cfg, envelope, prompt)
-	return evaluateCDPExpression(ctx, target.WebSocketDebuggerURL, expr)
+	return evaluateCDPExpression(ctx, target.WebSocketDebuggerURL, expr, strings.TrimSpace(cfg.ConversationID))
 }
 
 func selectCodexAppCDPTarget(ctx context.Context, endpoint, selector string) (cdpTarget, error) {
@@ -986,7 +986,7 @@ func preferredCodexAppCDPTarget(targets []cdpTarget) (cdpTarget, bool) {
 	return cdpTarget{}, false
 }
 
-func evaluateCDPExpression(ctx context.Context, wsURL, expression string) error {
+func evaluateCDPExpression(ctx context.Context, wsURL, expression, expectedConversationID string) error {
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, wsURL, nil)
 	if err != nil {
 		return fmt.Errorf("connect CDP websocket: %w", err)
@@ -1024,11 +1024,94 @@ func evaluateCDPExpression(ctx context.Context, wsURL, expression string) error 
 		if response.Result.ExceptionDetails != nil {
 			return fmt.Errorf("Codex App delivery script failed: %s", response.Result.ExceptionDetails.Text)
 		}
-		if response.Result.Result.Type == "object" || response.Result.Result.Type == "boolean" || response.Result.Result.Type == "string" || response.Result.Result.Type == "undefined" {
-			return nil
-		}
-		return nil
+		return validateCodexAppDeliveryValue(response.Result.Result.Value, expectedConversationID)
 	}
+}
+
+func validateCodexAppDeliveryValue(value interface{}, expectedConversationID string) error {
+	result, ok := value.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("Codex App delivery returned %T, expected object", value)
+	}
+	if okValue, ok := result["ok"].(bool); !ok || !okValue {
+		return fmt.Errorf("Codex App delivery was not accepted: %s", codexAppBridgeErrorDetail(result))
+	}
+	conversationID, _ := result["conversationId"].(string)
+	conversationID = strings.TrimSpace(conversationID)
+	if conversationID == "" {
+		return errors.New("Codex App delivery did not return a conversationId")
+	}
+	if expected := strings.TrimSpace(expectedConversationID); expected != "" && conversationID != expected {
+		return fmt.Errorf("Codex App delivery targeted conversation %q, expected %q", conversationID, expected)
+	}
+	if bridgeResultHasError(result["result"]) {
+		return fmt.Errorf("Codex App start-turn-for-host failed: %s", codexAppBridgeErrorDetail(result["result"]))
+	}
+	return nil
+}
+
+func bridgeResultHasError(value interface{}) bool {
+	result, ok := value.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if okValue, ok := result["ok"].(bool); ok && !okValue {
+		return true
+	}
+	if successValue, ok := result["success"].(bool); ok && !successValue {
+		return true
+	}
+	for _, key := range []string{"error", "errorMessage"} {
+		if errorValue, exists := result[key]; exists && !isEmptyBridgeValue(errorValue) {
+			return true
+		}
+	}
+	if status, ok := result["status"].(string); ok {
+		switch strings.ToLower(strings.TrimSpace(status)) {
+		case "error", "failed", "failure", "rejected":
+			return true
+		}
+	}
+	return false
+}
+
+func isEmptyBridgeValue(value interface{}) bool {
+	if value == nil {
+		return true
+	}
+	if text, ok := value.(string); ok {
+		return strings.TrimSpace(text) == ""
+	}
+	return false
+}
+
+func codexAppBridgeErrorDetail(value interface{}) string {
+	switch typed := value.(type) {
+	case nil:
+		return "empty result"
+	case string:
+		if text := strings.TrimSpace(typed); text != "" {
+			return text
+		}
+	case map[string]interface{}:
+		for _, key := range []string{"error", "errorMessage", "message", "reason", "status"} {
+			if detail, ok := typed[key]; ok {
+				if text := codexAppBridgeErrorDetail(detail); text != "" && text != "empty result" {
+					return text
+				}
+			}
+		}
+		encoded, err := json.Marshal(typed)
+		if err == nil && len(encoded) > 0 {
+			return string(encoded)
+		}
+	default:
+		encoded, err := json.Marshal(typed)
+		if err == nil && len(encoded) > 0 {
+			return string(encoded)
+		}
+	}
+	return "empty result"
 }
 
 type cdpEvaluateResponse struct {
@@ -1105,6 +1188,13 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
     conversationId,
     params: { input }
   });
+  if (result && typeof result === "object") {
+    const status = typeof result.status === "string" ? result.status.toLowerCase() : "";
+    if (result.error || result.errorMessage || result.ok === false || result.success === false || ["error", "failed", "failure", "rejected"].includes(status)) {
+      const detail = result.error?.message || result.errorMessage || result.message || result.reason || status || JSON.stringify(result);
+      throw new Error("Codex App start-turn-for-host failed: " + detail);
+    }
+  }
   return { ok: true, conversationId, result };
 })()`, string(encoded))
 }

--- a/internal/agent/codex_app_cdp.go
+++ b/internal/agent/codex_app_cdp.go
@@ -9,8 +9,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"sort"
 	"strings"
 	"time"
 
@@ -23,7 +27,17 @@ import (
 const (
 	defaultCodexAppHostID          = "local"
 	defaultCodexAppDeliveryTimeout = 20 * time.Second
+	defaultCodexAppWatchInterval   = 60 * time.Second
+	defaultCodexAppRepairCooldown  = 90 * time.Second
+	defaultCodexAppPath            = "/Applications/Codex.app"
 	codexAppAssignAckMessage       = "处理中…"
+)
+
+const (
+	codexAppCDPRepairOff         = "off"
+	codexAppCDPRepairStatusOnly  = "status-only"
+	codexAppCDPRepairNewInstance = "new-instance"
+	codexAppCDPRepairRelaunch    = "relaunch"
 )
 
 type CodexAppEnvelope struct {
@@ -55,6 +69,53 @@ type codexAppCDPClient interface {
 }
 
 type liveCodexAppCDPClient struct{}
+
+var queryCodexAppThreads = queryCodexAppThreadsFromStateDB
+
+// CodexAppCDPReadinessStatus is exposed in /status for CDP observability.
+type CodexAppCDPReadinessStatus struct {
+	Enabled          bool
+	Endpoint         string
+	Available        bool
+	TargetCount      int
+	RepairPolicy     string
+	CheckOnIncoming  bool
+	WatchEnabled     bool
+	WatchRunning     bool
+	IntervalSeconds  int
+	CooldownSeconds  int
+	LastCheckedAt    time.Time
+	LastError        string
+	LastRepairAt     time.Time
+	LastRepairAction string
+	LastRepairError  string
+}
+
+// CodexAppCDPResolvedConversationStatus is exposed in /status for target
+// observability when delivery resolves project/session to a conversation id.
+type CodexAppCDPResolvedConversationStatus struct {
+	Configured     bool
+	ProjectName    string
+	ProjectCWD     string
+	Session        string
+	ID             string
+	Title          string
+	ThreadCWD      string
+	UpdatedAt      time.Time
+	Source         string
+	LastResolvedAt time.Time
+	LastError      string
+}
+
+type codexAppThreadRecord struct {
+	ID            string `json:"id"`
+	Title         string `json:"title"`
+	AgentNickname string `json:"agent_nickname"`
+	CWD           string `json:"cwd"`
+	Source        string `json:"source"`
+	UpdatedAt     int64  `json:"updated_at"`
+	UpdatedAtMS   int64  `json:"updated_at_ms"`
+}
 
 func (m *Manager) isCodexAppCDPEnabled() bool {
 	if m.config == nil || m.config.CodexAppCDP == nil {
@@ -114,23 +175,36 @@ func (m *Manager) deliverCodexAppEnvelope(ctx context.Context, cfg *config.Codex
 
 	endpoint := strings.TrimSpace(cfg.CDPEndpoint)
 	if endpoint != "" {
+		deliveryCfg := *cfg
 		deliveryCtx := ctx
 		if timeout := codexAppDeliveryTimeout(cfg); timeout > 0 {
 			var cancel context.CancelFunc
 			deliveryCtx, cancel = context.WithTimeout(ctx, timeout)
 			defer cancel()
 		}
-		client := m.codexAppCDPClient
-		if client == nil {
-			client = liveCodexAppCDPClient{}
+		if codexAppCheckOnIncoming(cfg) {
+			deliveryErr = m.ensureCodexAppCDPReady(deliveryCtx, cfg, "incoming")
 		}
-		if err := client.Deliver(deliveryCtx, cfg, envelope, prompt); err == nil {
-			result.Status = "delivered"
-			result.CDPDelivered = true
-			result.ConversationID = strings.TrimSpace(cfg.ConversationID)
-			return result
-		} else {
-			deliveryErr = err
+		if deliveryErr == nil {
+			if conversationID, err := m.resolveCodexAppConversation(deliveryCtx, cfg); err != nil {
+				deliveryErr = err
+			} else if strings.TrimSpace(conversationID) != "" {
+				deliveryCfg.ConversationID = conversationID
+			}
+		}
+		if deliveryErr == nil {
+			client := m.codexAppCDPClient
+			if client == nil {
+				client = liveCodexAppCDPClient{}
+			}
+			if err := client.Deliver(deliveryCtx, &deliveryCfg, envelope, prompt); err == nil {
+				result.Status = "delivered"
+				result.CDPDelivered = true
+				result.ConversationID = strings.TrimSpace(deliveryCfg.ConversationID)
+				return result
+			} else {
+				deliveryErr = err
+			}
 		}
 	}
 
@@ -167,6 +241,547 @@ func codexAppDeliveryTimeout(cfg *config.CodexAppCDPConfig) time.Duration {
 		return time.Duration(cfg.DeliveryTimeoutSeconds) * time.Second
 	}
 	return defaultCodexAppDeliveryTimeout
+}
+
+func codexAppRepairPolicy(cfg *config.CodexAppCDPConfig) string {
+	if cfg == nil {
+		return codexAppCDPRepairRelaunch
+	}
+	policy := strings.TrimSpace(cfg.RepairPolicy)
+	if policy == "" {
+		return codexAppCDPRepairRelaunch
+	}
+	return policy
+}
+
+func codexAppCheckOnIncoming(cfg *config.CodexAppCDPConfig) bool {
+	if cfg == nil || cfg.CheckOnIncomingMessage == nil {
+		return true
+	}
+	return *cfg.CheckOnIncomingMessage
+}
+
+func codexAppWatchInterval(cfg *config.CodexAppCDPConfig) time.Duration {
+	if cfg != nil && cfg.Watch.IntervalSeconds > 0 {
+		return time.Duration(cfg.Watch.IntervalSeconds) * time.Second
+	}
+	return defaultCodexAppWatchInterval
+}
+
+func codexAppRepairCooldown(cfg *config.CodexAppCDPConfig) time.Duration {
+	if cfg != nil && cfg.Watch.CooldownSeconds > 0 {
+		return time.Duration(cfg.Watch.CooldownSeconds) * time.Second
+	}
+	return defaultCodexAppRepairCooldown
+}
+
+func codexAppWatchEnabled(cfg *config.CodexAppCDPConfig) bool {
+	if cfg == nil || !cfg.Enabled {
+		return false
+	}
+	if cfg.Watch.Enabled == nil {
+		return true
+	}
+	return *cfg.Watch.Enabled
+}
+
+func (m *Manager) startCodexAppCDPWatch(parent context.Context, cfg *config.CodexAppCDPConfig) {
+	if cfg == nil || !codexAppWatchEnabled(cfg) || strings.TrimSpace(cfg.CDPEndpoint) == "" || codexAppRepairPolicy(cfg) == codexAppCDPRepairOff {
+		m.updateCodexAppCDPReadinessStatus(cfg, nil, false)
+		return
+	}
+	m.stopCodexAppCDPWatch(context.Background())
+
+	watchCtx, cancel := context.WithCancel(parent)
+	done := make(chan struct{})
+	m.mu.Lock()
+	m.cdpMonitorCancel = cancel
+	m.cdpMonitorDone = done
+	m.mu.Unlock()
+	m.updateCodexAppCDPReadinessStatus(cfg, nil, true)
+
+	go func() {
+		defer close(done)
+		interval := codexAppWatchInterval(cfg)
+		m.ensureCodexAppCDPReadyWithTimeout(watchCtx, cfg, "watch")
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-watchCtx.Done():
+				return
+			case <-ticker.C:
+				m.ensureCodexAppCDPReadyWithTimeout(watchCtx, cfg, "watch")
+			}
+		}
+	}()
+}
+
+func (m *Manager) stopCodexAppCDPWatch(ctx context.Context) {
+	m.mu.Lock()
+	cancel := m.cdpMonitorCancel
+	done := m.cdpMonitorDone
+	m.cdpMonitorCancel = nil
+	m.cdpMonitorDone = nil
+	m.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-ctx.Done():
+	}
+	m.mu.Lock()
+	if m.cdpReadiness != nil {
+		m.cdpReadiness.WatchRunning = false
+	}
+	m.mu.Unlock()
+}
+
+func (m *Manager) CodexAppCDPReadinessStatus() *CodexAppCDPReadinessStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.cdpReadiness == nil {
+		return nil
+	}
+	status := *m.cdpReadiness
+	return &status
+}
+
+func (m *Manager) CodexAppCDPResolvedConversationStatus() *CodexAppCDPResolvedConversationStatus {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.cdpResolvedTarget == nil {
+		return nil
+	}
+	status := *m.cdpResolvedTarget
+	return &status
+}
+
+func (m *Manager) updateCodexAppCDPResolvedConversationStatus(cfg *config.CodexAppCDPConfig, update func(*CodexAppCDPResolvedConversationStatus)) {
+	if cfg == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status := m.cdpResolvedTarget
+	if status == nil {
+		status = &CodexAppCDPResolvedConversationStatus{}
+		m.cdpResolvedTarget = status
+	}
+	status.Configured = codexAppTargetProjectConfigured(cfg)
+	status.ProjectName = strings.TrimSpace(cfg.TargetProject.Name)
+	status.ProjectCWD = strings.TrimSpace(cfg.TargetProject.CWD)
+	status.Session = strings.TrimSpace(cfg.TargetProject.Session)
+	if update != nil {
+		update(status)
+	}
+}
+
+func (m *Manager) updateCodexAppCDPReadinessStatus(cfg *config.CodexAppCDPConfig, update func(*CodexAppCDPReadinessStatus), watchRunning bool) {
+	if cfg == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	status := m.cdpReadiness
+	if status == nil {
+		status = &CodexAppCDPReadinessStatus{}
+		m.cdpReadiness = status
+	}
+	status.Enabled = cfg.Enabled
+	status.Endpoint = strings.TrimSpace(cfg.CDPEndpoint)
+	status.RepairPolicy = codexAppRepairPolicy(cfg)
+	status.CheckOnIncoming = codexAppCheckOnIncoming(cfg)
+	status.WatchEnabled = codexAppWatchEnabled(cfg)
+	status.WatchRunning = watchRunning || (m.cdpMonitorCancel != nil)
+	status.IntervalSeconds = int(codexAppWatchInterval(cfg) / time.Second)
+	status.CooldownSeconds = int(codexAppRepairCooldown(cfg) / time.Second)
+	if update != nil {
+		update(status)
+	}
+}
+
+func (m *Manager) ensureCodexAppCDPReady(ctx context.Context, cfg *config.CodexAppCDPConfig, _ string) error {
+	if cfg == nil || strings.TrimSpace(cfg.CDPEndpoint) == "" {
+		return nil
+	}
+	policy := codexAppRepairPolicy(cfg)
+	if policy == codexAppCDPRepairOff {
+		return nil
+	}
+
+	available, targetCount, checkErr := checkCodexAppCDPReady(ctx, cfg)
+	m.updateCodexAppCDPReadinessStatus(cfg, func(status *CodexAppCDPReadinessStatus) {
+		status.Available = available
+		status.TargetCount = targetCount
+		status.LastCheckedAt = time.Now().UTC()
+		status.LastError = errorString(checkErr)
+	}, false)
+	if checkErr == nil {
+		return nil
+	}
+	if policy == codexAppCDPRepairStatusOnly {
+		return checkErr
+	}
+
+	if !m.canRepairCodexAppCDP(cfg) {
+		return checkErr
+	}
+
+	repairErr := repairCodexAppCDP(ctx, cfg, policy)
+	m.updateCodexAppCDPReadinessStatus(cfg, func(status *CodexAppCDPReadinessStatus) {
+		status.LastRepairAt = time.Now().UTC()
+		status.LastRepairAction = policy
+		status.LastRepairError = errorString(repairErr)
+	}, false)
+	if repairErr != nil {
+		return fmt.Errorf("Codex App CDP unavailable: %v; repair failed: %w", checkErr, repairErr)
+	}
+
+	available, targetCount, checkErr = waitCodexAppCDPReady(ctx, cfg)
+	m.updateCodexAppCDPReadinessStatus(cfg, func(status *CodexAppCDPReadinessStatus) {
+		status.Available = available
+		status.TargetCount = targetCount
+		status.LastCheckedAt = time.Now().UTC()
+		status.LastError = errorString(checkErr)
+	}, false)
+	return checkErr
+}
+
+func (m *Manager) ensureCodexAppCDPReadyWithTimeout(ctx context.Context, cfg *config.CodexAppCDPConfig, reason string) error {
+	if timeout := codexAppDeliveryTimeout(cfg); timeout > 0 {
+		checkCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		return m.ensureCodexAppCDPReady(checkCtx, cfg, reason)
+	}
+	return m.ensureCodexAppCDPReady(ctx, cfg, reason)
+}
+
+func (m *Manager) canRepairCodexAppCDP(cfg *config.CodexAppCDPConfig) bool {
+	cooldown := codexAppRepairCooldown(cfg)
+	if cooldown <= 0 {
+		return true
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.cdpReadiness == nil || m.cdpReadiness.LastRepairAt.IsZero() || time.Since(m.cdpReadiness.LastRepairAt) >= cooldown
+}
+
+func checkCodexAppCDPReady(ctx context.Context, cfg *config.CodexAppCDPConfig) (bool, int, error) {
+	endpoint := strings.TrimRight(strings.TrimSpace(cfg.CDPEndpoint), "/")
+	if endpoint == "" {
+		return false, 0, errors.New("agents.codexAppCDP.cdpEndpoint is required")
+	}
+	if err := getCodexAppCDPJSON(ctx, endpoint+"/json/version", nil); err != nil {
+		return false, 0, err
+	}
+	var targets []cdpTarget
+	if err := getCodexAppCDPJSON(ctx, endpoint+"/json/list", &targets); err != nil {
+		return false, 0, err
+	}
+	count := 0
+	for _, target := range targets {
+		if target.WebSocketDebuggerURL != "" {
+			count++
+		}
+	}
+	if count == 0 {
+		return false, 0, errors.New("Codex App CDP has no debuggable targets")
+	}
+	return true, count, nil
+}
+
+func waitCodexAppCDPReady(ctx context.Context, cfg *config.CodexAppCDPConfig) (bool, int, error) {
+	var lastErr error
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		available, targetCount, err := checkCodexAppCDPReady(ctx, cfg)
+		if err == nil {
+			return available, targetCount, nil
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return false, 0, lastErr
+			}
+			return false, 0, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func getCodexAppCDPJSON(ctx context.Context, endpoint string, dest interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("query CDP endpoint %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("query CDP endpoint %s: HTTP %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if dest == nil {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 512))
+		return nil
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dest); err != nil {
+		return fmt.Errorf("decode CDP endpoint %s: %w", endpoint, err)
+	}
+	return nil
+}
+
+func repairCodexAppCDP(ctx context.Context, cfg *config.CodexAppCDPConfig, policy string) error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("repair policy %q is only supported on macOS", policy)
+	}
+	port, err := codexAppCDPPort(cfg.CDPEndpoint)
+	if err != nil {
+		return err
+	}
+	switch policy {
+	case codexAppCDPRepairNewInstance:
+		return openCodexAppWithCDP(ctx, port)
+	case codexAppCDPRepairRelaunch:
+		_ = exec.CommandContext(ctx, "osascript", "-e", `tell application "Codex" to quit`).Run()
+		time.Sleep(2 * time.Second)
+		return openCodexAppWithCDP(ctx, port)
+	default:
+		return fmt.Errorf("unsupported repair policy %q", policy)
+	}
+}
+
+func openCodexAppWithCDP(ctx context.Context, port string) error {
+	cmd := exec.CommandContext(ctx, "open", "-na", defaultCodexAppPath, "--args", "--remote-debugging-port="+port)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("launch Codex App with CDP: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func codexAppCDPPort(endpoint string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil || parsed.Host == "" {
+		return "", fmt.Errorf("agents.codexAppCDP.cdpEndpoint: invalid endpoint %q", endpoint)
+	}
+	port := parsed.Port()
+	if port == "" {
+		switch parsed.Scheme {
+		case "http":
+			port = "80"
+		case "https":
+			port = "443"
+		default:
+			return "", fmt.Errorf("agents.codexAppCDP.cdpEndpoint: unsupported scheme %q", parsed.Scheme)
+		}
+	}
+	return port, nil
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+func (m *Manager) resolveCodexAppConversation(ctx context.Context, cfg *config.CodexAppCDPConfig) (string, error) {
+	if cfg == nil {
+		return "", nil
+	}
+	if conversationID := strings.TrimSpace(cfg.ConversationID); conversationID != "" {
+		m.updateCodexAppCDPResolvedConversationStatus(cfg, func(status *CodexAppCDPResolvedConversationStatus) {
+			status.ID = conversationID
+			status.Title = ""
+			status.ThreadCWD = ""
+			status.UpdatedAt = time.Time{}
+			status.Source = "config"
+			status.LastResolvedAt = time.Now().UTC()
+			status.LastError = ""
+		})
+		return conversationID, nil
+	}
+	if !codexAppTargetProjectConfigured(cfg) {
+		return "", nil
+	}
+	threads, source, err := queryCodexAppThreads(ctx, cfg)
+	if err != nil {
+		m.updateCodexAppCDPResolvedConversationStatus(cfg, func(status *CodexAppCDPResolvedConversationStatus) {
+			status.ID = ""
+			status.Title = ""
+			status.ThreadCWD = ""
+			status.UpdatedAt = time.Time{}
+			status.LastResolvedAt = time.Now().UTC()
+			status.LastError = err.Error()
+			status.Source = source
+		})
+		return "", err
+	}
+	thread, matchSource, err := selectCodexAppTargetThread(threads, cfg)
+	if err != nil {
+		m.updateCodexAppCDPResolvedConversationStatus(cfg, func(status *CodexAppCDPResolvedConversationStatus) {
+			status.ID = ""
+			status.Title = ""
+			status.ThreadCWD = ""
+			status.UpdatedAt = time.Time{}
+			status.LastResolvedAt = time.Now().UTC()
+			status.LastError = err.Error()
+			status.Source = source
+		})
+		return "", err
+	}
+	updatedAt := codexAppThreadUpdatedAt(thread)
+	m.updateCodexAppCDPResolvedConversationStatus(cfg, func(status *CodexAppCDPResolvedConversationStatus) {
+		status.ID = thread.ID
+		status.Title = thread.Title
+		status.ThreadCWD = thread.CWD
+		status.UpdatedAt = updatedAt
+		status.Source = strings.Trim(strings.Join([]string{source, matchSource}, ":"), ":")
+		status.LastResolvedAt = time.Now().UTC()
+		status.LastError = ""
+	})
+	return thread.ID, nil
+}
+
+func codexAppTargetProjectConfigured(cfg *config.CodexAppCDPConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	target := cfg.TargetProject
+	return strings.TrimSpace(target.Name) != "" || strings.TrimSpace(target.CWD) != "" || strings.TrimSpace(target.Session) != ""
+}
+
+func queryCodexAppThreadsFromStateDB(ctx context.Context, cfg *config.CodexAppCDPConfig) ([]codexAppThreadRecord, string, error) {
+	dbPath, err := codexAppStateDBPath(cfg)
+	if err != nil {
+		return nil, "state-db", err
+	}
+	query := `select id,title,coalesce(agent_nickname,'') as agent_nickname,cwd,source,updated_at,coalesce(updated_at_ms,0) as updated_at_ms from threads where archived=0 order by updated_at desc, updated_at_ms desc limit 500;`
+	cmd := exec.CommandContext(ctx, "sqlite3", "-json", dbPath, query)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, "state-db", fmt.Errorf("query Codex App state DB %s: %w: %s", dbPath, err, strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, "state-db", fmt.Errorf("query Codex App state DB %s: %w", dbPath, err)
+	}
+	var threads []codexAppThreadRecord
+	if err := json.Unmarshal(output, &threads); err != nil {
+		return nil, "state-db", fmt.Errorf("decode Codex App state DB threads: %w", err)
+	}
+	return threads, "state-db", nil
+}
+
+func codexAppStateDBPath(cfg *config.CodexAppCDPConfig) (string, error) {
+	if cfg != nil {
+		if dbPath := strings.TrimSpace(cfg.TargetProject.StateDB); dbPath != "" {
+			return dbPath, nil
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve Codex App state DB: %w", err)
+	}
+	matches, err := filepath.Glob(filepath.Join(home, ".codex", "state_*.sqlite"))
+	if err != nil {
+		return "", fmt.Errorf("resolve Codex App state DB: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", errors.New("no Codex App state DB found at ~/.codex/state_*.sqlite")
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		left, leftErr := os.Stat(matches[i])
+		right, rightErr := os.Stat(matches[j])
+		if leftErr != nil || rightErr != nil {
+			return matches[i] > matches[j]
+		}
+		return left.ModTime().After(right.ModTime())
+	})
+	return matches[0], nil
+}
+
+func selectCodexAppTargetThread(threads []codexAppThreadRecord, cfg *config.CodexAppCDPConfig) (codexAppThreadRecord, string, error) {
+	if cfg == nil {
+		return codexAppThreadRecord{}, "", errors.New("agents.codexAppCDP is required")
+	}
+	target := cfg.TargetProject
+	projectName := strings.TrimSpace(target.Name)
+	projectCWD := cleanCodexAppCWD(target.CWD)
+	session := strings.TrimSpace(target.Session)
+	matches := make([]codexAppThreadRecord, 0, len(threads))
+	for _, thread := range threads {
+		if strings.TrimSpace(thread.ID) == "" {
+			continue
+		}
+		if !codexAppProjectMatches(thread, projectName, projectCWD) {
+			continue
+		}
+		matches = append(matches, thread)
+	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return codexAppThreadUpdatedAt(matches[i]).After(codexAppThreadUpdatedAt(matches[j]))
+	})
+	if len(matches) == 0 {
+		return codexAppThreadRecord{}, "", fmt.Errorf("no Codex App thread matched project cwd=%q name=%q", target.CWD, target.Name)
+	}
+	if session == "" {
+		return matches[0], "project-latest", nil
+	}
+	for _, thread := range matches {
+		if codexAppSessionMatches(thread, session) {
+			return thread, "named-session", nil
+		}
+	}
+	if strings.EqualFold(session, "main") {
+		return matches[0], "main-latest", nil
+	}
+	return codexAppThreadRecord{}, "", fmt.Errorf("no Codex App thread matched project cwd=%q name=%q session=%q", target.CWD, target.Name, target.Session)
+}
+
+func codexAppProjectMatches(thread codexAppThreadRecord, projectName, projectCWD string) bool {
+	threadCWD := cleanCodexAppCWD(thread.CWD)
+	if projectCWD != "" {
+		return threadCWD == projectCWD
+	}
+	if projectName == "" {
+		return true
+	}
+	return strings.EqualFold(filepath.Base(threadCWD), projectName)
+}
+
+func codexAppSessionMatches(thread codexAppThreadRecord, session string) bool {
+	session = strings.TrimSpace(session)
+	if session == "" {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(thread.AgentNickname), session) || strings.EqualFold(strings.TrimSpace(thread.Title), session)
+}
+
+func cleanCodexAppCWD(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return filepath.Clean(value)
+}
+
+func codexAppThreadUpdatedAt(thread codexAppThreadRecord) time.Time {
+	if thread.UpdatedAtMS > 0 {
+		return time.UnixMilli(thread.UpdatedAtMS).UTC()
+	}
+	if thread.UpdatedAt > 0 {
+		return time.Unix(thread.UpdatedAt, 0).UTC()
+	}
+	return time.Time{}
 }
 
 func buildCodexAppEnvelope(userText, selectedAgent string, inboundData map[string]interface{}) CodexAppEnvelope {
@@ -329,18 +944,46 @@ func selectCodexAppCDPTarget(ctx context.Context, endpoint, selector string) (cd
 		return cdpTarget{}, fmt.Errorf("decode CDP targets: %w", err)
 	}
 	selector = strings.TrimSpace(selector)
+	candidates := make([]cdpTarget, 0, len(targets))
 	for _, target := range targets {
 		if target.WebSocketDebuggerURL == "" {
 			continue
 		}
-		if selector == "" && (target.Type == "page" || target.Type == "webview" || target.Type == "other") {
+		if selector != "" && (strings.Contains(target.Title, selector) || strings.Contains(target.URL, selector)) {
 			return target, nil
 		}
-		if selector != "" && (strings.Contains(target.Title, selector) || strings.Contains(target.URL, selector)) {
+		candidates = append(candidates, target)
+	}
+	if selector == "" {
+		if target, ok := preferredCodexAppCDPTarget(candidates); ok {
 			return target, nil
 		}
 	}
 	return cdpTarget{}, fmt.Errorf("no Codex App CDP target matched %q", selector)
+}
+
+func preferredCodexAppCDPTarget(targets []cdpTarget) (cdpTarget, bool) {
+	for _, target := range targets {
+		if target.Type == "page" && target.URL == "app://-/index.html" {
+			return target, true
+		}
+	}
+	for _, target := range targets {
+		if target.Type == "page" && (target.Title == "Codex" || strings.HasPrefix(target.URL, "app://-/")) {
+			return target, true
+		}
+	}
+	for _, target := range targets {
+		if target.Type == "page" {
+			return target, true
+		}
+	}
+	for _, target := range targets {
+		if target.Type == "webview" || target.Type == "other" {
+			return target, true
+		}
+	}
+	return cdpTarget{}, false
 }
 
 func evaluateCDPExpression(ctx context.Context, wsURL, expression string) error {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -45,6 +45,10 @@ type Manager struct {
 	routingMu         sync.RWMutex
 	lastRouting       *RoutingOutcome
 	codexAppCDPClient codexAppCDPClient
+	cdpMonitorCancel  context.CancelFunc
+	cdpMonitorDone    chan struct{}
+	cdpReadiness      *CodexAppCDPReadinessStatus
+	cdpResolvedTarget *CodexAppCDPResolvedConversationStatus
 }
 
 type RoutingOutcome struct {
@@ -73,13 +77,15 @@ func NewManager(cfg *config.AgentsConfig) *Manager {
 
 // Start initializes resources required by the manager.
 func (m *Manager) Start(ctx context.Context) error {
-	_ = ctx
+	if m.config != nil && m.config.CodexAppCDP != nil && m.config.CodexAppCDP.Enabled {
+		m.startCodexAppCDPWatch(ctx, m.config.CodexAppCDP)
+	}
 	return nil
 }
 
 // Stop releases resources held by the manager.
 func (m *Manager) Stop(ctx context.Context) error {
-	_ = ctx
+	m.stopCodexAppCDPWatch(ctx)
 	return nil
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -1098,6 +1098,40 @@ func TestSelectCodexAppTargetThreadMainFallsBackToLatestProjectThread(t *testing
 	}
 }
 
+func TestSelectCodexAppTargetThreadUsesSidebarSessionName(t *testing.T) {
+	threads := []codexAppThreadRecord{
+		{
+			ID:        "latest",
+			Title:     "recent task",
+			CWD:       "/repo/cloudbank",
+			UpdatedAt: 300,
+		},
+		{
+			ID:        "named-main",
+			Title:     "health check",
+			CWD:       "/repo/cloudbank",
+			UpdatedAt: 100,
+		},
+	}
+	mergeCodexAppSidebarThreads(threads, []codexAppSidebarThreadRecord{{
+		ID:    "named-main",
+		Title: "main",
+	}})
+
+	thread, source, err := selectCodexAppTargetThread(threads, &config.CodexAppCDPConfig{
+		TargetProject: config.CodexAppCDPTargetProjectConfig{
+			CWD:     "/repo/cloudbank",
+			Session: "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("select target: %v", err)
+	}
+	if thread.ID != "named-main" || source != "named-session" {
+		t.Fatalf("selected thread=%#v source=%q", thread, source)
+	}
+}
+
 func TestResolveCodexAppConversationUsesExplicitConversationIDOverride(t *testing.T) {
 	oldQuery := queryCodexAppThreads
 	defer func() { queryCodexAppThreads = oldQuery }()

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -714,7 +714,7 @@ func TestHandleIncomingCodexAppCDPDeliversViaCDP(t *testing.T) {
 		if err := conn.WriteJSON(map[string]interface{}{
 			"id": req.ID,
 			"result": map[string]interface{}{
-				"result": map[string]interface{}{"type": "object", "value": map[string]interface{}{"ok": true}},
+				"result": map[string]interface{}{"type": "object", "value": map[string]interface{}{"ok": true, "conversationId": "thread-123"}},
 			},
 		}); err != nil {
 			t.Fatalf("write cdp response: %v", err)
@@ -753,6 +753,93 @@ func TestHandleIncomingCodexAppCDPDeliversViaCDP(t *testing.T) {
 	telemetry := manager.LastRoutingOutcome()
 	if telemetry == nil || telemetry.Backend != "codexAppCDP" || telemetry.Status != "delivered" || telemetry.EnvelopeID == "" || telemetry.InboxPath != "" {
 		t.Fatalf("unexpected telemetry: %#v", telemetry)
+	}
+}
+
+func TestHandleIncomingCodexAppCDPBridgeRejectionFallsBackToInbox(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/devtools/page/1"
+	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]cdpTarget{{
+			Type:                 "page",
+			Title:                "Codex",
+			URL:                  "app://-/index.html",
+			WebSocketDebuggerURL: wsURL,
+		}})
+	})
+	mux.HandleFunc("/devtools/page/1", func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Fatalf("upgrade: %v", err)
+		}
+		defer conn.Close()
+		var req struct {
+			ID int `json:"id"`
+		}
+		if err := conn.ReadJSON(&req); err != nil {
+			t.Fatalf("read cdp request: %v", err)
+		}
+		if err := conn.WriteJSON(map[string]interface{}{
+			"id": req.ID,
+			"result": map[string]interface{}{
+				"result": map[string]interface{}{
+					"type": "object",
+					"value": map[string]interface{}{
+						"ok":             true,
+						"conversationId": "thread-123",
+						"result": map[string]interface{}{
+							"error": map[string]interface{}{
+								"message": "conversation has an active turn",
+							},
+						},
+					},
+				},
+			},
+		}); err != nil {
+			t.Fatalf("write cdp response: %v", err)
+		}
+	})
+
+	inbox := filepath.Join(t.TempDir(), "inbox")
+	manager := NewManager(&config.AgentsConfig{
+		Router: "codexAppCDP",
+		CodexAppCDP: &config.CodexAppCDPConfig{
+			Enabled:         true,
+			CDPEndpoint:     server.URL,
+			ConversationID:  "thread-123",
+			InboxPath:       inbox,
+			FallbackToInbox: true,
+			DefaultAgent:    "main",
+			RepairPolicy:    "off",
+		},
+	})
+
+	reply, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "feishu",
+			"text":    "deliver during active turn",
+			"chat_id": "oc_123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming failed: %v", err)
+	}
+	if reply != codexAppAssignAckMessage {
+		t.Fatalf("reply=%q", reply)
+	}
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected queued inbox envelope, got %d", len(entries))
+	}
+	telemetry := manager.LastRoutingOutcome()
+	if telemetry == nil || telemetry.Status != "queued" || telemetry.Error == "" || !strings.Contains(telemetry.Error, "conversation has an active turn") {
+		t.Fatalf("expected queued telemetry with bridge error, got %#v", telemetry)
 	}
 }
 

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -8,13 +8,30 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 	"github.com/gorilla/websocket"
 )
+
+type recordingCodexAppCDPClient struct {
+	calls          int32
+	conversationID string
+}
+
+func (c *recordingCodexAppCDPClient) Deliver(ctx context.Context, cfg *config.CodexAppCDPConfig, envelope CodexAppEnvelope, prompt string) error {
+	atomic.AddInt32(&c.calls, 1)
+	c.conversationID = strings.TrimSpace(cfg.ConversationID)
+	return nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
 
 func TestValidateOhMyCodeAgentDefaultOnly(t *testing.T) {
 	manager := NewManager(&config.AgentsConfig{
@@ -663,6 +680,9 @@ func TestHandleIncomingCodexAppCDPDeliversViaCDP(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/devtools/page/1"
+	mux.HandleFunc("/json/version", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"Browser": "Codex"})
+	})
 	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode([]cdpTarget{{
 			Type:                 "page",
@@ -733,6 +753,401 @@ func TestHandleIncomingCodexAppCDPDeliversViaCDP(t *testing.T) {
 	telemetry := manager.LastRoutingOutcome()
 	if telemetry == nil || telemetry.Backend != "codexAppCDP" || telemetry.Status != "delivered" || telemetry.EnvelopeID == "" || telemetry.InboxPath != "" {
 		t.Fatalf("unexpected telemetry: %#v", telemetry)
+	}
+}
+
+func TestHandleIncomingCodexAppCDPChecksReadinessAndFallsBackToInbox(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/json/version", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "cdp down", http.StatusServiceUnavailable)
+	})
+
+	inbox := filepath.Join(t.TempDir(), "inbox")
+	manager := NewManager(&config.AgentsConfig{
+		Router: "codexAppCDP",
+		CodexAppCDP: &config.CodexAppCDPConfig{
+			Enabled:         true,
+			CDPEndpoint:     server.URL,
+			InboxPath:       inbox,
+			FallbackToInbox: true,
+			DefaultAgent:    "main",
+			RepairPolicy:    "status-only",
+		},
+	})
+
+	reply, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "feishu",
+			"text":    "queue when cdp is down",
+			"agent":   "main",
+			"chat_id": "oc_123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming failed: %v", err)
+	}
+	if reply != codexAppAssignAckMessage {
+		t.Fatalf("reply=%q", reply)
+	}
+
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected one inbox envelope, got %d", len(entries))
+	}
+	telemetry := manager.LastRoutingOutcome()
+	if telemetry == nil || telemetry.Status != "queued" || telemetry.Error == "" {
+		t.Fatalf("expected queued telemetry with readiness error, got %#v", telemetry)
+	}
+	ready := manager.CodexAppCDPReadinessStatus()
+	if ready == nil || ready.Available || ready.LastError == "" || ready.RepairPolicy != "status-only" {
+		t.Fatalf("unexpected readiness status: %#v", ready)
+	}
+}
+
+func TestHandleIncomingCodexAppCDPRepairOffSkipsReadinessCheck(t *testing.T) {
+	var versionHits int32
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/json/version", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&versionHits, 1)
+		http.Error(w, "should not be checked", http.StatusInternalServerError)
+	})
+
+	client := &recordingCodexAppCDPClient{}
+	manager := NewManager(&config.AgentsConfig{
+		Router: "codexAppCDP",
+		CodexAppCDP: &config.CodexAppCDPConfig{
+			Enabled:      true,
+			CDPEndpoint:  server.URL,
+			DefaultAgent: "main",
+			RepairPolicy: "off",
+		},
+	})
+	manager.codexAppCDPClient = client
+
+	reply, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "feishu",
+			"text":    "deliver without readiness",
+			"agent":   "main",
+			"chat_id": "oc_123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming failed: %v", err)
+	}
+	if reply != codexAppAssignAckMessage {
+		t.Fatalf("reply=%q", reply)
+	}
+	if atomic.LoadInt32(&versionHits) != 0 {
+		t.Fatalf("expected no readiness calls, got %d", versionHits)
+	}
+	if atomic.LoadInt32(&client.calls) != 1 {
+		t.Fatalf("expected one delivery call, got %d", client.calls)
+	}
+	telemetry := manager.LastRoutingOutcome()
+	if telemetry == nil || telemetry.Status != "delivered" {
+		t.Fatalf("expected delivered telemetry, got %#v", telemetry)
+	}
+}
+
+func TestHandleIncomingCodexAppCDPResolvesTargetProjectSession(t *testing.T) {
+	oldQuery := queryCodexAppThreads
+	defer func() { queryCodexAppThreads = oldQuery }()
+	queryCodexAppThreads = func(ctx context.Context, cfg *config.CodexAppCDPConfig) ([]codexAppThreadRecord, string, error) {
+		return []codexAppThreadRecord{
+			{
+				ID:            "thread-old",
+				Title:         "main",
+				AgentNickname: "main",
+				CWD:           "/repo/cloudbank",
+				UpdatedAt:     100,
+			},
+			{
+				ID:            "thread-new",
+				Title:         "main",
+				AgentNickname: "main",
+				CWD:           "/repo/cloudbank",
+				UpdatedAt:     200,
+			},
+		}, "state-db", nil
+	}
+
+	client := &recordingCodexAppCDPClient{}
+	manager := NewManager(&config.AgentsConfig{
+		Router: "codexAppCDP",
+		CodexAppCDP: &config.CodexAppCDPConfig{
+			Enabled:      true,
+			CDPEndpoint:  "http://127.0.0.1:9222",
+			DefaultAgent: "main",
+			RepairPolicy: "off",
+			TargetProject: config.CodexAppCDPTargetProjectConfig{
+				CWD:     "/repo/cloudbank",
+				Session: "main",
+			},
+		},
+	})
+	manager.codexAppCDPClient = client
+
+	reply, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "feishu",
+			"text":    "deliver to main",
+			"agent":   "main",
+			"chat_id": "oc_123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming failed: %v", err)
+	}
+	if reply != codexAppAssignAckMessage {
+		t.Fatalf("reply=%q", reply)
+	}
+	if client.conversationID != "thread-new" {
+		t.Fatalf("conversationID=%q", client.conversationID)
+	}
+	resolved := manager.CodexAppCDPResolvedConversationStatus()
+	if resolved == nil || resolved.ID != "thread-new" || resolved.Source != "state-db:named-session" || resolved.LastError != "" {
+		t.Fatalf("unexpected resolved status: %#v", resolved)
+	}
+}
+
+func TestHandleIncomingCodexAppCDPMissingTargetFallsBackToInbox(t *testing.T) {
+	oldQuery := queryCodexAppThreads
+	defer func() { queryCodexAppThreads = oldQuery }()
+	queryCodexAppThreads = func(ctx context.Context, cfg *config.CodexAppCDPConfig) ([]codexAppThreadRecord, string, error) {
+		return []codexAppThreadRecord{{
+			ID:        "thread-qa",
+			Title:     "qa",
+			CWD:       "/repo/cloudbank",
+			UpdatedAt: 100,
+		}}, "state-db", nil
+	}
+
+	inbox := filepath.Join(t.TempDir(), "inbox")
+	client := &recordingCodexAppCDPClient{}
+	manager := NewManager(&config.AgentsConfig{
+		Router: "codexAppCDP",
+		CodexAppCDP: &config.CodexAppCDPConfig{
+			Enabled:         true,
+			CDPEndpoint:     "http://127.0.0.1:9222",
+			InboxPath:       inbox,
+			FallbackToInbox: true,
+			DefaultAgent:    "main",
+			RepairPolicy:    "off",
+			TargetProject: config.CodexAppCDPTargetProjectConfig{
+				CWD:     "/repo/cloudbank",
+				Session: "release",
+			},
+		},
+	})
+	manager.codexAppCDPClient = client
+
+	reply, err := manager.HandleIncoming(context.Background(), &protocol.Message{
+		Data: map[string]interface{}{
+			"channel": "feishu",
+			"text":    "queue missing target",
+			"agent":   "main",
+			"chat_id": "oc_123",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleIncoming failed: %v", err)
+	}
+	if reply != codexAppAssignAckMessage {
+		t.Fatalf("reply=%q", reply)
+	}
+	if atomic.LoadInt32(&client.calls) != 0 {
+		t.Fatalf("expected no delivery calls, got %d", client.calls)
+	}
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected queued envelope, got %d", len(entries))
+	}
+	telemetry := manager.LastRoutingOutcome()
+	if telemetry == nil || telemetry.Status != "queued" || telemetry.Error == "" {
+		t.Fatalf("expected queued telemetry with resolve error, got %#v", telemetry)
+	}
+	resolved := manager.CodexAppCDPResolvedConversationStatus()
+	if resolved == nil || resolved.LastError == "" {
+		t.Fatalf("expected resolved error status, got %#v", resolved)
+	}
+}
+
+func TestSelectCodexAppTargetThreadMainFallsBackToLatestProjectThread(t *testing.T) {
+	thread, source, err := selectCodexAppTargetThread([]codexAppThreadRecord{
+		{
+			ID:        "older",
+			Title:     "old task",
+			CWD:       "/repo/cloudbank",
+			UpdatedAt: 100,
+		},
+		{
+			ID:        "newer",
+			Title:     "current task",
+			CWD:       "/repo/cloudbank",
+			UpdatedAt: 200,
+		},
+	}, &config.CodexAppCDPConfig{
+		TargetProject: config.CodexAppCDPTargetProjectConfig{
+			CWD:     "/repo/cloudbank",
+			Session: "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("select target: %v", err)
+	}
+	if thread.ID != "newer" || source != "main-latest" {
+		t.Fatalf("selected thread=%#v source=%q", thread, source)
+	}
+}
+
+func TestResolveCodexAppConversationUsesExplicitConversationIDOverride(t *testing.T) {
+	oldQuery := queryCodexAppThreads
+	defer func() { queryCodexAppThreads = oldQuery }()
+	queryCodexAppThreads = func(ctx context.Context, cfg *config.CodexAppCDPConfig) ([]codexAppThreadRecord, string, error) {
+		t.Fatal("queryCodexAppThreads should not be called when conversationId is configured")
+		return nil, "", nil
+	}
+
+	manager := NewManager(nil)
+	id, err := manager.resolveCodexAppConversation(context.Background(), &config.CodexAppCDPConfig{
+		ConversationID: "pinned-thread",
+		TargetProject: config.CodexAppCDPTargetProjectConfig{
+			CWD:     "/repo/cloudbank",
+			Session: "main",
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if id != "pinned-thread" {
+		t.Fatalf("id=%q", id)
+	}
+	resolved := manager.CodexAppCDPResolvedConversationStatus()
+	if resolved == nil || resolved.ID != "pinned-thread" || resolved.Source != "config" {
+		t.Fatalf("unexpected resolved status: %#v", resolved)
+	}
+}
+
+func TestCodexAppCDPDefaultsEnableWatchAndRelaunchRepair(t *testing.T) {
+	cfg := &config.CodexAppCDPConfig{
+		Enabled:     true,
+		CDPEndpoint: "http://127.0.0.1:9222",
+	}
+	if got := codexAppRepairPolicy(cfg); got != codexAppCDPRepairRelaunch {
+		t.Fatalf("repair policy=%q", got)
+	}
+	if !codexAppWatchEnabled(cfg) {
+		t.Fatal("expected watch to be enabled by default")
+	}
+
+	cfg.Watch.Enabled = boolPtr(false)
+	if codexAppWatchEnabled(cfg) {
+		t.Fatal("expected explicit watch.enabled=false to disable watch")
+	}
+}
+
+func TestCodexAppCDPWatchUpdatesReadinessAndStops(t *testing.T) {
+	checked := make(chan struct{}, 1)
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/json/version", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"Browser": "Codex"})
+	})
+	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case checked <- struct{}{}:
+		default:
+		}
+		_ = json.NewEncoder(w).Encode([]cdpTarget{{
+			Type:                 "page",
+			Title:                "Codex",
+			URL:                  "app://-/index.html",
+			WebSocketDebuggerURL: "ws://127.0.0.1:1/devtools/page/codex",
+		}})
+	})
+
+	manager := NewManager(&config.AgentsConfig{
+		CodexAppCDP: &config.CodexAppCDPConfig{
+			Enabled:      true,
+			CDPEndpoint:  server.URL,
+			RepairPolicy: "status-only",
+			Watch: config.CodexAppCDPWatchConfig{
+				Enabled:         boolPtr(true),
+				IntervalSeconds: 1,
+				CooldownSeconds: 1,
+			},
+		},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := manager.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	select {
+	case <-checked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for readiness watch")
+	}
+	var ready *CodexAppCDPReadinessStatus
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ready = manager.CodexAppCDPReadinessStatus()
+		if ready != nil && ready.Available && ready.TargetCount == 1 && ready.WatchRunning {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if ready == nil || !ready.Available || ready.TargetCount != 1 || !ready.WatchRunning {
+		t.Fatalf("unexpected readiness status: %#v", ready)
+	}
+	if err := manager.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop failed: %v", err)
+	}
+	ready = manager.CodexAppCDPReadinessStatus()
+	if ready == nil || ready.WatchRunning {
+		t.Fatalf("expected stopped readiness watch, got %#v", ready)
+	}
+}
+
+func TestSelectCodexAppCDPTargetPrefersCodexPageOverBlankWebview(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/json/list", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode([]cdpTarget{
+			{
+				Type:                 "webview",
+				Title:                "about:blank",
+				URL:                  "about:blank",
+				WebSocketDebuggerURL: "ws://127.0.0.1:1/devtools/webview/blank",
+			},
+			{
+				Type:                 "page",
+				Title:                "Codex",
+				URL:                  "app://-/index.html",
+				WebSocketDebuggerURL: "ws://127.0.0.1:1/devtools/page/codex",
+			},
+		})
+	})
+
+	target, err := selectCodexAppCDPTarget(context.Background(), server.URL, "")
+	if err != nil {
+		t.Fatalf("select target: %v", err)
+	}
+	if target.URL != "app://-/index.html" {
+		t.Fatalf("selected URL=%q", target.URL)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,6 +163,10 @@ type CodexAppCDPConfig struct {
 	// If empty, the CDP bridge extracts the active /local/<conversationId> route.
 	ConversationID string `yaml:"conversationId,omitempty"`
 
+	// TargetProject resolves the Codex App conversation dynamically by project
+	// and named session. ConversationID, when set, remains an explicit override.
+	TargetProject CodexAppCDPTargetProjectConfig `yaml:"targetProject,omitempty"`
+
 	// InboxPath is a durable file-backed inbox used as the MVP queue and CDP fallback.
 	InboxPath string `yaml:"inboxPath,omitempty"`
 
@@ -178,6 +182,46 @@ type CodexAppCDPConfig struct {
 
 	// DeliveryTimeoutSeconds limits CDP delivery time. Defaults to 20 seconds.
 	DeliveryTimeoutSeconds int `yaml:"deliveryTimeoutSeconds,omitempty"`
+
+	// RepairPolicy controls what the gateway may do when CDP is unavailable.
+	// Supported values: "off", "status-only", "new-instance", "relaunch".
+	// Empty defaults to "relaunch" when Codex App CDP is enabled.
+	RepairPolicy string `yaml:"repairPolicy,omitempty"`
+
+	// CheckOnIncomingMessage controls whether inbound Codex App routes check CDP
+	// readiness before delivery. Nil defaults to true.
+	CheckOnIncomingMessage *bool `yaml:"checkOnIncomingMessage,omitempty"`
+
+	// Watch periodically checks CDP readiness while the gateway is running.
+	Watch CodexAppCDPWatchConfig `yaml:"watch,omitempty"`
+}
+
+// CodexAppCDPTargetProjectConfig describes a stable logical Codex App target.
+type CodexAppCDPTargetProjectConfig struct {
+	// Name is an optional display alias used when CWD is not configured.
+	Name string `yaml:"name,omitempty"`
+
+	// CWD is the project working directory. Exact CWD match is preferred.
+	CWD string `yaml:"cwd,omitempty"`
+
+	// Session is the named Codex App session, for example "main".
+	Session string `yaml:"session,omitempty"`
+
+	// StateDB optionally pins the Codex App state sqlite DB for resolution.
+	// Empty defaults to the newest ~/.codex/state_*.sqlite.
+	StateDB string `yaml:"stateDb,omitempty"`
+}
+
+// CodexAppCDPWatchConfig controls the long-running Codex App CDP watchdog.
+type CodexAppCDPWatchConfig struct {
+	// Enabled controls the watchdog. Nil defaults to true when Codex App CDP is enabled.
+	Enabled *bool `yaml:"enabled,omitempty"`
+
+	// IntervalSeconds sets the watchdog interval. Defaults to 60 when watch is enabled.
+	IntervalSeconds int `yaml:"intervalSeconds,omitempty"`
+
+	// CooldownSeconds prevents repeated repair attempts. Defaults to 90.
+	CooldownSeconds int `yaml:"cooldownSeconds,omitempty"`
 }
 
 // AgentsConfig contains gateway-side agent routing settings.
@@ -348,11 +392,22 @@ func validateCodexAppCDPConfig(cfg *Config) error {
 	if !codex.Enabled {
 		return nil
 	}
-	if strings.TrimSpace(codex.InboxPath) == "" {
-		return fmt.Errorf("agents.codexAppCDP.inboxPath: required when agents.codexAppCDP.enabled is true")
+	if strings.TrimSpace(codex.CDPEndpoint) == "" && strings.TrimSpace(codex.InboxPath) == "" {
+		return fmt.Errorf("agents.codexAppCDP.cdpEndpoint or agents.codexAppCDP.inboxPath: required when agents.codexAppCDP.enabled is true")
 	}
 	if codex.DeliveryTimeoutSeconds < 0 {
 		return fmt.Errorf("agents.codexAppCDP.deliveryTimeoutSeconds: must be >= 0")
+	}
+	switch strings.TrimSpace(codex.RepairPolicy) {
+	case "", "off", "status-only", "new-instance", "relaunch":
+	default:
+		return fmt.Errorf("agents.codexAppCDP.repairPolicy: unsupported policy %q", codex.RepairPolicy)
+	}
+	if codex.Watch.IntervalSeconds < 0 {
+		return fmt.Errorf("agents.codexAppCDP.watch.intervalSeconds: must be >= 0")
+	}
+	if codex.Watch.CooldownSeconds < 0 {
+		return fmt.Errorf("agents.codexAppCDP.watch.cooldownSeconds: must be >= 0")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -322,7 +322,7 @@ func TestLoadConfigValidatesCodexAppCDPAgentAllowlist(t *testing.T) {
 	}
 }
 
-func TestLoadConfigRequiresCodexAppCDPInboxWhenEnabled(t *testing.T) {
+func TestLoadConfigRequiresCodexAppCDPEndpointOrInboxWhenEnabled(t *testing.T) {
 	tmp := t.TempDir()
 	path := filepath.Join(tmp, "config.yaml")
 	content := []byte("agents:\n  router: codexAppCDP\n  codexAppCDP:\n    enabled: true\n    defaultAgent: \"main\"\n")
@@ -332,9 +332,67 @@ func TestLoadConfigRequiresCodexAppCDPInboxWhenEnabled(t *testing.T) {
 
 	_, err := LoadConfig(path)
 	if err == nil {
-		t.Fatal("expected inboxPath error")
+		t.Fatal("expected endpoint or inboxPath error")
 	}
-	if !strings.Contains(err.Error(), "agents.codexAppCDP.inboxPath") {
-		t.Fatalf("expected inboxPath error, got %v", err)
+	if !strings.Contains(err.Error(), "agents.codexAppCDP.cdpEndpoint") || !strings.Contains(err.Error(), "agents.codexAppCDP.inboxPath") {
+		t.Fatalf("expected endpoint/inboxPath error, got %v", err)
+	}
+}
+
+func TestLoadConfigAcceptsCodexAppCDPReadinessConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`agents:
+  router: codexAppCDP
+  codexAppCDP:
+    enabled: true
+    cdpEndpoint: "http://127.0.0.1:9222"
+    repairPolicy: "status-only"
+    checkOnIncomingMessage: true
+    targetProject:
+      name: "CloudBank"
+      cwd: "/repo/cloudbank"
+      session: "main"
+      stateDb: "/tmp/state.sqlite"
+    watch:
+      enabled: true
+      intervalSeconds: 60
+      cooldownSeconds: 90
+    defaultAgent: "main"
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig failed: %v", err)
+	}
+	if cfg.Agents.CodexAppCDP == nil || cfg.Agents.CodexAppCDP.RepairPolicy != "status-only" {
+		t.Fatalf("unexpected codex config: %#v", cfg.Agents.CodexAppCDP)
+	}
+	if cfg.Agents.CodexAppCDP.CheckOnIncomingMessage == nil || !*cfg.Agents.CodexAppCDP.CheckOnIncomingMessage {
+		t.Fatalf("expected checkOnIncomingMessage=true")
+	}
+	if cfg.Agents.CodexAppCDP.TargetProject.Name != "CloudBank" || cfg.Agents.CodexAppCDP.TargetProject.CWD != "/repo/cloudbank" || cfg.Agents.CodexAppCDP.TargetProject.Session != "main" || cfg.Agents.CodexAppCDP.TargetProject.StateDB != "/tmp/state.sqlite" {
+		t.Fatalf("unexpected targetProject: %#v", cfg.Agents.CodexAppCDP.TargetProject)
+	}
+	if cfg.Agents.CodexAppCDP.Watch.Enabled == nil || !*cfg.Agents.CodexAppCDP.Watch.Enabled || cfg.Agents.CodexAppCDP.Watch.IntervalSeconds != 60 || cfg.Agents.CodexAppCDP.Watch.CooldownSeconds != 90 {
+		t.Fatalf("unexpected watch config: %#v", cfg.Agents.CodexAppCDP.Watch)
+	}
+}
+
+func TestLoadConfigRejectsInvalidCodexAppCDPRepairPolicy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("agents:\n  router: codexAppCDP\n  codexAppCDP:\n    enabled: true\n    cdpEndpoint: \"http://127.0.0.1:9222\"\n    repairPolicy: \"restart-everything\"\n    defaultAgent: \"main\"\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(path)
+	if err == nil {
+		t.Fatal("expected repairPolicy error")
+	}
+	if !strings.Contains(err.Error(), "agents.codexAppCDP.repairPolicy") {
+		t.Fatalf("expected repairPolicy error, got %v", err)
 	}
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -447,16 +447,57 @@ type ohMyCodeStatus struct {
 }
 
 type codexAppCDPStatus struct {
-	Enabled         bool                `json:"enabled"`
-	CDPEndpoint     string              `json:"cdp_endpoint,omitempty"`
-	TargetSelector  string              `json:"target_selector,omitempty"`
-	HostID          string              `json:"host_id,omitempty"`
-	ConversationID  string              `json:"conversation_id,omitempty"`
-	InboxConfigured bool                `json:"inbox_configured"`
-	FallbackToInbox bool                `json:"fallback_to_inbox"`
-	DefaultAgent    string              `json:"default_agent,omitempty"`
-	AllowedAgents   []string            `json:"allowed_agents,omitempty"`
-	LastRouting     *agentRoutingStatus `json:"last_routing,omitempty"`
+	Enabled              bool                       `json:"enabled"`
+	CDPEndpoint          string                     `json:"cdp_endpoint,omitempty"`
+	TargetSelector       string                     `json:"target_selector,omitempty"`
+	HostID               string                     `json:"host_id,omitempty"`
+	ConversationID       string                     `json:"conversation_id,omitempty"`
+	TargetProject        *codexAppCDPTargetProject  `json:"target_project,omitempty"`
+	ResolvedConversation *codexAppCDPResolvedTarget `json:"resolved_conversation,omitempty"`
+	InboxConfigured      bool                       `json:"inbox_configured"`
+	FallbackToInbox      bool                       `json:"fallback_to_inbox"`
+	RepairPolicy         string                     `json:"repair_policy,omitempty"`
+	CheckOnIncoming      bool                       `json:"check_on_incoming_message"`
+	Watch                codexAppCDPWatch           `json:"watch"`
+	Readiness            *codexAppCDPReady          `json:"readiness,omitempty"`
+	DefaultAgent         string                     `json:"default_agent,omitempty"`
+	AllowedAgents        []string                   `json:"allowed_agents,omitempty"`
+	LastRouting          *agentRoutingStatus        `json:"last_routing,omitempty"`
+}
+
+type codexAppCDPTargetProject struct {
+	Name    string `json:"name,omitempty"`
+	CWD     string `json:"cwd,omitempty"`
+	Session string `json:"session,omitempty"`
+	StateDB string `json:"state_db,omitempty"`
+}
+
+type codexAppCDPResolvedTarget struct {
+	Configured     bool   `json:"configured"`
+	ID             string `json:"id,omitempty"`
+	Title          string `json:"title,omitempty"`
+	CWD            string `json:"cwd,omitempty"`
+	UpdatedAt      string `json:"updated_at,omitempty"`
+	Source         string `json:"source,omitempty"`
+	LastResolvedAt string `json:"last_resolved_at,omitempty"`
+	LastError      string `json:"last_error,omitempty"`
+}
+
+type codexAppCDPWatch struct {
+	Enabled         bool `json:"enabled"`
+	Running         bool `json:"running"`
+	IntervalSeconds int  `json:"interval_seconds,omitempty"`
+	CooldownSeconds int  `json:"cooldown_seconds,omitempty"`
+}
+
+type codexAppCDPReady struct {
+	Available        bool   `json:"available"`
+	TargetCount      int    `json:"target_count"`
+	LastCheckedAt    string `json:"last_checked_at,omitempty"`
+	LastError        string `json:"last_error,omitempty"`
+	LastRepairAt     string `json:"last_repair_at,omitempty"`
+	LastRepairAction string `json:"last_repair_action,omitempty"`
+	LastRepairError  string `json:"last_repair_error,omitempty"`
 }
 
 func (s *Server) channelStatus() []channelStatus {
@@ -630,7 +671,48 @@ func (s *Server) agentStatus() *agentStatus {
 			ConversationID:  strings.TrimSpace(codex.ConversationID),
 			InboxConfigured: strings.TrimSpace(codex.InboxPath) != "",
 			FallbackToInbox: codex.FallbackToInbox,
-			DefaultAgent:    strings.TrimSpace(codex.DefaultAgent),
+			RepairPolicy:    codexRepairPolicy(codex),
+			CheckOnIncoming: codexCheckOnIncoming(codex),
+			Watch: codexAppCDPWatch{
+				Enabled:         codexWatchEnabled(codex),
+				IntervalSeconds: codexWatchIntervalSeconds(codex),
+				CooldownSeconds: codexCooldownSeconds(codex),
+			},
+			DefaultAgent: strings.TrimSpace(codex.DefaultAgent),
+		}
+		if codexTargetProjectConfigured(codex) {
+			status.CodexAppCDP.TargetProject = &codexAppCDPTargetProject{
+				Name:    strings.TrimSpace(codex.TargetProject.Name),
+				CWD:     strings.TrimSpace(codex.TargetProject.CWD),
+				Session: strings.TrimSpace(codex.TargetProject.Session),
+				StateDB: strings.TrimSpace(codex.TargetProject.StateDB),
+			}
+		}
+		if s.agentManager != nil {
+			if readiness := s.agentManager.CodexAppCDPReadinessStatus(); readiness != nil {
+				status.CodexAppCDP.Watch.Running = readiness.WatchRunning
+				status.CodexAppCDP.Readiness = &codexAppCDPReady{
+					Available:        readiness.Available,
+					TargetCount:      readiness.TargetCount,
+					LastCheckedAt:    formatStatusTime(readiness.LastCheckedAt),
+					LastError:        readiness.LastError,
+					LastRepairAt:     formatStatusTime(readiness.LastRepairAt),
+					LastRepairAction: readiness.LastRepairAction,
+					LastRepairError:  readiness.LastRepairError,
+				}
+			}
+			if resolved := s.agentManager.CodexAppCDPResolvedConversationStatus(); resolved != nil {
+				status.CodexAppCDP.ResolvedConversation = &codexAppCDPResolvedTarget{
+					Configured:     resolved.Configured,
+					ID:             resolved.ID,
+					Title:          resolved.Title,
+					CWD:            resolved.ThreadCWD,
+					UpdatedAt:      formatStatusTime(resolved.UpdatedAt),
+					Source:         resolved.Source,
+					LastResolvedAt: formatStatusTime(resolved.LastResolvedAt),
+					LastError:      resolved.LastError,
+				}
+			}
 		}
 		if len(codex.AllowedAgents) > 0 {
 			status.CodexAppCDP.AllowedAgents = append([]string{}, codex.AllowedAgents...)
@@ -657,6 +739,49 @@ func activeAgentRouterName(cfg *config.AgentsConfig) string {
 		return "codexAppCDP"
 	}
 	return ""
+}
+
+func codexRepairPolicy(cfg *config.CodexAppCDPConfig) string {
+	if cfg == nil || strings.TrimSpace(cfg.RepairPolicy) == "" {
+		return "relaunch"
+	}
+	return strings.TrimSpace(cfg.RepairPolicy)
+}
+
+func codexCheckOnIncoming(cfg *config.CodexAppCDPConfig) bool {
+	return cfg == nil || cfg.CheckOnIncomingMessage == nil || *cfg.CheckOnIncomingMessage
+}
+
+func codexWatchEnabled(cfg *config.CodexAppCDPConfig) bool {
+	if cfg == nil || !cfg.Enabled {
+		return false
+	}
+	if cfg.Watch.Enabled == nil {
+		return true
+	}
+	return *cfg.Watch.Enabled
+}
+
+func codexTargetProjectConfigured(cfg *config.CodexAppCDPConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	target := cfg.TargetProject
+	return strings.TrimSpace(target.Name) != "" || strings.TrimSpace(target.CWD) != "" || strings.TrimSpace(target.Session) != "" || strings.TrimSpace(target.StateDB) != ""
+}
+
+func codexWatchIntervalSeconds(cfg *config.CodexAppCDPConfig) int {
+	if cfg != nil && cfg.Watch.IntervalSeconds > 0 {
+		return cfg.Watch.IntervalSeconds
+	}
+	return 60
+}
+
+func codexCooldownSeconds(cfg *config.CodexAppCDPConfig) int {
+	if cfg != nil && cfg.Watch.CooldownSeconds > 0 {
+		return cfg.Watch.CooldownSeconds
+	}
+	return 90
 }
 
 func routingStatusFromOutcome(routing *agent.RoutingOutcome) *agentRoutingStatus {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -767,11 +767,11 @@ func TestStatusEndpointReportsCodexAppCDPRouting(t *testing.T) {
 			Router: "codexAppCDP",
 			CodexAppCDP: &config.CodexAppCDPConfig{
 				Enabled:         true,
-				CDPEndpoint:     "http://127.0.0.1:9222",
 				TargetSelector:  "Codex",
 				HostID:          "local",
 				InboxPath:       inbox,
 				FallbackToInbox: true,
+				RepairPolicy:    "status-only",
 				DefaultAgent:    "main",
 				AllowedAgents:   []string{"main"},
 			},
@@ -814,8 +814,63 @@ func TestStatusEndpointReportsCodexAppCDPRouting(t *testing.T) {
 	if codex["enabled"] != true || codex["default_agent"] != "main" || codex["inbox_configured"] != true {
 		t.Fatalf("unexpected codex status: %#v", codex)
 	}
+	if codex["repair_policy"] != "status-only" || codex["check_on_incoming_message"] != true {
+		t.Fatalf("unexpected codex readiness config: %#v", codex)
+	}
 	routing := agents["last_routing"].(map[string]interface{})
 	if routing["backend"] != "codexAppCDP" || routing["status"] != "queued" || routing["envelope_id"] == "" {
 		t.Fatalf("unexpected routing status: %#v", routing)
+	}
+}
+
+func TestStatusEndpointReportsCodexAppCDPDefaultRepairAndWatch(t *testing.T) {
+	cfg := &config.Config{
+		Gateway:  &config.GatewayConfig{Bind: "127.0.0.1", Port: 0},
+		Channels: &config.ChannelsConfig{},
+		Agents: &config.AgentsConfig{
+			Router: "codexAppCDP",
+			CodexAppCDP: &config.CodexAppCDPConfig{
+				Enabled:      true,
+				CDPEndpoint:  "http://127.0.0.1:9222",
+				DefaultAgent: "main",
+				TargetProject: config.CodexAppCDPTargetProjectConfig{
+					Name:    "CloudBank",
+					CWD:     "/repo/cloudbank",
+					Session: "main",
+				},
+			},
+		},
+	}
+	server, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer failed: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/status", server.handleStatus)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/status")
+	if err != nil {
+		t.Fatalf("status request: %v", err)
+	}
+	defer resp.Body.Close()
+	var payload map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	agents := payload["agents"].(map[string]interface{})
+	codex := agents["codex_app_cdp"].(map[string]interface{})
+	if codex["repair_policy"] != "relaunch" {
+		t.Fatalf("expected relaunch default, got %#v", codex)
+	}
+	watch := codex["watch"].(map[string]interface{})
+	if watch["enabled"] != true {
+		t.Fatalf("expected watch enabled by default, got %#v", watch)
+	}
+	targetProject := codex["target_project"].(map[string]interface{})
+	if targetProject["name"] != "CloudBank" || targetProject["cwd"] != "/repo/cloudbank" || targetProject["session"] != "main" {
+		t.Fatalf("unexpected target_project: %#v", targetProject)
 	}
 }


### PR DESCRIPTION
## Summary
- add Codex App CDP readiness config, validation, incoming-message checks, and optional watchdog with cooldown
- default enabled Codex App CDP routing to a watchdog-backed `relaunch` repair policy
- add project + named-session target resolution so delivery does not depend on a stale hard-coded conversation id
- resolve named sessions from the visible Codex App sidebar when state DB titles are stale, so `targetProject.session: main` maps to the actual sidebar `main` conversation
- use the current Codex App app-server bridge export (`signals.on`) before legacy exports, fixing delivered-with-no-effect CDP sends on newer Codex App bundles
- validate CDP delivery responses so bridge failures do not report false `delivered` status
- expose repair policy, watch state, target project, resolved conversation, and readiness details in `/status`
- document recommended targetProject config and troubleshooting, including no fallback to invisible app-server proxy/listen delivery

Fixes #352
Fixes #354

## Tests
- `go test ./...`
- `git diff --check`

## Local validation
- rebuilt and restarted local gateway from `fd17002`
- Feishu websocket connected
- user confirmed Feishu delivery to CloudBank main works after the sidebar-session and bridge-export fixes