### PR TITLE
fix(feishu): drop app-sender messages before allowlist to prevent echo loops

### DIFF
--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -280,6 +280,12 @@ func (b *FeishuBot) handleMessageEvent(ctx context.Context, event *larkim.P2Mess
 	if msg == nil {
 		return nil
 	}
+	// Drop app-sent messages explicitly. Without this, anything the bot (or
+	// another app in the chat) sends can re-enter as agent input whenever the
+	// sender happens to pass the allowlist, producing echo/self-reply loops.
+	if msg.senderType == "app" {
+		return nil
+	}
 	if b.isContentDuplicate(msg.openID, msg.text) {
 		return nil
 	}
@@ -485,6 +491,7 @@ type feishuInboundMessage struct {
 	text        string
 	openID      string
 	userID      string
+	senderType  string
 	chatID      string
 	chatType    string
 	messageID   string
@@ -520,6 +527,7 @@ func parseFeishuInbound(event *larkim.P2MessageReceiveV1) (*feishuInboundMessage
 
 	openID := derefString(event.Event.Sender.SenderId.OpenId)
 	userID := derefString(event.Event.Sender.SenderId.UserId)
+	senderType := derefString(event.Event.Sender.SenderType)
 	chatID := derefString(msg.ChatId)
 	chatType := derefString(msg.ChatType)
 	messageID := derefString(msg.MessageId)
@@ -535,6 +543,7 @@ func parseFeishuInbound(event *larkim.P2MessageReceiveV1) (*feishuInboundMessage
 		text:        text,
 		openID:      openID,
 		userID:      userID,
+		senderType:  senderType,
 		chatID:      chatID,
 		chatType:    chatType,
 		messageID:   messageID,

--- a/internal/channels/feishu_test.go
+++ b/internal/channels/feishu_test.go
@@ -83,6 +83,34 @@ func TestFeishuHelpIncludesToAlias(t *testing.T) {
 	}
 }
 
+func TestFeishuDropsAppSenderMessages(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", []string{"ou_allowed"}, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+
+	var sent feishuSendCapture
+	sendCalls := 0
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		sendCalls++
+		sent = feishuSendCapture{receiveIDType: receiveIDType, receiveID: receiveID, text: text}
+		return nil
+	}
+
+	handler := &fakeFeishuHandler{reply: "ok"}
+	bot.SetHandler(handler)
+
+	// Even when the open_id passes the allowlist, an app-sent message must
+	// never reach the agent handler (echo/self-reply loop guard).
+	bot.handleMessageEvent(context.Background(), buildFeishuEventWithSenderType("hello", "p2p", "ou_allowed", "u1", "chat1", "app"))
+	if handler.called {
+		t.Fatalf("expected handler not called for app sender")
+	}
+	if sendCalls != 0 {
+		t.Fatalf("expected no replies for app sender, got %d (%q)", sendCalls, sent.text)
+	}
+}
+
 func TestFeishuAllowlist(t *testing.T) {
 	bot, err := NewFeishuBot("app", "secret", "feishu", []string{"ou_allowed"}, "", nil)
 	if err != nil {
@@ -423,6 +451,10 @@ func TestFeishuReplyTruncation(t *testing.T) {
 }
 
 func buildFeishuEvent(text, chatType, openID, userID, chatID string) *larkim.P2MessageReceiveV1 {
+	return buildFeishuEventWithSenderType(text, chatType, openID, userID, chatID, "user")
+}
+
+func buildFeishuEventWithSenderType(text, chatType, openID, userID, chatID, senderType string) *larkim.P2MessageReceiveV1 {
 	content := fmt.Sprintf(`{"text":%q}`, text)
 	return &larkim.P2MessageReceiveV1{
 		Event: &larkim.P2MessageReceiveV1Data{
@@ -431,6 +463,7 @@ func buildFeishuEvent(text, chatType, openID, userID, chatID string) *larkim.P2M
 					OpenId: strPtr(openID),
 					UserId: strPtr(userID),
 				},
+				SenderType: strPtr(senderType),
 			},
 			Message: &larkim.EventMessage{
 				MessageId:   strPtr("msg_1"),


### PR DESCRIPTION
## Summary

Explicitly drop `sender_type=app` messages in the Feishu webhook inbound path (`handleMessageEvent`), before content dedup, allowlist, and command handling.

## Problem

App-sent messages were only kept out of the agent pipeline as an **allowlist side effect** (the bot's open_id is normally not in `allowedUsers`). If an app sender ever passes the allowlist — e.g. an admin adds it, or outbound is injected into the chat under an allowlisted identity by an external tool — the bot's own outbound re-enters as agent input, producing echo / self-reply loops.

We hit this in production: agent outbound sent under a user's identity into a polled p2p chat was re-ingested and re-delivered to the agent as a new task.

## Fix

- Parse `SenderType` from the webhook event into `feishuInboundMessage.senderType`.
- Return early in `handleMessageEvent` when `senderType == "app"`: app messages are never user commands, and dropping them also prevents bot-to-bot loops.
- Regression test: an allowlisted `open_id` with `sender_type=app` reaches neither the agent handler nor `reply()`.

## Testing

- `go test ./internal/channels/ -count=1` — ok
- `go test ./... -count=1` — all packages ok
- `gofmt` clean

## Scope

2 files, +42 lines: `internal/channels/feishu.go`, `internal/channels/feishu_test.go`. No behavior change for `sender_type=user` messages.
