### PR TITLE
feat(channels): demail channel — on-chain agent mail via fractal-demail (KR4 slice 4)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -106,6 +106,8 @@ channels:
   #   gasCoin: "0x<gas-coin-object-id>"
   #   # Inbound event poll interval (seconds). Default: 2.
   #   pollIntervalSeconds: 2
+  #   # Processed Message object id journal; prevents historical replay on restart.
+  #   cursorFile: "~/.local/state/fractalbot/demail-processed.log"
   #   # Allowed sender Sui addresses (empty means deny all)
   #   allowedSenders:
   #     - "0x<peer-address>"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,6 +86,34 @@ channels:
     allowedUsers:
       - "123456789012345678"
 
+  # demail channel configuration (optional)
+  # On-chain agent mail via fractal-demail (Sui). Inbound messages are polled
+  # from MessageSent events and decrypted with this node's identity key;
+  # outbound sends are sponsored transactions signed via the local sui CLI.
+  # demail:
+  #   enabled: true
+  #   # Sui JSON-RPC endpoint
+  #   rpcUrl: "https://fullnode.testnet.sui.io:443"
+  #   # fractal-demail Move package id
+  #   packageId: "0x<package-id>"
+  #   # This node's Sui address (inbound recipient / outbound sender)
+  #   address: "0x<our-address>"
+  #   # File containing this node's base64 Ed25519 private key
+  #   # (32-byte seed or 64-byte key). Read at start; never logged.
+  #   identityKeyFile: "~/.config/fractalbot/demail-identity.key"
+  #   # Gas sponsor Sui address and sponsor-owned gas coin object id (outbound)
+  #   sponsorAddress: "0x<sponsor-address>"
+  #   gasCoin: "0x<gas-coin-object-id>"
+  #   # Inbound event poll interval (seconds). Default: 2.
+  #   pollIntervalSeconds: 2
+  #   # Allowed sender Sui addresses (empty means deny all)
+  #   allowedSenders:
+  #     - "0x<peer-address>"
+  #   # Recipient Sui address -> base64 Ed25519 public key.
+  #   # Required per outbound recipient (a pubkey cannot be derived from an address).
+  #   peers:
+  #     "0x<peer-address>": "<base64-ed25519-public-key>"
+
   # iMessage channel configuration (macOS only, optional)
   imessage:
     enabled: true

--- a/go.mod
+++ b/go.mod
@@ -4,15 +4,18 @@ go 1.25.6
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0
+	github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260702210713-01db07216ca4
+	github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 	github.com/slack-go/slack v0.17.3
+	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/sys v0.22.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
+	golang.org/x/crypto v0.39.0 // indirect
+	golang.org/x/sys v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+EgjDno=
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260702210713-01db07216ca4 h1:jqOAC+ywCycgu0qQ8l9wexTt5snvoa4wi8fs+cKbUFw=
+github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260702210713-01db07216ca4/go.mod h1:te9w6GASyunKCjWbSUByl/eaP+8E3Vy16u0SOK78GRQ=
+github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4 h1:yU8EgEww0HJDYu9p/jWbWTRzhCktwVk5yAtV+X8dlrs=
+github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4/go.mod h1:WbNInBdabo2hStb2F+dznTRThh1ttZtFbegMs8Kcnsk=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -26,8 +32,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.39.0 h1:SHs+kF4LP+f+p14esP5jAoDpHU8Gu/v9lFRK6IT5imM=
+golang.org/x/crypto v0.39.0/go.mod h1:L+Xg3Wf6HoL4Bn4238Z6ft6KfEpN0tJGo53AAPC632U=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -42,8 +48,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
+golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/internal/channels/demail.go
+++ b/internal/channels/demail.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +47,9 @@ type DemailOptions struct {
 	GasCoin string
 	// PollInterval controls inbound event polling. Zero uses the default (2s).
 	PollInterval time.Duration
+	// CursorFile stores processed Message object ids so historical event replay
+	// on restart cannot re-execute old tasks or re-spend reply gas.
+	CursorFile string
 	// AllowedSenders is an allowlist of Sui addresses. Empty means deny all.
 	AllowedSenders []string
 	// Peers maps a recipient Sui address to its base64 Ed25519 public key.
@@ -72,6 +76,7 @@ type DemailChannel struct {
 	identityKeyFile string
 	sponsorAddress  string
 	gasCoin         string
+	cursorFile      string
 	pollInterval    time.Duration
 
 	allowlist DemailAllowlist
@@ -95,6 +100,9 @@ type DemailChannel struct {
 	ctx    context.Context
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	processedMu       sync.Mutex
+	processedMessages map[string]struct{}
 
 	telemetryMu  sync.RWMutex
 	lastActivity time.Time
@@ -121,9 +129,24 @@ func NewDemailChannel(opts DemailOptions) (*DemailChannel, error) {
 		}
 	}
 
+	gasCoin := strings.TrimSpace(opts.GasCoin)
+	if gasCoin != "" {
+		// Object ids share the Sui address format; reject anything else
+		// before it can ever reach a CLI argv.
+		if gasCoin, err = normalizeDemailAddress(gasCoin); err != nil {
+			return nil, fmt.Errorf("demail gasCoin: %w", err)
+		}
+	}
+
 	allowlist, err := NewDemailAllowlist(opts.AllowedSenders)
 	if err != nil {
 		return nil, err
+	}
+
+	cursorFile := strings.TrimSpace(opts.CursorFile)
+	processedMessages, err := loadDemailProcessedMessages(cursorFile)
+	if err != nil {
+		return nil, fmt.Errorf("demail cursorFile: %w", err)
 	}
 
 	peers := make(map[string]ed25519.PublicKey, len(opts.Peers))
@@ -148,19 +171,31 @@ func NewDemailChannel(opts DemailOptions) (*DemailChannel, error) {
 	}
 
 	channel := &DemailChannel{
-		rpcURL:          strings.TrimSpace(opts.RPCURL),
-		packageID:       strings.TrimSpace(opts.PackageID),
-		address:         address,
-		identityKeyFile: strings.TrimSpace(opts.IdentityKeyFile),
-		sponsorAddress:  sponsor,
-		gasCoin:         strings.TrimSpace(opts.GasCoin),
-		pollInterval:    pollInterval,
-		allowlist:       allowlist,
-		peers:           peers,
-		nowFn:           time.Now,
+		rpcURL:            strings.TrimSpace(opts.RPCURL),
+		packageID:         strings.TrimSpace(opts.PackageID),
+		address:           address,
+		identityKeyFile:   strings.TrimSpace(opts.IdentityKeyFile),
+		sponsorAddress:    sponsor,
+		gasCoin:           gasCoin,
+		pollInterval:      pollInterval,
+		cursorFile:        cursorFile,
+		allowlist:         allowlist,
+		peers:             peers,
+		processedMessages: processedMessages,
+		nowFn:             time.Now,
 	}
 	channel.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		return exec.CommandContext(ctx, name, args...).CombinedOutput()
+		output, err := exec.CommandContext(ctx, name, args...).CombinedOutput()
+		if err != nil {
+			// Surface the CLI's own diagnostics (stderr is in CombinedOutput);
+			// cap the tail so errors stay loggable.
+			tail := lastNonEmptyLine(string(output))
+			if len(tail) > 300 {
+				tail = tail[:300]
+			}
+			return output, fmt.Errorf("%w: %s", err, tail)
+		}
+		return output, nil
 	}
 	return channel, nil
 }
@@ -213,6 +248,9 @@ func (b *DemailChannel) markError() {
 
 // Start builds the inbound listener and runs it until Stop or ctx cancel.
 func (b *DemailChannel) Start(ctx context.Context) error {
+	if b.IsRunning() {
+		return errors.New("demail channel already running")
+	}
 	b.ctx, b.cancel = context.WithCancel(ctx)
 
 	runFn := b.runListenerFn
@@ -244,6 +282,8 @@ func (b *DemailChannel) Start(ctx context.Context) error {
 		if err := runFn(b.ctx); err != nil && b.ctx.Err() == nil {
 			log.Printf("demail listener exited: %v", err)
 			b.markError()
+			// The inbound loop is dead; reflect reality for health checks.
+			b.setRunning(false)
 		}
 	}()
 
@@ -271,6 +311,10 @@ func (b *DemailChannel) IsAllowed(senderID string) bool {
 // handleInbound delivers one decrypted message to the shared inbound handler.
 // Input is untrusted even after schema sanitization; it must never panic.
 func (b *DemailChannel) handleInbound(messageID string, msg *schema.Plaintext) {
+	messageID = strings.TrimSpace(messageID)
+	if messageID != "" && b.isProcessed(messageID) {
+		return
+	}
 	if msg == nil {
 		return
 	}
@@ -299,10 +343,81 @@ func (b *DemailChannel) handleInbound(messageID string, msg *schema.Plaintext) {
 	}
 	b.markActivity()
 
+	defer func() {
+		if messageID != "" {
+			b.markProcessed(messageID)
+		}
+	}()
+
+	// Loop guard: only "task" messages get an automatic on-chain reply.
+	// Outbound sends are stamped type "reply", so two mutually-allowlisted
+	// gateways cannot ping-pong sponsored transactions forever.
+	if msg.Type != schema.TypeTask {
+		return
+	}
 	if trimmed := strings.TrimSpace(reply); trimmed != "" {
 		if _, err := b.Send(ctx, OutboundMessage{To: from, Text: trimmed}); err != nil {
 			log.Printf("demail reply send failed: %v", err)
 		}
+	}
+}
+
+func loadDemailProcessedMessages(path string) (map[string]struct{}, error) {
+	processed := make(map[string]struct{})
+	if path == "" {
+		return processed, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return processed, nil
+		}
+		return nil, err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		processed[line] = struct{}{}
+	}
+	return processed, nil
+}
+
+func (b *DemailChannel) isProcessed(messageID string) bool {
+	b.processedMu.Lock()
+	defer b.processedMu.Unlock()
+	_, ok := b.processedMessages[messageID]
+	return ok
+}
+
+func (b *DemailChannel) markProcessed(messageID string) {
+	b.processedMu.Lock()
+	if _, ok := b.processedMessages[messageID]; ok {
+		b.processedMu.Unlock()
+		return
+	}
+	b.processedMessages[messageID] = struct{}{}
+	b.processedMu.Unlock()
+
+	if b.cursorFile == "" {
+		return
+	}
+	dir := filepath.Dir(b.cursorFile)
+	if dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			log.Printf("demail cursor mkdir failed: %v", err)
+			return
+		}
+	}
+	f, err := os.OpenFile(b.cursorFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
+	if err != nil {
+		log.Printf("demail cursor open failed: %v", err)
+		return
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintln(f, messageID); err != nil {
+		log.Printf("demail cursor write failed: %v", err)
 	}
 }
 

--- a/internal/channels/demail.go
+++ b/internal/channels/demail.go
@@ -1,0 +1,609 @@
+package channels
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fractalmind-ai/fractal-demail/client-go/envelope"
+	"github.com/fractalmind-ai/fractal-demail/client-go/listener"
+	"github.com/fractalmind-ai/fractal-demail/client-go/schema"
+	gasstation "github.com/fractalmind-ai/fractal-demail/gas-station-adapter"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+const (
+	defaultDemailPollInterval = 2 * time.Second
+	demailClockObjectID       = "0x6"
+	demailGasBudget           = "10000000"
+)
+
+// DemailOptions configures the demail channel.
+type DemailOptions struct {
+	// RPCURL is the Sui JSON-RPC endpoint polled for MessageSent events.
+	RPCURL string
+	// PackageID is the fractal-demail Move package id.
+	PackageID string
+	// Address is this node's Sui address (inbound recipient / outbound sender).
+	Address string
+	// IdentityKeyFile is a path to a base64 Ed25519 private key (32-byte seed
+	// or 64-byte key). It is read at Start and never logged.
+	IdentityKeyFile string
+	// SponsorAddress is the gas sponsor Sui address for outbound sends.
+	SponsorAddress string
+	// GasCoin is the sponsor-owned gas coin object id used by outbound sends.
+	GasCoin string
+	// PollInterval controls inbound event polling. Zero uses the default (2s).
+	PollInterval time.Duration
+	// AllowedSenders is an allowlist of Sui addresses. Empty means deny all.
+	AllowedSenders []string
+	// Peers maps a recipient Sui address to its base64 Ed25519 public key.
+	// A Sui address cannot be reversed into a public key, so outbound sends
+	// require an explicit entry here.
+	Peers map[string]string
+}
+
+// DemailChannel implements the Channel interface over fractal-demail:
+// on-chain encrypted agent mail on Sui.
+//
+// Inbound: a fractal-demail listener polls MessageSent events, decrypts and
+// sanitizes each message, and this channel hands it to the shared
+// IncomingMessageHandler (same pathway as telegram/discord/imessage). The
+// sender identity and chat id are both the sender's Sui address.
+//
+// Security posture: AllowedSenders is an explicit allowlist; when it is empty
+// every sender is denied, matching the deny-all default of the other gateway
+// channels.
+type DemailChannel struct {
+	rpcURL          string
+	packageID       string
+	address         string
+	identityKeyFile string
+	sponsorAddress  string
+	gasCoin         string
+	pollInterval    time.Duration
+
+	allowlist DemailAllowlist
+	// peers maps normalized recipient address -> Ed25519 public key.
+	peers map[string]ed25519.PublicKey
+
+	handler IncomingMessageHandler
+
+	// execFn runs an external command; injectable so tests can mock the sui CLI.
+	execFn func(ctx context.Context, name string, args ...string) ([]byte, error)
+	// runListenerFn runs the inbound loop until ctx is cancelled; injectable so
+	// tests can feed fake events without a network. Nil means the real
+	// fractal-demail listener is built at Start.
+	runListenerFn func(ctx context.Context) error
+	// nowFn provides plaintext timestamps; injectable for deterministic tests.
+	nowFn func() time.Time
+
+	runningMu sync.RWMutex
+	running   bool
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+
+	telemetryMu  sync.RWMutex
+	lastActivity time.Time
+	lastError    time.Time
+}
+
+// NewDemailChannel validates options and returns a demail channel.
+func NewDemailChannel(opts DemailOptions) (*DemailChannel, error) {
+	if strings.TrimSpace(opts.RPCURL) == "" {
+		return nil, errors.New("demail rpcUrl is required")
+	}
+	if strings.TrimSpace(opts.PackageID) == "" {
+		return nil, errors.New("demail packageId is required")
+	}
+	address, err := normalizeDemailAddress(opts.Address)
+	if err != nil {
+		return nil, fmt.Errorf("demail address: %w", err)
+	}
+
+	sponsor := strings.TrimSpace(opts.SponsorAddress)
+	if sponsor != "" {
+		if sponsor, err = normalizeDemailAddress(sponsor); err != nil {
+			return nil, fmt.Errorf("demail sponsorAddress: %w", err)
+		}
+	}
+
+	allowlist, err := NewDemailAllowlist(opts.AllowedSenders)
+	if err != nil {
+		return nil, err
+	}
+
+	peers := make(map[string]ed25519.PublicKey, len(opts.Peers))
+	for addr, pubB64 := range opts.Peers {
+		normalized, err := normalizeDemailAddress(addr)
+		if err != nil {
+			return nil, fmt.Errorf("demail peers[%s]: %w", addr, err)
+		}
+		pub, err := base64.StdEncoding.DecodeString(strings.TrimSpace(pubB64))
+		if err != nil {
+			return nil, fmt.Errorf("demail peers[%s]: invalid base64 public key", addr)
+		}
+		if len(pub) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("demail peers[%s]: public key must be %d bytes, got %d", addr, ed25519.PublicKeySize, len(pub))
+		}
+		peers[normalized] = ed25519.PublicKey(pub)
+	}
+
+	pollInterval := opts.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = defaultDemailPollInterval
+	}
+
+	channel := &DemailChannel{
+		rpcURL:          strings.TrimSpace(opts.RPCURL),
+		packageID:       strings.TrimSpace(opts.PackageID),
+		address:         address,
+		identityKeyFile: strings.TrimSpace(opts.IdentityKeyFile),
+		sponsorAddress:  sponsor,
+		gasCoin:         strings.TrimSpace(opts.GasCoin),
+		pollInterval:    pollInterval,
+		allowlist:       allowlist,
+		peers:           peers,
+		nowFn:           time.Now,
+	}
+	channel.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		return exec.CommandContext(ctx, name, args...).CombinedOutput()
+	}
+	return channel, nil
+}
+
+func (b *DemailChannel) Name() string {
+	return "demail"
+}
+
+func (b *DemailChannel) SetHandler(handler IncomingMessageHandler) {
+	b.handler = handler
+}
+
+func (b *DemailChannel) IsRunning() bool {
+	b.runningMu.RLock()
+	defer b.runningMu.RUnlock()
+	return b.running
+}
+
+func (b *DemailChannel) setRunning(running bool) {
+	b.runningMu.Lock()
+	b.running = running
+	b.runningMu.Unlock()
+}
+
+// LastActivity reports the last successful send or inbound handling time.
+func (b *DemailChannel) LastActivity() time.Time {
+	b.telemetryMu.RLock()
+	defer b.telemetryMu.RUnlock()
+	return b.lastActivity
+}
+
+// LastError reports the last channel error time.
+func (b *DemailChannel) LastError() time.Time {
+	b.telemetryMu.RLock()
+	defer b.telemetryMu.RUnlock()
+	return b.lastError
+}
+
+func (b *DemailChannel) markActivity() {
+	b.telemetryMu.Lock()
+	b.lastActivity = time.Now().UTC()
+	b.telemetryMu.Unlock()
+}
+
+func (b *DemailChannel) markError() {
+	b.telemetryMu.Lock()
+	b.lastError = time.Now().UTC()
+	b.telemetryMu.Unlock()
+}
+
+// Start builds the inbound listener and runs it until Stop or ctx cancel.
+func (b *DemailChannel) Start(ctx context.Context) error {
+	b.ctx, b.cancel = context.WithCancel(ctx)
+
+	runFn := b.runListenerFn
+	if runFn == nil {
+		identityKey, err := loadDemailIdentityKey(b.identityKeyFile)
+		if err != nil {
+			b.cancel()
+			return err
+		}
+		inbound, err := listener.New(listener.Config{
+			RPCURL:       b.rpcURL,
+			PackageID:    b.packageID,
+			Recipient:    b.address,
+			IdentityKey:  identityKey,
+			PollInterval: b.pollInterval,
+		}, func(messageID string, msg *schema.Plaintext) {
+			b.handleInbound(messageID, msg)
+		})
+		if err != nil {
+			b.cancel()
+			return fmt.Errorf("demail listener init failed: %w", err)
+		}
+		runFn = inbound.Run
+	}
+
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		if err := runFn(b.ctx); err != nil && b.ctx.Err() == nil {
+			log.Printf("demail listener exited: %v", err)
+			b.markError()
+		}
+	}()
+
+	b.setRunning(true)
+	return nil
+}
+
+// Stop cancels the listener context and waits for the poll loop to exit.
+func (b *DemailChannel) Stop(ctx context.Context) error {
+	_ = ctx
+	if b.cancel != nil {
+		b.cancel()
+	}
+	b.wg.Wait()
+	b.setRunning(false)
+	return nil
+}
+
+// IsAllowed reports whether the sender Sui address is on the allowlist.
+// An empty allowlist denies all senders.
+func (b *DemailChannel) IsAllowed(senderID string) bool {
+	return b.allowlist.Allowed(senderID)
+}
+
+// handleInbound delivers one decrypted message to the shared inbound handler.
+// Input is untrusted even after schema sanitization; it must never panic.
+func (b *DemailChannel) handleInbound(messageID string, msg *schema.Plaintext) {
+	if msg == nil {
+		return
+	}
+	from := strings.ToLower(strings.TrimSpace(msg.From))
+	if from == "" {
+		return
+	}
+	if !b.allowlist.Allowed(from) {
+		log.Printf("demail: dropping message %s from non-allowlisted sender %s", messageID, from)
+		return
+	}
+	if b.handler == nil {
+		return
+	}
+
+	ctx := b.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	reply, err := b.handler.HandleIncoming(ctx, b.toProtocolMessage(messageID, from, msg))
+	if err != nil {
+		b.markError()
+		log.Printf("demail inbound handler failed for message %s: %v", messageID, err)
+		return
+	}
+	b.markActivity()
+
+	if trimmed := strings.TrimSpace(reply); trimmed != "" {
+		if _, err := b.Send(ctx, OutboundMessage{To: from, Text: trimmed}); err != nil {
+			log.Printf("demail reply send failed: %v", err)
+		}
+	}
+}
+
+func (b *DemailChannel) toProtocolMessage(messageID, from string, msg *schema.Plaintext) *protocol.Message {
+	return &protocol.Message{
+		Kind:   protocol.MessageKindChannel,
+		Action: protocol.ActionCreate,
+		Data: map[string]interface{}{
+			"channel":    "demail",
+			"text":       msg.Body,
+			"agent":      "",
+			"user_id":    from,
+			"chat_id":    from,
+			"sender":     from,
+			"message_id": messageID,
+			"subject":    msg.Subject,
+			"msg_type":   msg.Type,
+			"reply_to":   msg.ReplyTo,
+			"timestamp":  msg.TS,
+			"chatType":   "dm",
+		},
+	}
+}
+
+// Send encrypts msg.Text to the recipient's registered Ed25519 key and
+// submits a sponsored demail::send_inline transaction through the sui CLI.
+// The transaction digest is returned in SendResult.MessageTS (documented
+// choice: MessageTS is the closest analogue to a per-message id; ChannelID
+// carries the recipient address).
+func (b *DemailChannel) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
+	recipient, err := normalizeDemailAddress(msg.To)
+	if err != nil {
+		return nil, fmt.Errorf("demail recipient: %w", err)
+	}
+	text := strings.TrimSpace(msg.Text)
+	if text == "" {
+		return nil, errors.New("demail text is required")
+	}
+	if b.sponsorAddress == "" {
+		return nil, errors.New("demail sponsorAddress is required for outbound sends")
+	}
+	if b.gasCoin == "" {
+		return nil, errors.New("demail gasCoin is required for outbound sends")
+	}
+	if b.execFn == nil {
+		return nil, errors.New("demail command runner not configured")
+	}
+
+	recipientPub, ok := b.peers[recipient]
+	if !ok {
+		return nil, fmt.Errorf("demail: no peer public key configured for %s (add it to channels.demail.peers)", recipient)
+	}
+
+	senderRaw, err := demailAddressBytes(b.address)
+	if err != nil {
+		return nil, fmt.Errorf("demail sender address: %w", err)
+	}
+	recipientRaw, err := demailAddressBytes(recipient)
+	if err != nil {
+		return nil, fmt.Errorf("demail recipient address: %w", err)
+	}
+
+	plaintext, err := json.Marshal(schema.Plaintext{
+		Type: schema.TypeReply,
+		From: b.address,
+		To:   recipient,
+		Body: text,
+		TS:   b.nowFn().UnixMilli(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("demail plaintext encode failed: %w", err)
+	}
+
+	env, err := envelope.Seal(recipientPub, senderRaw, recipientRaw, plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("demail envelope seal failed: %w", err)
+	}
+	envJSON, err := env.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("demail envelope encode failed: %w", err)
+	}
+	payloadB64 := base64.StdEncoding.EncodeToString(envJSON)
+
+	txBytes, err := b.serializeUnsignedTx(ctx, recipient, payloadB64)
+	if err != nil {
+		b.markError()
+		return nil, err
+	}
+
+	transport := &demailCLITransport{execFn: b.execFn}
+	relay, err := gasstation.New(gasstation.Route{Sender: b.address, GasSponsor: b.sponsorAddress}, transport)
+	if err != nil {
+		return nil, fmt.Errorf("demail relay init failed: %w", err)
+	}
+
+	request, err := relay.Sponsor(ctx, []byte(txBytes), b.suiSigner(b.address), b.suiSigner(b.sponsorAddress))
+	if err != nil {
+		b.markError()
+		return nil, fmt.Errorf("demail sponsor signing failed: %w", err)
+	}
+	if err := relay.Relay(ctx, request); err != nil {
+		b.markError()
+		return nil, fmt.Errorf("demail relay failed: %w", err)
+	}
+
+	b.markActivity()
+	return &SendResult{
+		ChannelName: "demail",
+		ChannelID:   recipient,
+		MessageTS:   transport.digest,
+	}, nil
+}
+
+// serializeUnsignedTx builds the sponsored PTB and returns base64 tx bytes.
+func (b *DemailChannel) serializeUnsignedTx(ctx context.Context, recipient, payloadB64 string) (string, error) {
+	args := []string{
+		"client", "ptb",
+		"--sender", "@" + b.address,
+		"--move-call", b.packageID + "::demail::send_inline",
+		"@" + recipient,
+		`"` + payloadB64 + `"`,
+		"@" + demailClockObjectID,
+		"--gas-sponsor", "@" + b.sponsorAddress,
+		"--gas-coin", "@" + b.gasCoin,
+		"--gas-budget", demailGasBudget,
+		"--serialize-unsigned-transaction",
+	}
+	output, err := b.execFn(ctx, "sui", args...)
+	if err != nil {
+		return "", fmt.Errorf("demail tx serialization failed: %w", err)
+	}
+	txBytes := lastNonEmptyLine(string(output))
+	if txBytes == "" {
+		return "", errors.New("demail tx serialization returned no tx bytes")
+	}
+	return txBytes, nil
+}
+
+// suiSigner signs base64 tx bytes with the sui keytool for the given address.
+// The returned bytes are the base64 .suiSignature string.
+func (b *DemailChannel) suiSigner(address string) gasstation.Signer {
+	return func(ctx context.Context, txBytes []byte) ([]byte, error) {
+		output, err := b.execFn(ctx, "sui", "keytool", "sign", "--address", address, "--data", string(txBytes), "--json")
+		if err != nil {
+			return nil, fmt.Errorf("sui keytool sign failed for %s: %w", address, err)
+		}
+		var result struct {
+			SuiSignature string `json:"suiSignature"`
+		}
+		if err := unmarshalDemailCLIJSON(output, &result); err != nil {
+			return nil, fmt.Errorf("sui keytool sign returned invalid json for %s: %w", address, err)
+		}
+		signature := strings.TrimSpace(result.SuiSignature)
+		if signature == "" {
+			return nil, fmt.Errorf("sui keytool sign returned empty suiSignature for %s", address)
+		}
+		return []byte(signature), nil
+	}
+}
+
+// demailCLITransport executes the dual-signed transaction via the sui CLI,
+// keeping the gasstation route/signature invariants on the outbound path.
+type demailCLITransport struct {
+	execFn func(ctx context.Context, name string, args ...string) ([]byte, error)
+	digest string
+}
+
+func (t *demailCLITransport) Relay(ctx context.Context, req gasstation.RelayRequest) error {
+	output, err := t.execFn(ctx, "sui",
+		"client", "execute-signed-tx",
+		"--tx-bytes", string(req.UnsignedTx),
+		"--signatures", string(req.SenderSignature),
+		"--signatures", string(req.SponsorSignature),
+		"--json",
+	)
+	if err != nil {
+		return fmt.Errorf("sui execute-signed-tx failed: %w", err)
+	}
+	var result struct {
+		Digest string `json:"digest"`
+	}
+	if err := unmarshalDemailCLIJSON(output, &result); err != nil {
+		return fmt.Errorf("sui execute-signed-tx returned invalid json: %w", err)
+	}
+	if strings.TrimSpace(result.Digest) == "" {
+		return errors.New("sui execute-signed-tx returned no digest")
+	}
+	t.digest = strings.TrimSpace(result.Digest)
+	return nil
+}
+
+// DemailAllowlist is an allowlist of normalized Sui addresses.
+// Empty means deny all (gateway security posture).
+type DemailAllowlist struct {
+	configured bool
+	allowed    map[string]struct{}
+}
+
+// NewDemailAllowlist normalizes and validates allowlist entries.
+func NewDemailAllowlist(values []string) (DemailAllowlist, error) {
+	allowed := make(map[string]struct{})
+	for idx, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		normalized, err := normalizeDemailAddress(trimmed)
+		if err != nil {
+			return DemailAllowlist{}, fmt.Errorf("demail allowedSenders[%d]: %w", idx, err)
+		}
+		allowed[normalized] = struct{}{}
+	}
+	return DemailAllowlist{configured: len(allowed) > 0, allowed: allowed}, nil
+}
+
+// Allowed reports whether the address is allowlisted. Deny all when empty.
+func (a DemailAllowlist) Allowed(address string) bool {
+	if !a.configured {
+		return false
+	}
+	normalized, err := normalizeDemailAddress(address)
+	if err != nil {
+		return false
+	}
+	_, ok := a.allowed[normalized]
+	return ok
+}
+
+// loadDemailIdentityKey reads a base64 Ed25519 private key (32-byte seed or
+// 64-byte key) from path. Key material is never logged.
+func loadDemailIdentityKey(path string) (ed25519.PrivateKey, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("demail identityKeyFile is required")
+	}
+	expanded, err := expandHomePath(path)
+	if err != nil {
+		return nil, fmt.Errorf("demail identityKeyFile: %w", err)
+	}
+	data, err := os.ReadFile(expanded)
+	if err != nil {
+		return nil, fmt.Errorf("demail identityKeyFile: %w", err)
+	}
+	raw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(string(data)))
+	if err != nil {
+		return nil, errors.New("demail identityKeyFile: content must be base64")
+	}
+	switch len(raw) {
+	case ed25519.SeedSize:
+		return ed25519.NewKeyFromSeed(raw), nil
+	case ed25519.PrivateKeySize:
+		return ed25519.PrivateKey(raw), nil
+	default:
+		return nil, fmt.Errorf("demail identityKeyFile: key must be %d-byte seed or %d-byte key, got %d bytes", ed25519.SeedSize, ed25519.PrivateKeySize, len(raw))
+	}
+}
+
+// normalizeDemailAddress lowercases and validates a 0x-prefixed 32-byte
+// Sui address.
+func normalizeDemailAddress(address string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(address))
+	if _, err := demailAddressBytes(normalized); err != nil {
+		return "", err
+	}
+	return normalized, nil
+}
+
+// demailAddressBytes converts a 0x-prefixed Sui address to raw 32 bytes.
+func demailAddressBytes(address string) ([]byte, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(address))
+	if !strings.HasPrefix(trimmed, "0x") {
+		return nil, fmt.Errorf("invalid sui address %q", address)
+	}
+	raw, err := hex.DecodeString(strings.TrimPrefix(trimmed, "0x"))
+	if err != nil || len(raw) != 32 {
+		return nil, fmt.Errorf("invalid sui address %q", address)
+	}
+	return raw, nil
+}
+
+// unmarshalDemailCLIJSON parses JSON from CLI output, tolerating any
+// non-JSON preamble the sui CLI prints before the JSON document.
+func unmarshalDemailCLIJSON(output []byte, out interface{}) error {
+	start := -1
+	for i, c := range output {
+		if c == '{' || c == '[' {
+			start = i
+			break
+		}
+	}
+	if start == -1 {
+		return errors.New("no json document in output")
+	}
+	return json.Unmarshal(output[start:], out)
+}
+
+func lastNonEmptyLine(output string) string {
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if trimmed := strings.TrimSpace(lines[i]); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/internal/channels/demail_test.go
+++ b/internal/channels/demail_test.go
@@ -1,0 +1,546 @@
+package channels
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractal-demail/client-go/envelope"
+	"github.com/fractalmind-ai/fractal-demail/client-go/schema"
+
+	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
+)
+
+var (
+	demailTestAddress   = "0x" + strings.Repeat("11", 32)
+	demailTestPeer      = "0x" + strings.Repeat("22", 32)
+	demailTestSponsor   = "0x" + strings.Repeat("33", 32)
+	demailTestGasCoin   = "0x" + strings.Repeat("44", 32)
+	demailTestPackageID = "0x" + strings.Repeat("55", 32)
+)
+
+type fakeDemailHandler struct {
+	reply string
+	err   error
+	calls int
+	msgs  []*protocol.Message
+}
+
+func (f *fakeDemailHandler) HandleIncoming(ctx context.Context, msg *protocol.Message) (string, error) {
+	_ = ctx
+	f.calls++
+	f.msgs = append(f.msgs, msg)
+	return f.reply, f.err
+}
+
+func newTestDemailChannel(t *testing.T, opts DemailOptions) *DemailChannel {
+	t.Helper()
+	if opts.RPCURL == "" {
+		opts.RPCURL = "http://127.0.0.1:9000"
+	}
+	if opts.PackageID == "" {
+		opts.PackageID = demailTestPackageID
+	}
+	if opts.Address == "" {
+		opts.Address = demailTestAddress
+	}
+	channel, err := NewDemailChannel(opts)
+	if err != nil {
+		t.Fatalf("NewDemailChannel: %v", err)
+	}
+	return channel
+}
+
+func TestNewDemailChannelValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		opts    DemailOptions
+		wantErr string
+	}{
+		{
+			name:    "missing rpc url",
+			opts:    DemailOptions{PackageID: demailTestPackageID, Address: demailTestAddress},
+			wantErr: "rpcUrl",
+		},
+		{
+			name:    "missing package id",
+			opts:    DemailOptions{RPCURL: "http://127.0.0.1:9000", Address: demailTestAddress},
+			wantErr: "packageId",
+		},
+		{
+			name:    "invalid address",
+			opts:    DemailOptions{RPCURL: "http://127.0.0.1:9000", PackageID: demailTestPackageID, Address: "0x123"},
+			wantErr: "address",
+		},
+		{
+			name: "invalid sponsor address",
+			opts: DemailOptions{
+				RPCURL: "http://127.0.0.1:9000", PackageID: demailTestPackageID, Address: demailTestAddress,
+				SponsorAddress: "not-an-address",
+			},
+			wantErr: "sponsorAddress",
+		},
+		{
+			name: "invalid allowlist entry",
+			opts: DemailOptions{
+				RPCURL: "http://127.0.0.1:9000", PackageID: demailTestPackageID, Address: demailTestAddress,
+				AllowedSenders: []string{"0xzz"},
+			},
+			wantErr: "allowedSenders[0]",
+		},
+		{
+			name: "invalid peer address",
+			opts: DemailOptions{
+				RPCURL: "http://127.0.0.1:9000", PackageID: demailTestPackageID, Address: demailTestAddress,
+				Peers: map[string]string{"bogus": base64.StdEncoding.EncodeToString(make([]byte, ed25519.PublicKeySize))},
+			},
+			wantErr: "peers[bogus]",
+		},
+		{
+			name: "invalid peer public key encoding",
+			opts: DemailOptions{
+				RPCURL: "http://127.0.0.1:9000", PackageID: demailTestPackageID, Address: demailTestAddress,
+				Peers: map[string]string{demailTestPeer: "%%%not-base64%%%"},
+			},
+			wantErr: "invalid base64 public key",
+		},
+		{
+			name: "invalid peer public key length",
+			opts: DemailOptions{
+				RPCURL: "http://127.0.0.1:9000", PackageID: demailTestPackageID, Address: demailTestAddress,
+				Peers: map[string]string{demailTestPeer: base64.StdEncoding.EncodeToString(make([]byte, 16))},
+			},
+			wantErr: "public key must be 32 bytes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewDemailChannel(tt.opts)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDemailAllowlistDeniesAllWhenEmpty(t *testing.T) {
+	channel := newTestDemailChannel(t, DemailOptions{})
+	if channel.IsAllowed(demailTestPeer) {
+		t.Fatal("empty allowlist must deny all senders")
+	}
+}
+
+func TestDemailIsAllowedNormalizesCase(t *testing.T) {
+	channel := newTestDemailChannel(t, DemailOptions{AllowedSenders: []string{demailTestPeer}})
+	if !channel.IsAllowed("0x" + strings.ToUpper(strings.Repeat("22", 32))) {
+		t.Fatal("allowlist must be case-insensitive")
+	}
+	if channel.IsAllowed(demailTestSponsor) {
+		t.Fatal("unlisted sender must be denied")
+	}
+	if channel.IsAllowed("garbage") {
+		t.Fatal("malformed sender must be denied")
+	}
+}
+
+func TestDemailInboundDelivery(t *testing.T) {
+	tests := []struct {
+		name        string
+		from        string
+		wantHandled bool
+	}{
+		{name: "allowed sender delivers", from: demailTestPeer, wantHandled: true},
+		{name: "unknown sender blocked", from: demailTestSponsor, wantHandled: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &fakeDemailHandler{}
+			channel := newTestDemailChannel(t, DemailOptions{AllowedSenders: []string{demailTestPeer}})
+			channel.SetHandler(handler)
+
+			delivered := make(chan struct{})
+			channel.runListenerFn = func(ctx context.Context) error {
+				channel.handleInbound("0xmsg1", &schema.Plaintext{
+					Type: schema.TypeTask,
+					From: tt.from,
+					To:   demailTestAddress,
+					Body: "run the tests",
+					TS:   1234,
+				})
+				close(delivered)
+				<-ctx.Done()
+				return ctx.Err()
+			}
+
+			if err := channel.Start(context.Background()); err != nil {
+				t.Fatalf("Start: %v", err)
+			}
+			<-delivered
+			if err := channel.Stop(context.Background()); err != nil {
+				t.Fatalf("Stop: %v", err)
+			}
+
+			if !tt.wantHandled {
+				if handler.calls != 0 {
+					t.Fatalf("expected handler not to be called, got %d calls", handler.calls)
+				}
+				return
+			}
+			if handler.calls != 1 {
+				t.Fatalf("expected 1 handler call, got %d", handler.calls)
+			}
+			data, ok := handler.msgs[0].Data.(map[string]interface{})
+			if !ok {
+				t.Fatalf("expected map data, got %T", handler.msgs[0].Data)
+			}
+			if data["channel"] != "demail" {
+				t.Fatalf("expected channel demail, got %v", data["channel"])
+			}
+			if data["user_id"] != tt.from {
+				t.Fatalf("expected user_id %s, got %v", tt.from, data["user_id"])
+			}
+			if data["chat_id"] != tt.from {
+				t.Fatalf("expected chat_id %s, got %v", tt.from, data["chat_id"])
+			}
+			if data["text"] != "run the tests" {
+				t.Fatalf("expected body text, got %v", data["text"])
+			}
+			if data["message_id"] != "0xmsg1" {
+				t.Fatalf("expected message_id 0xmsg1, got %v", data["message_id"])
+			}
+		})
+	}
+}
+
+func TestDemailInboundSurvivesMalformedInput(t *testing.T) {
+	handler := &fakeDemailHandler{}
+	channel := newTestDemailChannel(t, DemailOptions{AllowedSenders: []string{demailTestPeer}})
+	channel.SetHandler(handler)
+
+	// Must not panic on nil or partially-populated plaintexts.
+	channel.handleInbound("0xmsg1", nil)
+	channel.handleInbound("0xmsg2", &schema.Plaintext{})
+	channel.handleInbound("0xmsg3", &schema.Plaintext{From: "not-an-address"})
+
+	if handler.calls != 0 {
+		t.Fatalf("expected no handler calls for malformed input, got %d", handler.calls)
+	}
+}
+
+func TestDemailStopTerminatesListener(t *testing.T) {
+	channel := newTestDemailChannel(t, DemailOptions{})
+	stopped := make(chan struct{})
+	channel.runListenerFn = func(ctx context.Context) error {
+		<-ctx.Done()
+		close(stopped)
+		return ctx.Err()
+	}
+
+	if err := channel.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if !channel.IsRunning() {
+		t.Fatal("expected channel to be running after Start")
+	}
+
+	if err := channel.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+	select {
+	case <-stopped:
+	case <-time.After(2 * time.Second):
+		t.Fatal("listener did not terminate after Stop")
+	}
+	if channel.IsRunning() {
+		t.Fatal("expected channel to not be running after Stop")
+	}
+}
+
+func TestDemailStartRequiresIdentityKey(t *testing.T) {
+	channel := newTestDemailChannel(t, DemailOptions{})
+	err := channel.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected Start to fail without identityKeyFile")
+	}
+	if !strings.Contains(err.Error(), "identityKeyFile") {
+		t.Fatalf("expected identityKeyFile error, got %v", err)
+	}
+	if channel.IsRunning() {
+		t.Fatal("channel must not report running after failed Start")
+	}
+}
+
+func TestLoadDemailIdentityKey(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	fullKey := ed25519.NewKeyFromSeed(seed)
+
+	writeKey := func(t *testing.T, content string) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), "identity.key")
+		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+			t.Fatalf("write key: %v", err)
+		}
+		return path
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr string
+	}{
+		{name: "32-byte seed", content: base64.StdEncoding.EncodeToString(seed)},
+		{name: "64-byte key", content: base64.StdEncoding.EncodeToString(fullKey)},
+		{name: "seed with trailing newline", content: base64.StdEncoding.EncodeToString(seed) + "\n"},
+		{name: "not base64", content: "%%%", wantErr: "must be base64"},
+		{name: "wrong length", content: base64.StdEncoding.EncodeToString(make([]byte, 16)), wantErr: "32-byte seed or 64-byte key"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key, err := loadDemailIdentityKey(writeKey(t, tt.content))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadDemailIdentityKey: %v", err)
+			}
+			if !key.Equal(fullKey) {
+				t.Fatal("loaded key does not match expected key")
+			}
+		})
+	}
+
+	if _, err := loadDemailIdentityKey(""); err == nil {
+		t.Fatal("expected error for empty path")
+	}
+	if _, err := loadDemailIdentityKey(filepath.Join(t.TempDir(), "missing.key")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+type demailExecCall struct {
+	name string
+	args []string
+}
+
+func TestDemailSendCLISequence(t *testing.T) {
+	recipientPub, recipientPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate recipient key: %v", err)
+	}
+
+	channel := newTestDemailChannel(t, DemailOptions{
+		SponsorAddress: demailTestSponsor,
+		GasCoin:        demailTestGasCoin,
+		Peers: map[string]string{
+			demailTestPeer: base64.StdEncoding.EncodeToString(recipientPub),
+		},
+	})
+	channel.nowFn = func() time.Time { return time.UnixMilli(1750000000000) }
+
+	const txBytes = "dGVzdC10eC1ieXRlcw=="
+	var calls []demailExecCall
+	channel.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		calls = append(calls, demailExecCall{name: name, args: append([]string{}, args...)})
+		switch {
+		case len(args) > 1 && args[0] == "client" && args[1] == "ptb":
+			return []byte(txBytes + "\n"), nil
+		case len(args) > 1 && args[0] == "keytool" && args[1] == "sign":
+			if args[3] == demailTestAddress {
+				return []byte(`{"suiSignature":"sig-sender"}`), nil
+			}
+			return []byte(`{"suiSignature":"sig-sponsor"}`), nil
+		case len(args) > 1 && args[0] == "client" && args[1] == "execute-signed-tx":
+			return []byte(`{"digest":"DIGEST123"}`), nil
+		default:
+			return nil, errors.New("unexpected command")
+		}
+	}
+
+	result, err := channel.Send(context.Background(), OutboundMessage{To: demailTestPeer, Text: "hello peer"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if result.MessageTS != "DIGEST123" {
+		t.Fatalf("expected digest in MessageTS, got %q", result.MessageTS)
+	}
+	if result.ChannelID != demailTestPeer {
+		t.Fatalf("expected recipient in ChannelID, got %q", result.ChannelID)
+	}
+	if result.ChannelName != "demail" {
+		t.Fatalf("expected ChannelName demail, got %q", result.ChannelName)
+	}
+
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 CLI calls, got %d", len(calls))
+	}
+	for i, call := range calls {
+		if call.name != "sui" {
+			t.Fatalf("call %d: expected sui binary, got %q", i, call.name)
+		}
+	}
+
+	// Call 1: serialize the sponsored PTB. The envelope payload is random
+	// (ephemeral key + nonce), so capture it and verify separately.
+	ptbArgs := calls[0].args
+	if len(ptbArgs) != 16 {
+		t.Fatalf("expected 16 ptb args, got %d: %v", len(ptbArgs), ptbArgs)
+	}
+	payloadArg := ptbArgs[7]
+	expectedPtb := []string{
+		"client", "ptb",
+		"--sender", "@" + demailTestAddress,
+		"--move-call", demailTestPackageID + "::demail::send_inline",
+		"@" + demailTestPeer,
+		payloadArg,
+		"@0x6",
+		"--gas-sponsor", "@" + demailTestSponsor,
+		"--gas-coin", "@" + demailTestGasCoin,
+		"--gas-budget", "10000000",
+		"--serialize-unsigned-transaction",
+	}
+	if !reflect.DeepEqual(ptbArgs, expectedPtb) {
+		t.Fatalf("unexpected ptb args:\n got %v\nwant %v", ptbArgs, expectedPtb)
+	}
+
+	// Calls 2+3: dual signatures over the identical tx bytes.
+	expectedSenderSign := []string{"keytool", "sign", "--address", demailTestAddress, "--data", txBytes, "--json"}
+	if !reflect.DeepEqual(calls[1].args, expectedSenderSign) {
+		t.Fatalf("unexpected sender sign args:\n got %v\nwant %v", calls[1].args, expectedSenderSign)
+	}
+	expectedSponsorSign := []string{"keytool", "sign", "--address", demailTestSponsor, "--data", txBytes, "--json"}
+	if !reflect.DeepEqual(calls[2].args, expectedSponsorSign) {
+		t.Fatalf("unexpected sponsor sign args:\n got %v\nwant %v", calls[2].args, expectedSponsorSign)
+	}
+
+	// Call 4: execution with both signatures in sender, sponsor order.
+	expectedExecute := []string{
+		"client", "execute-signed-tx",
+		"--tx-bytes", txBytes,
+		"--signatures", "sig-sender",
+		"--signatures", "sig-sponsor",
+		"--json",
+	}
+	if !reflect.DeepEqual(calls[3].args, expectedExecute) {
+		t.Fatalf("unexpected execute args:\n got %v\nwant %v", calls[3].args, expectedExecute)
+	}
+
+	// The payload must be a quoted base64 envelope sealed to the recipient's
+	// Ed25519 key with the on-chain route as AAD.
+	if !strings.HasPrefix(payloadArg, `"`) || !strings.HasSuffix(payloadArg, `"`) {
+		t.Fatalf("expected quoted payload arg, got %q", payloadArg)
+	}
+	envJSON, err := base64.StdEncoding.DecodeString(strings.Trim(payloadArg, `"`))
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	env, err := envelope.Unmarshal(envJSON)
+	if err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	senderRaw, err := demailAddressBytes(demailTestAddress)
+	if err != nil {
+		t.Fatalf("sender address bytes: %v", err)
+	}
+	recipientRaw, err := demailAddressBytes(demailTestPeer)
+	if err != nil {
+		t.Fatalf("recipient address bytes: %v", err)
+	}
+	plaintext, err := envelope.Open(recipientPriv, senderRaw, recipientRaw, env)
+	if err != nil {
+		t.Fatalf("envelope must decrypt with the recipient key: %v", err)
+	}
+	parsed, err := schema.Parse(plaintext, demailTestAddress, demailTestPeer)
+	if err != nil {
+		t.Fatalf("plaintext must satisfy the demail schema: %v", err)
+	}
+	if parsed.Type != schema.TypeReply {
+		t.Fatalf("expected type reply, got %q", parsed.Type)
+	}
+	if parsed.Body != "hello peer" {
+		t.Fatalf("expected body 'hello peer', got %q", parsed.Body)
+	}
+	if parsed.TS != 1750000000000 {
+		t.Fatalf("expected ts 1750000000000, got %d", parsed.TS)
+	}
+}
+
+func TestDemailSendFailures(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	peerKey := base64.StdEncoding.EncodeToString(pub)
+
+	tests := []struct {
+		name    string
+		opts    DemailOptions
+		msg     OutboundMessage
+		wantErr string
+	}{
+		{
+			name:    "unknown peer",
+			opts:    DemailOptions{SponsorAddress: demailTestSponsor, GasCoin: demailTestGasCoin},
+			msg:     OutboundMessage{To: demailTestPeer, Text: "hi"},
+			wantErr: "no peer public key configured",
+		},
+		{
+			name:    "invalid recipient",
+			opts:    DemailOptions{SponsorAddress: demailTestSponsor, GasCoin: demailTestGasCoin},
+			msg:     OutboundMessage{To: "0x123", Text: "hi"},
+			wantErr: "recipient",
+		},
+		{
+			name:    "empty text",
+			opts:    DemailOptions{SponsorAddress: demailTestSponsor, GasCoin: demailTestGasCoin},
+			msg:     OutboundMessage{To: demailTestPeer, Text: "  "},
+			wantErr: "text is required",
+		},
+		{
+			name:    "missing sponsor",
+			opts:    DemailOptions{GasCoin: demailTestGasCoin, Peers: map[string]string{demailTestPeer: peerKey}},
+			msg:     OutboundMessage{To: demailTestPeer, Text: "hi"},
+			wantErr: "sponsorAddress is required",
+		},
+		{
+			name:    "missing gas coin",
+			opts:    DemailOptions{SponsorAddress: demailTestSponsor, Peers: map[string]string{demailTestPeer: peerKey}},
+			msg:     OutboundMessage{To: demailTestPeer, Text: "hi"},
+			wantErr: "gasCoin is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			channel := newTestDemailChannel(t, tt.opts)
+			channel.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				t.Fatalf("no CLI command should run, got %s %v", name, args)
+				return nil, nil
+			}
+			_, err := channel.Send(context.Background(), tt.msg)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}

--- a/internal/channels/demail_test.go
+++ b/internal/channels/demail_test.go
@@ -240,6 +240,66 @@ func TestDemailInboundSurvivesMalformedInput(t *testing.T) {
 	}
 }
 
+func TestDemailDoesNotAutoReplyToReplyMessages(t *testing.T) {
+	handler := &fakeDemailHandler{reply: "pong"}
+	channel := newTestDemailChannel(t, DemailOptions{
+		AllowedSenders: []string{demailTestPeer},
+		SponsorAddress: demailTestSponsor,
+		GasCoin:        demailTestGasCoin,
+	})
+	channel.SetHandler(handler)
+	channel.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		t.Fatalf("reply-type inbound must not trigger outbound send, got %s %v", name, args)
+		return nil, nil
+	}
+
+	channel.handleInbound("0xreply-msg", &schema.Plaintext{
+		Type: schema.TypeReply,
+		From: demailTestPeer,
+		To:   demailTestAddress,
+		Body: "already a reply",
+		TS:   1234,
+	})
+
+	if handler.calls != 1 {
+		t.Fatalf("expected handler to see the reply once, got %d", handler.calls)
+	}
+}
+
+func TestDemailProcessedMessageDedupPersists(t *testing.T) {
+	cursor := filepath.Join(t.TempDir(), "demail-processed.log")
+	msg := &schema.Plaintext{
+		Type: schema.TypeTask,
+		From: demailTestPeer,
+		To:   demailTestAddress,
+		Body: "run once",
+		TS:   1234,
+	}
+
+	firstHandler := &fakeDemailHandler{}
+	first := newTestDemailChannel(t, DemailOptions{CursorFile: cursor, AllowedSenders: []string{demailTestPeer}})
+	first.SetHandler(firstHandler)
+	first.handleInbound("0xmsg-dedup", msg)
+	if firstHandler.calls != 1 {
+		t.Fatalf("expected first handler call, got %d", firstHandler.calls)
+	}
+	data, err := os.ReadFile(cursor)
+	if err != nil {
+		t.Fatalf("read cursor: %v", err)
+	}
+	if !strings.Contains(string(data), "0xmsg-dedup") {
+		t.Fatalf("cursor missing message id: %q", data)
+	}
+
+	secondHandler := &fakeDemailHandler{}
+	second := newTestDemailChannel(t, DemailOptions{CursorFile: cursor, AllowedSenders: []string{demailTestPeer}})
+	second.SetHandler(secondHandler)
+	second.handleInbound("0xmsg-dedup", msg)
+	if secondHandler.calls != 0 {
+		t.Fatalf("expected duplicate replay to be skipped, got %d calls", secondHandler.calls)
+	}
+}
+
 func TestDemailStopTerminatesListener(t *testing.T) {
 	channel := newTestDemailChannel(t, DemailOptions{})
 	stopped := make(chan struct{})

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -385,6 +385,7 @@ func (m *Manager) registerConfiguredChannels() error {
 			SponsorAddress:  m.cfg.Demail.SponsorAddress,
 			GasCoin:         m.cfg.Demail.GasCoin,
 			PollInterval:    time.Duration(m.cfg.Demail.PollIntervalSeconds) * time.Second,
+			CursorFile:      m.cfg.Demail.CursorFile,
 			AllowedSenders:  m.cfg.Demail.AllowedSenders,
 			Peers:           m.cfg.Demail.Peers,
 		})

--- a/internal/channels/manager.go
+++ b/internal/channels/manager.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 )
@@ -365,6 +366,34 @@ func (m *Manager) registerConfiguredChannels() error {
 
 		if err := m.Register(bot); err != nil {
 			return fmt.Errorf("failed to register imessage bot: %w", err)
+		}
+	}
+
+	if m.cfg.Demail != nil && m.cfg.Demail.Enabled {
+		if m.Get("demail") != nil {
+			return nil
+		}
+		if strings.TrimSpace(m.cfg.Demail.RPCURL) == "" || strings.TrimSpace(m.cfg.Demail.PackageID) == "" || strings.TrimSpace(m.cfg.Demail.Address) == "" {
+			return errors.New("channels.demail.rpcUrl, channels.demail.packageId and channels.demail.address are required when demail is enabled")
+		}
+
+		channel, err := NewDemailChannel(DemailOptions{
+			RPCURL:          m.cfg.Demail.RPCURL,
+			PackageID:       m.cfg.Demail.PackageID,
+			Address:         m.cfg.Demail.Address,
+			IdentityKeyFile: m.cfg.Demail.IdentityKeyFile,
+			SponsorAddress:  m.cfg.Demail.SponsorAddress,
+			GasCoin:         m.cfg.Demail.GasCoin,
+			PollInterval:    time.Duration(m.cfg.Demail.PollIntervalSeconds) * time.Second,
+			AllowedSenders:  m.cfg.Demail.AllowedSenders,
+			Peers:           m.cfg.Demail.Peers,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to init demail channel: %w", err)
+		}
+
+		if err := m.Register(channel); err != nil {
+			return fmt.Errorf("failed to register demail channel: %w", err)
 		}
 	}
 

--- a/internal/channels/manager_demail_test.go
+++ b/internal/channels/manager_demail_test.go
@@ -1,0 +1,48 @@
+package channels
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+func TestManagerRegistersDemailChannel(t *testing.T) {
+	manager := NewManager(&config.ChannelsConfig{
+		Demail: &config.DemailConfig{
+			Enabled:   true,
+			RPCURL:    "http://127.0.0.1:9000",
+			PackageID: demailTestPackageID,
+			Address:   demailTestAddress,
+		},
+	}, nil)
+
+	if err := manager.registerConfiguredChannels(); err != nil {
+		t.Fatalf("registerConfiguredChannels: %v", err)
+	}
+
+	channel := manager.Get("demail")
+	if channel == nil {
+		t.Fatal("expected demail channel to be registered")
+	}
+	if channel.Name() != "demail" {
+		t.Fatalf("expected channel name demail, got %q", channel.Name())
+	}
+}
+
+func TestManagerRejectsDemailWithoutRequiredFields(t *testing.T) {
+	manager := NewManager(&config.ChannelsConfig{
+		Demail: &config.DemailConfig{
+			Enabled: true,
+			RPCURL:  "http://127.0.0.1:9000",
+		},
+	}, nil)
+
+	err := manager.registerConfiguredChannels()
+	if err == nil {
+		t.Fatal("expected error for missing demail config fields")
+	}
+	if !strings.Contains(err.Error(), "channels.demail") {
+		t.Fatalf("expected channels.demail error, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -139,6 +139,8 @@ type DemailConfig struct {
 	GasCoin string `yaml:"gasCoin,omitempty"`
 	// PollIntervalSeconds controls inbound event polling. Default: 2.
 	PollIntervalSeconds int `yaml:"pollIntervalSeconds,omitempty"`
+	// CursorFile persists processed Message object ids to prevent replay on restart.
+	CursorFile string `yaml:"cursorFile,omitempty"`
 	// AllowedSenders is an allowlist of sender Sui addresses. Empty means deny all.
 	AllowedSenders []string `yaml:"allowedSenders,omitempty"`
 	// Peers maps a recipient Sui address to its base64 Ed25519 public key.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,6 +34,7 @@ type ChannelsConfig struct {
 	Slack    *SlackConfig    `yaml:"slack,omitempty"`
 	Discord  *DiscordConfig  `yaml:"discord,omitempty"`
 	IMessage *IMessageConfig `yaml:"imessage,omitempty"`
+	Demail   *DemailConfig   `yaml:"demail,omitempty"`
 }
 
 // TelegramConfig contains Telegram channel settings.
@@ -118,6 +119,31 @@ type IMessageConfig struct {
 	PollingLimit int `yaml:"pollingLimit,omitempty"`
 	// DatabasePath overrides Messages DB path. Default: ~/Library/Messages/chat.db.
 	DatabasePath string `yaml:"databasePath,omitempty"`
+}
+
+// DemailConfig contains fractal-demail (on-chain agent mail on Sui) settings.
+type DemailConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
+	// RPCURL is the Sui JSON-RPC endpoint (e.g. https://fullnode.testnet.sui.io:443).
+	RPCURL string `yaml:"rpcUrl,omitempty"`
+	// PackageID is the fractal-demail Move package id.
+	PackageID string `yaml:"packageId,omitempty"`
+	// Address is this node's Sui address (inbound recipient / outbound sender).
+	Address string `yaml:"address,omitempty"`
+	// IdentityKeyFile is a path to a file containing the node's base64 Ed25519
+	// private key (32-byte seed or 64-byte key). Read at channel start; never logged.
+	IdentityKeyFile string `yaml:"identityKeyFile,omitempty"`
+	// SponsorAddress is the gas sponsor Sui address for outbound sends.
+	SponsorAddress string `yaml:"sponsorAddress,omitempty"`
+	// GasCoin is the sponsor-owned gas coin object id for outbound sends.
+	GasCoin string `yaml:"gasCoin,omitempty"`
+	// PollIntervalSeconds controls inbound event polling. Default: 2.
+	PollIntervalSeconds int `yaml:"pollIntervalSeconds,omitempty"`
+	// AllowedSenders is an allowlist of sender Sui addresses. Empty means deny all.
+	AllowedSenders []string `yaml:"allowedSenders,omitempty"`
+	// Peers maps a recipient Sui address to its base64 Ed25519 public key.
+	// Required per outbound recipient: a public key cannot be derived from a Sui address.
+	Peers map[string]string `yaml:"peers,omitempty"`
 }
 
 // OhMyCodeConfig contains integration settings for the oh-my-code workspace.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -396,3 +396,76 @@ func TestLoadConfigRejectsInvalidCodexAppCDPRepairPolicy(t *testing.T) {
 		t.Fatalf("expected repairPolicy error, got %v", err)
 	}
 }
+
+func TestLoadConfigParsesDemailChannel(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(strings.Join([]string{
+		"channels:",
+		"  demail:",
+		"    enabled: true",
+		"    rpcUrl: \"https://fullnode.testnet.sui.io:443\"",
+		"    packageId: \"0xpkg\"",
+		"    address: \"0xabc\"",
+		"    identityKeyFile: \"/tmp/identity.key\"",
+		"    sponsorAddress: \"0xdef\"",
+		"    gasCoin: \"0xgas\"",
+		"    pollIntervalSeconds: 7",
+		"    allowedSenders:",
+		"      - \"0xpeer\"",
+		"    peers:",
+		"      \"0xpeer\": \"cHVibGljLWtleQ==\"",
+		"",
+	}, "\n"))
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Channels == nil || cfg.Channels.Demail == nil {
+		t.Fatal("expected channels.demail to be parsed")
+	}
+	demail := cfg.Channels.Demail
+	if !demail.Enabled {
+		t.Fatal("expected demail.enabled true")
+	}
+	if demail.RPCURL != "https://fullnode.testnet.sui.io:443" {
+		t.Fatalf("unexpected rpcUrl: %q", demail.RPCURL)
+	}
+	if demail.PackageID != "0xpkg" || demail.Address != "0xabc" {
+		t.Fatalf("unexpected packageId/address: %q %q", demail.PackageID, demail.Address)
+	}
+	if demail.IdentityKeyFile != "/tmp/identity.key" {
+		t.Fatalf("unexpected identityKeyFile: %q", demail.IdentityKeyFile)
+	}
+	if demail.SponsorAddress != "0xdef" || demail.GasCoin != "0xgas" {
+		t.Fatalf("unexpected sponsorAddress/gasCoin: %q %q", demail.SponsorAddress, demail.GasCoin)
+	}
+	if demail.PollIntervalSeconds != 7 {
+		t.Fatalf("unexpected pollIntervalSeconds: %d", demail.PollIntervalSeconds)
+	}
+	if len(demail.AllowedSenders) != 1 || demail.AllowedSenders[0] != "0xpeer" {
+		t.Fatalf("unexpected allowedSenders: %v", demail.AllowedSenders)
+	}
+	if demail.Peers["0xpeer"] != "cHVibGljLWtleQ==" {
+		t.Fatalf("unexpected peers: %v", demail.Peers)
+	}
+}
+
+func TestLoadConfigDemailDisabledByDefault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte("channels:\n  telegram:\n    enabled: false\n")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Channels.Demail != nil {
+		t.Fatalf("expected nil demail config, got %#v", cfg.Channels.Demail)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -410,6 +410,7 @@ func TestLoadConfigParsesDemailChannel(t *testing.T) {
 		"    sponsorAddress: \"0xdef\"",
 		"    gasCoin: \"0xgas\"",
 		"    pollIntervalSeconds: 7",
+		"    cursorFile: \"/tmp/demail-cursor.log\"",
 		"    allowedSenders:",
 		"      - \"0xpeer\"",
 		"    peers:",
@@ -445,6 +446,9 @@ func TestLoadConfigParsesDemailChannel(t *testing.T) {
 	}
 	if demail.PollIntervalSeconds != 7 {
 		t.Fatalf("unexpected pollIntervalSeconds: %d", demail.PollIntervalSeconds)
+	}
+	if demail.CursorFile != "/tmp/demail-cursor.log" {
+		t.Fatalf("unexpected cursorFile: %q", demail.CursorFile)
 	}
 	if len(demail.AllowedSenders) != 1 || demail.AllowedSenders[0] != "0xpeer" {
 		t.Fatalf("unexpected allowedSenders: %v", demail.AllowedSenders)


### PR DESCRIPTION
## What

Adds a new `demail` channel to fractalbot that wires in the [fractal-demail](https://github.com/fractalmind-ai/fractal-demail) Go client — on-chain encrypted agent mail on Sui (KR4 slice 4 of the fractal-demail Phase 1 OKR).

- **Inbound**: a `fractal-demail/client-go/listener` polls `MessageSent` events, decrypts + sanitizes each message, and the channel delivers it through the same `IncomingMessageHandler` pathway as telegram/discord/imessage. Sender identity and chat id are the sender's Sui address. `allowedSenders` is an explicit allowlist — **empty means deny all**, matching the gateway security posture of the other channels.
- **Outbound `Send`**: `msg.To` is a recipient Sui address; its Ed25519 pubkey is looked up in the `peers` config map (a pubkey cannot be derived from a Sui address). Plaintext (`type: "reply"`) is built per the demail schema, `envelope.Seal`ed, and submitted as a sponsored `demail::send_inline` transaction via the sui CLI: `ptb --serialize-unsigned-transaction` → dual `keytool sign` → `execute-signed-tx`, routed through `gasstation.Relay` with a CLI-backed `Transport` so the adapter's route/signature invariants apply. **The tx digest is returned in `SendResult.MessageTS`** (closest analogue to a per-message id); `ChannelID` carries the recipient address.
- The command runner (`execFn`) and listener loop (`runListenerFn`) are injectable seams so tests run with no network and no sui CLI. The identity key is read from `identityKeyFile` at `Start` and never logged.

## Why

Gives fractalbot agents a decentralized, sponsor-funded mail channel: tasks/replies flow over Sui instead of a centralized chat provider. Tracks https://github.com/fractalmind-ai/fractal-demail/issues/1.

## Config example

```yaml
channels:
  demail:
    enabled: true
    rpcUrl: "https://fullnode.testnet.sui.io:443"
    packageId: "0x<package-id>"
    address: "0x<our-address>"
    identityKeyFile: "~/.config/fractalbot/demail-identity.key"  # base64 ed25519 seed/key; never logged
    sponsorAddress: "0x<sponsor-address>"
    gasCoin: "0x<gas-coin-object-id>"
    pollIntervalSeconds: 2
    allowedSenders:            # empty = deny all
      - "0x<peer-address>"
    peers:                     # address -> base64 ed25519 pubkey (required per outbound recipient)
      "0x<peer-address>": "<base64-ed25519-public-key>"
```

## Test coverage

- Config: demail block parsing (all fields incl. peers map), disabled-by-default.
- Manager: registration when enabled; required-field rejection.
- Inbound (table-driven, injected listener run fn): allowed sender delivered to the handler with correct `user_id`/`chat_id`; unknown sender blocked; nil/malformed plaintext never panics; empty allowlist denies all; case-insensitive address matching.
- Outbound (mock command runner): exact 4-call CLI argument sequence (ptb serialize → sender sign → sponsor sign → execute-signed-tx), digest returned in `MessageTS`, envelope decrypts with the recipient's real Ed25519 key and satisfies `schema.Parse` (route AAD verified); peers-lookup failure, invalid recipient, empty text, missing sponsor/gas-coin errors.
- Lifecycle: `Stop` cancels the listener context and `IsRunning` reflects state; `Start` fails cleanly without an identity key file.
- Identity key loading: 32-byte seed, 64-byte key, trailing whitespace, bad base64, wrong length, missing file.

`go vet ./...`, `gofmt -l` clean, `go test ./...` fully green. Note: `make test` (`-race`) has three pre-existing failures on `main` (`TestImsgWatchReconnectsOnProcessExit`, `TestManagerStartStop`, `TestManagerStartBestEffortWhenOneChannelFails`) unrelated to this change; all demail tests pass under `-race`.

**Merge gate: CI green + QA Verdict: PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
