### PR TITLE
fix(demail): pin client-go with inline payload encoding fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.6
 
 require (
 	github.com/bwmarrin/discordgo v0.29.0
-	github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703020049-57bd0a76fcd4
+	github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703072745-61cb7759e4b9
 	github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/bwmarrin/discordgo v0.29.0 h1:FmWeXFaKUwrcL3Cx65c20bTRW+vOb6k8AnaP+Eg
 github.com/bwmarrin/discordgo v0.29.0/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703020049-57bd0a76fcd4 h1:/t+DPV1FII4DqTDBNGuYEsVmdShpiRuBJeExU0EVIGU=
-github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703020049-57bd0a76fcd4/go.mod h1:te9w6GASyunKCjWbSUByl/eaP+8E3Vy16u0SOK78GRQ=
+github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703072745-61cb7759e4b9 h1:BMdph+YO4wXNkn53/GvkGdnCrikkKmXyLfcjKV8Vrxw=
+github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703072745-61cb7759e4b9/go.mod h1:te9w6GASyunKCjWbSUByl/eaP+8E3Vy16u0SOK78GRQ=
 github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4 h1:yU8EgEww0HJDYu9p/jWbWTRzhCktwVk5yAtV+X8dlrs=
 github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4/go.mod h1:WbNInBdabo2hStb2F+dznTRThh1ttZtFbegMs8Kcnsk=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=


### PR DESCRIPTION
Pin bump only (go.mod/go.sum): fractal-demail/client-go → `61cb7759`, bringing in [fractal-demail#5](https://github.com/fractalmind-ai/fractal-demail/pull/5) — the live e2e demo found that CLI/PTB senders write envelopes as base64 text on-chain while the listener parsed raw bytes, dropping every real message as poison. QA PASS with mutation check on the library fix.

Live e2e evidence (Testnet, package `0x65c96400…2e82`):
- task (zero-balance sender, sponsored): `6Ubq7tzJYpaQUQng6M9zjNz5ksQfyVbBjnLU4XRA86ny`
- channel decrypt + handler wake + auto-reply (distinct sponsor): `DWpiyeakBc5zsJneWEaZvG5pb1vpBzvw7gFKvd3SM2nY`
- reply decrypts on the agent side; restart replays nothing (journal + cursor).

Merge gate: CI green + QA Verdict: PASS (pin-only; library fix already QA-passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)