### PR TITLE
feat(demail): self-sponsored single-signature sends (adapter pin + transport argv)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -101,7 +101,9 @@ channels:
   #   # File containing this node's base64 Ed25519 private key
   #   # (32-byte seed or 64-byte key). Read at start; never logged.
   #   identityKeyFile: "~/.config/fractalbot/demail-identity.key"
-  #   # Gas sponsor Sui address and sponsor-owned gas coin object id (outbound)
+  #   # Gas sponsor Sui address and sponsor-owned gas coin object id (outbound).
+  #   # sponsorAddress may equal address: that is a supported self-sponsored
+  #   # route where this node pays its own gas and sends a single signature.
   #   sponsorAddress: "0x<sponsor-address>"
   #   gasCoin: "0x<gas-coin-object-id>"
   #   # Inbound event poll interval (seconds). Default: 2.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.6
 require (
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703072745-61cb7759e4b9
-	github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4
+	github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260703092431-07048eacc6b7
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
 	github.com/slack-go/slack v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703072745-61cb7759e4b9 h1:BMdph+YO4wXNkn53/GvkGdnCrikkKmXyLfcjKV8Vrxw=
 github.com/fractalmind-ai/fractal-demail/client-go v0.0.0-20260703072745-61cb7759e4b9/go.mod h1:te9w6GASyunKCjWbSUByl/eaP+8E3Vy16u0SOK78GRQ=
-github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4 h1:yU8EgEww0HJDYu9p/jWbWTRzhCktwVk5yAtV+X8dlrs=
-github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260702210713-01db07216ca4/go.mod h1:WbNInBdabo2hStb2F+dznTRThh1ttZtFbegMs8Kcnsk=
+github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260703092431-07048eacc6b7 h1:gpoJY53+Fx4RxavrEC/sFg+vjr2nPhCPXyYK+hCDEjg=
+github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260703092431-07048eacc6b7/go.mod h1:WbNInBdabo2hStb2F+dznTRThh1ttZtFbegMs8Kcnsk=
 github.com/go-test/deep v1.1.1 h1:0r/53hagsehfO4bzD2Pgr/+RgHqhmf+k1Bpse2cTu1U=
 github.com/go-test/deep v1.1.1/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/internal/channels/demail.go
+++ b/internal/channels/demail.go
@@ -42,6 +42,8 @@ type DemailOptions struct {
 	// or 64-byte key). It is read at Start and never logged.
 	IdentityKeyFile string
 	// SponsorAddress is the gas sponsor Sui address for outbound sends.
+	// It may equal Address: that is a supported self-sponsored route where
+	// the sender pays its own gas and only one signature is produced.
 	SponsorAddress string
 	// GasCoin is the sponsor-owned gas coin object id used by outbound sends.
 	GasCoin string
@@ -516,12 +518,21 @@ func (b *DemailChannel) Send(ctx context.Context, msg OutboundMessage) (*SendRes
 	}
 
 	transport := &demailCLITransport{execFn: b.execFn}
-	relay, err := gasstation.New(gasstation.Route{Sender: b.address, GasSponsor: b.sponsorAddress}, transport)
+	route := gasstation.Route{Sender: b.address, GasSponsor: b.sponsorAddress}
+	relay, err := gasstation.New(route, transport)
 	if err != nil {
 		return nil, fmt.Errorf("demail relay init failed: %w", err)
 	}
 
-	request, err := relay.Sponsor(ctx, []byte(txBytes), b.suiSigner(b.address), b.suiSigner(b.sponsorAddress))
+	// Self-sponsored route (sponsorAddress == address): Sui expects exactly
+	// one signature, so pass a nil sponsor signer and let the adapter collect
+	// only the sender signature (a single keytool sign call).
+	var sponsorSigner gasstation.Signer
+	if !route.SelfSponsored() {
+		sponsorSigner = b.suiSigner(b.sponsorAddress)
+	}
+
+	request, err := relay.Sponsor(ctx, []byte(txBytes), b.suiSigner(b.address), sponsorSigner)
 	if err != nil {
 		b.markError()
 		return nil, fmt.Errorf("demail sponsor signing failed: %w", err)
@@ -586,21 +597,39 @@ func (b *DemailChannel) suiSigner(address string) gasstation.Signer {
 	}
 }
 
-// demailCLITransport executes the dual-signed transaction via the sui CLI,
+// demailCLITransport executes the signed transaction via the sui CLI,
 // keeping the gasstation route/signature invariants on the outbound path.
+// Per the gasstation transport contract it submits only non-empty
+// signatures: two on a distinct-sponsor route, one on a self-sponsored
+// route (where SponsorSignature is empty).
 type demailCLITransport struct {
 	execFn func(ctx context.Context, name string, args ...string) ([]byte, error)
 	digest string
 }
 
 func (t *demailCLITransport) Relay(ctx context.Context, req gasstation.RelayRequest) error {
-	output, err := t.execFn(ctx, "sui",
+	args := []string{
 		"client", "execute-signed-tx",
 		"--tx-bytes", string(req.UnsignedTx),
-		"--signatures", string(req.SenderSignature),
-		"--signatures", string(req.SponsorSignature),
-		"--json",
-	)
+	}
+	// Sender first, then sponsor: Sui expects the sender signature ahead of
+	// the sponsor signature on a dual-signed transaction. The adapter
+	// validates signature presence, but stay defensive: never submit an
+	// empty --signatures value and never submit zero signatures.
+	signatures := 0
+	for _, sig := range [][]byte{req.SenderSignature, req.SponsorSignature} {
+		if len(sig) == 0 {
+			continue
+		}
+		args = append(args, "--signatures", string(sig))
+		signatures++
+	}
+	if signatures == 0 {
+		return errors.New("demail transport: relay request has no non-empty signatures")
+	}
+	args = append(args, "--json")
+
+	output, err := t.execFn(ctx, "sui", args...)
 	if err != nil {
 		return fmt.Errorf("sui execute-signed-tx failed: %w", err)
 	}

--- a/internal/channels/demail_test.go
+++ b/internal/channels/demail_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/fractalmind-ai/fractal-demail/client-go/envelope"
 	"github.com/fractalmind-ai/fractal-demail/client-go/schema"
+	gasstation "github.com/fractalmind-ai/fractal-demail/gas-station-adapter"
 
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
 )
@@ -542,6 +543,95 @@ func TestDemailSendCLISequence(t *testing.T) {
 	}
 	if parsed.TS != 1750000000000 {
 		t.Fatalf("expected ts 1750000000000, got %d", parsed.TS)
+	}
+}
+
+func TestDemailSendSelfSponsoredSingleSignature(t *testing.T) {
+	recipientPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate recipient key: %v", err)
+	}
+
+	// Self-sponsored route: sponsorAddress == address is a supported
+	// configuration where the node pays its own gas with a single signature.
+	channel := newTestDemailChannel(t, DemailOptions{
+		SponsorAddress: demailTestAddress,
+		GasCoin:        demailTestGasCoin,
+		Peers: map[string]string{
+			demailTestPeer: base64.StdEncoding.EncodeToString(recipientPub),
+		},
+	})
+	channel.nowFn = func() time.Time { return time.UnixMilli(1750000000000) }
+
+	const txBytes = "dGVzdC10eC1ieXRlcw=="
+	var calls []demailExecCall
+	channel.execFn = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+		_ = ctx
+		calls = append(calls, demailExecCall{name: name, args: append([]string{}, args...)})
+		switch {
+		case len(args) > 1 && args[0] == "client" && args[1] == "ptb":
+			return []byte(txBytes + "\n"), nil
+		case len(args) > 1 && args[0] == "keytool" && args[1] == "sign":
+			return []byte(`{"suiSignature":"sig-sender"}`), nil
+		case len(args) > 1 && args[0] == "client" && args[1] == "execute-signed-tx":
+			return []byte(`{"digest":"DIGEST456"}`), nil
+		default:
+			return nil, errors.New("unexpected command")
+		}
+	}
+
+	result, err := channel.Send(context.Background(), OutboundMessage{To: demailTestPeer, Text: "hello peer"})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if result.MessageTS != "DIGEST456" {
+		t.Fatalf("expected digest in MessageTS, got %q", result.MessageTS)
+	}
+
+	// Exactly one keytool sign: the sender signature is the only signature
+	// on a self-sponsored route, so no second sign runs for the sponsor.
+	if len(calls) != 3 {
+		t.Fatalf("expected 3 CLI calls (ptb, sign, execute), got %d: %v", len(calls), calls)
+	}
+	signCalls := 0
+	for _, call := range calls {
+		if len(call.args) > 1 && call.args[0] == "keytool" && call.args[1] == "sign" {
+			signCalls++
+		}
+	}
+	if signCalls != 1 {
+		t.Fatalf("expected exactly 1 keytool sign call, got %d", signCalls)
+	}
+	expectedSign := []string{"keytool", "sign", "--address", demailTestAddress, "--data", txBytes, "--json"}
+	if !reflect.DeepEqual(calls[1].args, expectedSign) {
+		t.Fatalf("unexpected sign args:\n got %v\nwant %v", calls[1].args, expectedSign)
+	}
+
+	// Execution submits exactly one --signatures pair (the sender signature).
+	expectedExecute := []string{
+		"client", "execute-signed-tx",
+		"--tx-bytes", txBytes,
+		"--signatures", "sig-sender",
+		"--json",
+	}
+	if !reflect.DeepEqual(calls[2].args, expectedExecute) {
+		t.Fatalf("unexpected execute args:\n got %v\nwant %v", calls[2].args, expectedExecute)
+	}
+}
+
+func TestDemailCLITransportRejectsEmptySignatures(t *testing.T) {
+	transport := &demailCLITransport{
+		execFn: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			t.Fatalf("no CLI command should run, got %s %v", name, args)
+			return nil, nil
+		},
+	}
+	err := transport.Relay(context.Background(), gasstation.RelayRequest{
+		Route:      gasstation.Route{Sender: demailTestAddress, GasSponsor: demailTestSponsor},
+		UnsignedTx: []byte("dGVzdC10eC1ieXRlcw=="),
+	})
+	if err == nil || !strings.Contains(err.Error(), "no non-empty signatures") {
+		t.Fatalf("expected zero-signature rejection, got %v", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,8 @@ type DemailConfig struct {
 	// private key (32-byte seed or 64-byte key). Read at channel start; never logged.
 	IdentityKeyFile string `yaml:"identityKeyFile,omitempty"`
 	// SponsorAddress is the gas sponsor Sui address for outbound sends.
+	// It may equal Address (self-sponsored: the node pays its own gas with a
+	// single signature); a distinct sponsor uses the dual-signature route.
 	SponsorAddress string `yaml:"sponsorAddress,omitempty"`
 	// GasCoin is the sponsor-owned gas coin object id for outbound sends.
 	GasCoin string `yaml:"gasCoin,omitempty"`


### PR DESCRIPTION
## Context

The live demo hit an on-chain **"Expect 1 signer"** rejection when fractalbot was configured with `sponsorAddress == address`: the transport always submitted two signatures, but Sui expects exactly one when the sender pays its own gas.

The adapter side landed in fractal-demail PR [#7](https://github.com/fractalmind-ai/fractal-demail/pull/7) (merged with QA PASS): `Route.SelfSponsored()`, `Sponsor` producing an empty `SponsorSignature` on self-sponsored routes (with `sponsorSigner` allowed to be nil), and a documented transport contract of submitting only non-empty signatures. QA on that PR explicitly recommended the consumer pin bump and the transport argv change land **together** — this PR is that atomic follow-up.

Tracker: fractalmind-ai/fractal-demail#6 (Phase 2 KR2 slice 1).

## Changes

- **go.mod**: bump `github.com/fractalmind-ai/fractal-demail/gas-station-adapter` to `v0.0.0-20260703092431-07048eacc6b7` (fractal-demail `main@07048eacc6b7`); `client-go` pin unchanged.
- **`demailCLITransport.Relay`**: build the `execute-signed-tx` argv dynamically — a `--signatures <sig>` pair is appended only for each non-empty signature (sender first, then sponsor). Defensively rejects a request with zero non-empty signatures even though the adapter validates upstream.
- **`DemailChannel.Send`**: when the route is self-sponsored (`Route.SelfSponsored()`), pass a nil sponsor signer so the adapter collects only the sender signature — exactly one `sui keytool sign` runs.
- **Config docs**: `sponsorAddress == address` is now a supported configuration; documented in `DemailOptions`, `DemailConfig`, and the `config.example.yaml` demail block (self-sponsored, single signature).

## Tests

- `TestDemailSendSelfSponsoredSingleSignature`: self-sponsored `Send` executes exactly one `keytool sign` and the `execute-signed-tx` argv contains exactly one `--signatures` pair (mock `execFn` asserts full argv).
- `TestDemailSendCLISequence` (existing, unchanged): distinct-route behavior stays dual-sign — two signs, two `--signatures` pairs, sender before sponsor.
- `TestDemailCLITransportRejectsEmptySignatures`: transport rejects a relay request with zero non-empty signatures without invoking the CLI.
- `gofmt -l` clean, `go vet ./...` clean, `go test ./... -count=1` green, `go test -race ./internal/channels/ -run Demail` green.

**Merge gate: CI green + QA Verdict: PASS**

🤖 Generated with [Claude Code](https://claude.com/claude-code)