### PR TITLE
fix: handle array-like Codex App CDP resources

### DIFF
--- a/internal/agent/codex_app_cdp.go
+++ b/internal/agent/codex_app_cdp.go
@@ -1237,11 +1237,40 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
     throw new Error("No active Codex App /local/<conversationId> route; configure agents.codexAppCDP.conversationId or open the target thread.");
   }
 
-  const resources = performance.getEntriesByType("resource").map((entry) => entry.name);
+  const toURLArray = (value) => {
+    const normalize = (item) => {
+      if (!item) {
+        return "";
+      }
+      if (typeof item === "string") {
+        return item;
+      }
+      return item.src || item.name || "";
+    };
+    if (!value) {
+      return [];
+    }
+    try {
+      return Array.from(value).map(normalize).filter(Boolean);
+    } catch (_) {
+      if (typeof value.length === "number") {
+        const out = [];
+        for (let i = 0; i < value.length; i += 1) {
+          const normalized = normalize(value[i]);
+          if (normalized) {
+            out.push(normalized);
+          }
+        }
+        return out;
+      }
+    }
+    return [];
+  };
+  const resources = toURLArray(performance.getEntriesByType("resource"));
   let signalsUrl = resources.find((name) => /app-server-manager-signals-[^/]+\.js$/.test(name));
   if (!signalsUrl) {
-    const scripts = Array.from(document.querySelectorAll("script[src]")).map((script) => script.src);
-    const candidates = [...scripts, ...resources].filter((src) => /\/assets\/[^/]+\.js$/.test(src));
+    const scripts = toURLArray(document.querySelectorAll("script[src]"));
+    const candidates = scripts.concat(resources).filter((src) => /\/assets\/[^/]+\.js$/.test(src));
     for (const candidate of candidates) {
       try {
         const source = await fetch(candidate).then((response) => response.text());
@@ -1258,12 +1287,26 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
   }
 
   const signals = await import(signalsUrl);
+  const isSendRequestBridge = (fn) => {
+    if (typeof fn !== "function") {
+      return false;
+    }
+    try {
+      const source = String(fn).replace(/\s+/g, "");
+      return /^asyncfunction\w*\([^)]*\)\{return\w+\.sendRequest\([^)]*\)\}$/.test(source) ||
+        /^function\w*\([^)]*\)\{return\w+\.sendRequest\([^)]*\)\}$/.test(source);
+    } catch (_) {
+      return false;
+    }
+  };
   const requestCandidates = [
+    ["ln", signals.ln],
     ["on", signals.on],
     ["Kn", signals.Kn],
     ["rn", signals.rn]
   ];
-  const candidate = requestCandidates.find(([, fn]) => typeof fn === "function");
+  const candidate = requestCandidates.find(([, fn]) => isSendRequestBridge(fn)) ||
+    Object.entries(signals).find(([, fn]) => isSendRequestBridge(fn));
   const sendRequest = candidate ? candidate[1] : null;
   if (typeof sendRequest !== "function") {
     throw new Error("Codex App app-server request bridge is unavailable.");

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -756,6 +756,31 @@ func TestHandleIncomingCodexAppCDPDeliversViaCDP(t *testing.T) {
 	}
 }
 
+func TestBuildCodexAppDeliveryScriptUsesArrayLikeSafeURLCollection(t *testing.T) {
+	script := buildCodexAppDeliveryScript(&config.CodexAppCDPConfig{
+		HostID:         "local",
+		ConversationID: "thread-123",
+	}, CodexAppEnvelope{ID: "env-1", Text: "hello"}, "hello")
+
+	if strings.Contains(script, "[...scripts, ...resources]") {
+		t.Fatalf("delivery script still uses spread over possibly array-like values")
+	}
+	for _, expected := range []string{
+		"const toURLArray = (value) =>",
+		"Array.from(value).map(normalize).filter(Boolean)",
+		"typeof value.length === \"number\"",
+		"scripts.concat(resources)",
+		"const isSendRequestBridge = (fn) =>",
+		"return /^asyncfunction",
+		"[\"ln\", signals.ln]",
+		"Object.entries(signals).find",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("delivery script missing %q:\n%s", expected, script)
+		}
+	}
+}
+
 func TestHandleIncomingCodexAppCDPBridgeRejectionFallsBackToInbox(t *testing.T) {
 	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary
- make Codex App CDP delivery script normalize resource/script collections before combining them
- avoid spreading values that may be array-like but not iterable in Electron renderer contexts
- select the actual Codex App app-server request bridge by detecting thin `.sendRequest(...)` wrapper exports, with `ln` covered for current Codex App builds
- add regression coverage for the generated delivery script

## Validation
- go test ./...
- real Codex App CDP smoke eval: URL collection returned ok without throwing
- real Codex App CDP smoke eval selected bridge `ln` -> `function Q(e,t){return ay.sendRequest(e,t)}`
- installed patched binary locally and verified FractalBot /status reports codexAppCDP readiness available=true
- replayed queued Slack envelope `d33a45188df8f1065a53173e7e730b78` to target main conversation; Codex App returned ok=true and created an in-progress turn