### PR TITLE
feat(demail): listener cursor persistence via client-go CursorFile pin bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0
-	github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260702210713-01db07216ca4
+	github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703020049-57bd0a76fcd4
 	github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+Eg
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260702210713-01db07216ca4 h1:jqOAC+ywCycgu0qQ8l9wexTt5snvoa4wi8fs+cKbUFw=
-github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260702210713-01db07216ca4/go.mod h1:te9w6GASyunKCjWbSUByl/eaP+8E3Vy16u0SOK78GRQ=
+github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703020049-57bd0a76fcd4 h1:/t+DPV1FII4DqTDBNGuYEsVmdShpiRuBJeExU0EVIGU=
+github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703020049-57bd0a76fcd4/go.mod h1:te9w6GASyunKCjWbSUByl/eaP+8E3Vy16u0SOK78GRQ=
 github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4 h1:yU8EgEww0HJDYu9p/jWbWTRzhCktwVk5yAtV+X8dlrs=
 github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4/go.mod h1:WbNInBdabo2hStb2F+dznTRThh1ttZtFbegMs8Kcnsk=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=

--- a/internal/channels/demail.go
+++ b/internal/channels/demail.go
@@ -260,12 +260,20 @@ func (b *DemailChannel) Start(ctx context.Context) error {
 			b.cancel()
 			return err
 		}
+		listenerCursorFile := ""
+		if b.cursorFile != "" {
+			// The journal file stores processed Message ids; the listener keeps
+			// its RPC poll cursor in a sibling file so a restart resumes from
+			// the last processed event instead of rescanning history.
+			listenerCursorFile = b.cursorFile + ".cursor"
+		}
 		inbound, err := listener.New(listener.Config{
 			RPCURL:       b.rpcURL,
 			PackageID:    b.packageID,
 			Recipient:    b.address,
 			IdentityKey:  identityKey,
 			PollInterval: b.pollInterval,
+			CursorFile:   listenerCursorFile,
 		}, func(messageID string, msg *schema.Plaintext) {
 			b.handleInbound(messageID, msg)
 		})


### PR DESCRIPTION
Follow-up to #356, closing the loop on QA finding B2 at the library level.

## What
- Pins `fractal-demail/client-go` to `57bd0a76` — brings in [fractal-demail#4](https://github.com/fractalmind-ai/fractal-demail/pull/4): listener cursor persistence + init-from-latest on fresh deployments (QA PASS, zero blocking).
- Wires `listener.Config.CursorFile` to a `.cursor` sibling of the channel's processed-id journal: restarts resume from the last processed event instead of rescanning full history; the journal stays as dedup defense in depth.

## Verification
- Pre-validated in an isolated clone before #356 merged, re-validated on merged main: `gofmt -l` clean, `go vet ./...` clean, `go test ./... -count=1` all 6 packages pass.

Tracker: https://github.com/fractalmind-ai/fractal-demail/issues/1
Merge gate: CI green + QA Verdict: PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)