### PR TITLE
fix(slack): route channel app_mention file/image attachments to agents

### DIFF
--- a/internal/channels/slack.go
+++ b/internal/channels/slack.go
@@ -44,6 +44,7 @@ type SlackBot struct {
 	sendMessageFn            func(ctx context.Context, channelID, text string) (*SendResult, error)
 	sendMessageWithOptionsFn func(ctx context.Context, channelID, text, threadTS string) (*SendResult, error)
 	fetchHistoryFn           func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error)
+	fetchMessageFilesFn      func(ctx context.Context, channelID, threadTS, ts string) ([]slack.File, error)
 
 	socketClientFactoryFn func(apiClient *slack.Client) *socketmode.Client
 	runSocketModeFn       func(ctx context.Context, socketClient *socketmode.Client) error
@@ -412,6 +413,7 @@ func (b *SlackBot) handleEventsAPIEvent(ctx context.Context, event slackevents.E
 		if msg == nil {
 			return
 		}
+		msg.attachments = b.appMentionAttachments(ctx, ev, event)
 		replyText := b.slashCommandReply(ctx, msg)
 		if strings.TrimSpace(replyText) == "" {
 			return
@@ -1090,7 +1092,94 @@ func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attac
 	if event == nil || event.Message == nil {
 		return nil
 	}
-	attachments := make([]protocol.Attachment, 0, len(event.Message.Files)+len(event.Message.Attachments))
+	return slackAttachmentsFromFiles(event.Message.Files, event.Message.Attachments)
+}
+
+// appMentionAttachments extracts file attachments for a channel app_mention.
+// The slack-go AppMentionEvent struct does not expose the "files" array that
+// Slack includes when the mentioning message carries attachments, so the raw
+// inner event JSON is re-parsed. If the payload has no files (Slack does not
+// guarantee them on app_mention), fall back to fetching the message itself
+// from the conversation history.
+func (b *SlackBot) appMentionAttachments(ctx context.Context, ev *slackevents.AppMentionEvent, apiEvent slackevents.EventsAPIEvent) []protocol.Attachment {
+	if attachments := slackAttachmentsFromCallbackEvent(apiEvent); len(attachments) > 0 {
+		return attachments
+	}
+	files, err := b.fetchMessageFiles(ctx, ev.Channel, ev.ThreadTimeStamp, ev.TimeStamp)
+	if err != nil {
+		log.Printf("slack: failed to fetch files for mention in %s at %s: %v", ev.Channel, ev.TimeStamp, err)
+		return nil
+	}
+	return slackAttachmentsFromFiles(files, nil)
+}
+
+// slackAttachmentsFromCallbackEvent re-parses the raw inner event JSON of an
+// Events API callback into a slack.Msg to recover the files/attachments
+// arrays that typed event structs may not expose.
+func slackAttachmentsFromCallbackEvent(apiEvent slackevents.EventsAPIEvent) []protocol.Attachment {
+	cbEvent, ok := apiEvent.Data.(*slackevents.EventsAPICallbackEvent)
+	if !ok || cbEvent == nil || cbEvent.InnerEvent == nil {
+		return nil
+	}
+	var msg slack.Msg
+	if err := json.Unmarshal(*cbEvent.InnerEvent, &msg); err != nil {
+		return nil
+	}
+	return slackAttachmentsFromFiles(msg.Files, msg.Attachments)
+}
+
+func (b *SlackBot) fetchMessageFiles(ctx context.Context, channelID, threadTS, ts string) ([]slack.File, error) {
+	fetchFn := b.fetchMessageFilesFn
+	if fetchFn == nil {
+		fetchFn = b.defaultFetchMessageFiles
+	}
+	return fetchFn(ctx, channelID, threadTS, ts)
+}
+
+func (b *SlackBot) defaultFetchMessageFiles(ctx context.Context, channelID, threadTS, ts string) ([]slack.File, error) {
+	if strings.TrimSpace(ts) == "" {
+		return nil, nil
+	}
+	if b.apiClient == nil {
+		return nil, errors.New("slack api client not initialized")
+	}
+	var messages []slack.Message
+	if strings.TrimSpace(threadTS) != "" {
+		msgs, _, _, err := b.apiClient.GetConversationRepliesContext(ctx, &slack.GetConversationRepliesParameters{
+			ChannelID: channelID,
+			Timestamp: threadTS,
+			Latest:    ts,
+			Oldest:    ts,
+			Inclusive: true,
+			Limit:     1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		messages = msgs
+	} else {
+		resp, err := b.apiClient.GetConversationHistoryContext(ctx, &slack.GetConversationHistoryParameters{
+			ChannelID: channelID,
+			Latest:    ts,
+			Oldest:    ts,
+			Inclusive: true,
+			Limit:     1,
+		})
+		if err != nil {
+			return nil, err
+		}
+		messages = resp.Messages
+	}
+	for _, m := range messages {
+		if m.Timestamp == ts {
+			return m.Files, nil
+		}
+	}
+	return nil, nil
+}
+
+func slackAttachmentsFromFiles(files []slack.File, legacy []slack.Attachment) []protocol.Attachment {
+	attachments := make([]protocol.Attachment, 0, len(files)+len(legacy))
 	seenURL := make(map[string]struct{})
 	appendAttachment := func(attachment protocol.Attachment) {
 		if attachment.URL == "" {
@@ -1103,7 +1192,7 @@ func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attac
 		attachments = append(attachments, attachment)
 	}
 
-	for _, file := range event.Message.Files {
+	for _, file := range files {
 		url := strings.TrimSpace(file.URLPrivate)
 		if url == "" {
 			url = strings.TrimSpace(file.URLPrivateDownload)
@@ -1127,12 +1216,12 @@ func slackAttachmentsFromEvent(event *slackevents.MessageEvent) []protocol.Attac
 		})
 	}
 
-	for _, legacy := range event.Message.Attachments {
-		url := slackLegacyAttachmentURL(legacy)
+	for _, legacyAttachment := range legacy {
+		url := slackLegacyAttachmentURL(legacyAttachment)
 		if url == "" {
 			continue
 		}
-		filename := strings.TrimSpace(legacy.Title)
+		filename := strings.TrimSpace(legacyAttachment.Title)
 		if filename == "" {
 			filename = slackFilenameFromURL(url)
 		}

--- a/internal/channels/slack_test.go
+++ b/internal/channels/slack_test.go
@@ -2011,3 +2011,236 @@ func TestSendTextWithOptionsResolvesMentions(t *testing.T) {
 		t.Fatalf("sent text = %q, want %q", sentText, "Hey <@U111>, check this")
 	}
 }
+
+func newSlackAppMentionTestBot(t *testing.T) (*SlackBot, *fakeSlackHandler) {
+	t.Helper()
+	bot, err := NewSlackBot("xoxb-token", "xapp-token", []string{"U123"}, nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewSlackBot: %v", err)
+	}
+	bot.sendMessageFn = func(ctx context.Context, channelID, text string) (*SendResult, error) {
+		return nil, nil
+	}
+	bot.fetchHistoryFn = func(ctx context.Context, channelID string, limit int) ([]map[string]interface{}, error) {
+		return nil, nil
+	}
+	bot.fetchMessageFilesFn = func(ctx context.Context, channelID, threadTS, ts string) ([]slack.File, error) {
+		return nil, nil
+	}
+	handler := &fakeSlackHandler{reply: "ok"}
+	bot.SetHandler(handler)
+	return bot, handler
+}
+
+func TestSlackAppMentionChannelImageAttachment(t *testing.T) {
+	// Reproduces issue #361: a channel message mentioning the bot with an
+	// image attached must route with the attachment, exactly like the DM path.
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "app_mention",
+			"text": "<@U0BOT> look at this screenshot",
+			"user": "U123",
+			"channel": "C0AH3NZH5R9",
+			"ts": "1783179559.001819",
+			"event_ts": "1783179559.001819",
+			"files": [
+				{
+					"id": "F0BF3KS2VCN",
+					"name": "455.png",
+					"mimetype": "image/png",
+					"filetype": "png",
+					"url_private": "https://files.slack.com/files-pri/T123-F0BF3KS2VCN/455.png"
+				}
+			]
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	bot, handler := newSlackAppMentionTestBot(t)
+	bot.handleEventsAPIEvent(context.Background(), event)
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if len(handler.last.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(handler.last.Attachments))
+	}
+	att := handler.last.Attachments[0]
+	if att.Type != "image" {
+		t.Fatalf("attachment.Type=%q, want image (image types must not be filtered)", att.Type)
+	}
+	if att.Filename != "455.png" {
+		t.Fatalf("attachment.Filename=%q", att.Filename)
+	}
+	if att.MimeType != "image/png" {
+		t.Fatalf("attachment.MimeType=%q", att.MimeType)
+	}
+	if att.URL != "https://files.slack.com/files-pri/T123-F0BF3KS2VCN/455.png" {
+		t.Fatalf("attachment.URL=%q", att.URL)
+	}
+	if att.Channel != "slack" {
+		t.Fatalf("attachment.Channel=%q", att.Channel)
+	}
+
+	data, ok := handler.last.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", handler.last.Data)
+	}
+	if _, ok := data["attachments"]; !ok {
+		t.Fatalf("expected attachments key in routed data")
+	}
+}
+
+func TestSlackAppMentionChannelFileAttachment(t *testing.T) {
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "app_mention",
+			"text": "<@U0BOT> review this doc",
+			"user": "U123",
+			"channel": "C0AH3NZH5R9",
+			"ts": "1783179559.001820",
+			"event_ts": "1783179559.001820",
+			"files": [
+				{
+					"id": "F456",
+					"name": "spec.pdf",
+					"mimetype": "application/pdf",
+					"filetype": "pdf",
+					"url_private": "https://files.slack.com/files-pri/T123-F456/spec.pdf"
+				}
+			]
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	bot, handler := newSlackAppMentionTestBot(t)
+	bot.handleEventsAPIEvent(context.Background(), event)
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if len(handler.last.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got %d", len(handler.last.Attachments))
+	}
+	att := handler.last.Attachments[0]
+	if att.Type != "file" {
+		t.Fatalf("attachment.Type=%q, want file", att.Type)
+	}
+	if att.Filename != "spec.pdf" {
+		t.Fatalf("attachment.Filename=%q", att.Filename)
+	}
+	if att.URL != "https://files.slack.com/files-pri/T123-F456/spec.pdf" {
+		t.Fatalf("attachment.URL=%q", att.URL)
+	}
+}
+
+func TestSlackAppMentionAttachmentsFallbackToHistory(t *testing.T) {
+	// When the app_mention payload carries no files, the bot must fall back
+	// to fetching the mentioning message from the conversation history.
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "app_mention",
+			"text": "<@U0BOT> look at the screenshot",
+			"user": "U123",
+			"channel": "C0AH3NZH5R9",
+			"thread_ts": "1783179000.000100",
+			"ts": "1783179559.001819",
+			"event_ts": "1783179559.001819"
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	bot, handler := newSlackAppMentionTestBot(t)
+	var gotChannel, gotThreadTS, gotTS string
+	bot.fetchMessageFilesFn = func(ctx context.Context, channelID, threadTS, ts string) ([]slack.File, error) {
+		gotChannel, gotThreadTS, gotTS = channelID, threadTS, ts
+		return []slack.File{
+			{
+				ID:         "F789",
+				Name:       "screen.png",
+				Mimetype:   "image/png",
+				Filetype:   "png",
+				URLPrivate: "https://files.slack.com/files-pri/T123-F789/screen.png",
+			},
+		}, nil
+	}
+	bot.handleEventsAPIEvent(context.Background(), event)
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if gotChannel != "C0AH3NZH5R9" || gotThreadTS != "1783179000.000100" || gotTS != "1783179559.001819" {
+		t.Fatalf("fetchMessageFiles called with channel=%q threadTS=%q ts=%q", gotChannel, gotThreadTS, gotTS)
+	}
+	if len(handler.last.Attachments) != 1 {
+		t.Fatalf("expected 1 attachment from history fallback, got %d", len(handler.last.Attachments))
+	}
+	att := handler.last.Attachments[0]
+	if att.Type != "image" || att.Filename != "screen.png" {
+		t.Fatalf("attachment=%+v", att)
+	}
+}
+
+func TestSlackAppMentionWithoutAttachments(t *testing.T) {
+	// A plain mention with no files must still route, with no attachments key.
+	eventJSON := `{
+		"token": "test-token",
+		"team_id": "T123",
+		"api_app_id": "A123",
+		"type": "event_callback",
+		"event": {
+			"type": "app_mention",
+			"text": "<@U0BOT> just words",
+			"user": "U123",
+			"channel": "C0AH3NZH5R9",
+			"ts": "1783179559.001821",
+			"event_ts": "1783179559.001821"
+		}
+	}`
+
+	event, err := slackevents.ParseEvent(json.RawMessage(eventJSON), slackevents.OptionNoVerifyToken())
+	if err != nil {
+		t.Fatalf("ParseEvent: %v", err)
+	}
+
+	bot, handler := newSlackAppMentionTestBot(t)
+	bot.handleEventsAPIEvent(context.Background(), event)
+
+	if !handler.called {
+		t.Fatalf("expected handler to be called")
+	}
+	if len(handler.last.Attachments) != 0 {
+		t.Fatalf("expected no attachments, got %d", len(handler.last.Attachments))
+	}
+	data, ok := handler.last.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected map data, got %T", handler.last.Data)
+	}
+	if _, ok := data["attachments"]; ok {
+		t.Fatalf("expected no attachments key in routed data")
+	}
+}


### PR DESCRIPTION
Fixes #361

## 根因

频道消息只经 **app_mention** 路径路由给 agent（`handleMessageEvent` 对非 `im` 消息直接 return，见 `internal/channels/slack.go`），而 `slackMessageFromAppMentionEvent` 从不提取 `files[]` —— slack-go 的 `AppMentionEvent` 结构体本身就没有 files 字段。DM 走 message 事件路径，有完整的附件提取逻辑，所以 DM 正常、频道被静默丢弃。

对照 issue 三个排查点：
- **event.files 读取**：app_mention 路径确实没读 —— 本 PR 修复点
- **mimetype 白名单**：不存在，`slackAttachmentType` 只做类型归类（image/video/audio/file），无过滤；下游 `extractAttachments` 也无过滤
- **subtype=file_share 分支**：message 事件路径已正确处理（`slackMessageFromEvent` 放行 file_share + 既有 fixup），问题不在此

## 修复

1. app_mention 回调时重新解析 raw inner event JSON（复用 `fixupSlackMessageEventFiles` 同款手法）恢复 `files[]`/legacy attachments
2. payload 无 files 时兜底调 `conversations.history`（线程内 mention 用 `conversations.replies`）按 ts 精确取回该消息的 files —— 即 issue 中 agent 手动做的操作
3. 抽出 `slackAttachmentsFromFiles` 供 DM 与频道路径共用，保证两条路径附件段格式一致（name/mimetype/url_private + `fractalbot file download` 命令由 `internal/agent/manager.go` 统一渲染）；图片类型不过滤

## 测试

新增 4 个用例（`internal/channels/slack_test.go`）：
- `TestSlackAppMentionChannelImageAttachment`：频道图片（复刻 issue 真实案例 455.png / image/png），断言 type=image 不被过滤
- `TestSlackAppMentionChannelFileAttachment`：频道普通文件（pdf）
- `TestSlackAppMentionAttachmentsFallbackToHistory`：payload 无 files 时 API 兜底（含 thread_ts 透传）
- `TestSlackAppMentionWithoutAttachments`：无附件消息路由不受影响，不带 attachments 键

DM 回归由既有 `TestSlackEventsParseMessageWithFiles*` / `TestSlackFixup*` 覆盖。

本地 `go test ./...` 全绿；`go test -race ./internal/channels/ -run TestSlack` 绿（注：`make test` 的 -race 在本地 main 分支同样失败于 imsg/manager 既有用例，与本 PR 无关）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)