### PR TITLE
fix: support ChatGPT app CDP delivery

### DIFF
--- a/internal/agent/codex_app_cdp.go
+++ b/internal/agent/codex_app_cdp.go
@@ -1237,6 +1237,61 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
     throw new Error("No active Codex App /local/<conversationId> route; configure agents.codexAppCDP.conversationId or open the target thread.");
   }
 
+  const sendVscodeAppServerRequest = async (method, params) => {
+    const bridge = window.electronBridge;
+    if (!bridge || typeof bridge.sendMessageFromView !== "function") {
+      throw new Error("Codex App Electron bridge is unavailable.");
+    }
+    const requestId = crypto.randomUUID();
+    return await new Promise(async (resolve, reject) => {
+      let settled = false;
+      const cleanup = () => {
+        window.removeEventListener("message", onMessage);
+      };
+      const finish = (callback, value) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        callback(value);
+      };
+      const timer = setTimeout(() => {
+        finish(reject, new Error("Timed out waiting for Codex App Electron bridge response."));
+      }, 15000);
+      const onMessage = (event) => {
+        const message = event.data;
+        if (!message || message.type !== "fetch-response" || message.requestId !== requestId) {
+          return;
+        }
+        clearTimeout(timer);
+        if (message.responseType !== "success" || message.status < 200 || message.status >= 300) {
+          finish(reject, new Error(message.error || message.bodyJsonString || "Codex App Electron bridge request failed."));
+          return;
+        }
+        try {
+          finish(resolve, message.bodyJsonString ? JSON.parse(message.bodyJsonString) : {});
+        } catch (error) {
+          finish(reject, new Error("Codex App Electron bridge returned invalid JSON: " + String(error)));
+        }
+      };
+      window.addEventListener("message", onMessage);
+      try {
+        await bridge.sendMessageFromView({
+          type: "fetch",
+          requestId,
+          method: "POST",
+          url: "vscode://codex/" + method,
+          headers: {},
+          body: JSON.stringify(params)
+        });
+      } catch (error) {
+        clearTimeout(timer);
+        finish(reject, error);
+      }
+    });
+  };
+
   const toURLArray = (value) => {
     const normalize = (item) => {
       if (!item) {
@@ -1282,8 +1337,15 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
       } catch (_) {}
     }
   }
+  const input = [{ type: "text", text: payload.prompt, text_elements: [] }];
+  const request = {
+    hostId: payload.hostId || "local",
+    conversationId,
+    params: { input }
+  };
   if (!signalsUrl) {
-    throw new Error("Unable to locate Codex App app-server-manager-signals bundle.");
+    const result = await sendVscodeAppServerRequest("start-turn-for-host", request);
+    return { ok: true, conversationId, bridge: "vscode-fetch", result };
   }
 
   const signals = await import(signalsUrl);
@@ -1312,12 +1374,7 @@ func buildCodexAppDeliveryScript(cfg *config.CodexAppCDPConfig, envelope CodexAp
     throw new Error("Codex App app-server request bridge is unavailable.");
   }
 
-  const input = [{ type: "text", text: payload.prompt, text_elements: [] }];
-  const result = await sendRequest("start-turn-for-host", {
-    hostId: payload.hostId || "local",
-    conversationId,
-    params: { input }
-  });
+  const result = await sendRequest("start-turn-for-host", request);
   if (result && typeof result === "object") {
     const status = typeof result.status === "string" ? result.status.toLowerCase() : "";
     if (result.error || result.errorMessage || result.ok === false || result.success === false || ["error", "failed", "failure", "rejected"].includes(status)) {

--- a/internal/agent/manager_test.go
+++ b/internal/agent/manager_test.go
@@ -766,6 +766,12 @@ func TestBuildCodexAppDeliveryScriptUsesArrayLikeSafeURLCollection(t *testing.T)
 		t.Fatalf("delivery script still uses spread over possibly array-like values")
 	}
 	for _, expected := range []string{
+		"const sendVscodeAppServerRequest = async (method, params) =>",
+		"window.electronBridge",
+		"type: \"fetch\"",
+		"url: \"vscode://codex/\" + method",
+		"message.type !== \"fetch-response\"",
+		"bridge: \"vscode-fetch\"",
 		"const toURLArray = (value) =>",
 		"Array.from(value).map(normalize).filter(Boolean)",
 		"typeof value.length === \"number\"",


### PR DESCRIPTION
Closes #367

## Summary

Adds a Codex CDP delivery fallback for current ChatGPT.app builds where the legacy `app-server-manager-signals` asset is no longer present. The fallback uses the application-supported Electron bridge to POST `start-turn-for-host` through `vscode://codex/`, waits for the matching `fetch-response`, and returns the bridge error when the main process rejects the request.

The existing signals-module implementation remains in place for older Codex App builds.

## Validation

- `go test ./...`
- `go vet ./...`
- `go build ./cmd/fractalbot`
- Manual CDP probe against ChatGPT.app `26.721.41059`: Electron `fetch` bridge successfully returned `200` for the application-native `get-global-state` endpoint.

## Notes

The app-specific `getAuthStatus` endpoint is not implemented by this Electron shell. The delivery fallback uses the supported `start-turn-for-host` app-server endpoint instead.