### PR TITLE
docs: streamline README and update architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,446 +1,127 @@
 # FractalBot
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Go Version](https://img.shields.io/badge/go-%3E%201.23-00ADD8E.svg)](https://golang.org)
+[![Go Version](https://img.shields.io/badge/go-%3E%201.23-00ADD8E.svg)](https://go.dev/)
 [![Stars](https://img.shields.io/github/stars/fractalmind-ai/fractalbot?style=social)](https://github.com/fractalmind-ai/fractalbot/stargazers)
 
-Pure CLI + HTTP messaging gateway for routing channel messages to external agents.
+FractalBot is a local-first Go messaging gateway that connects chat channels to external agent runtimes through HTTP, CLI, and WebSocket interfaces.
 
-## 📋 Table of Contents
+## Capabilities
 
-- [Overview](#overview)
-- [Features](#features)
-- [Architecture](#architecture)
-- [Quick Start](#quick-start)
-- [Troubleshooting](#-troubleshooting)
-- [Development](#development)
-- [Contributing](#contributing)
-- [License](#license)
+### Channels
 
-## 🎯 Overview
+| Channel | Inbound | Outbound | Transport and scope |
+| --- | --- | --- | --- |
+| Telegram | Yes | Yes | Long polling or webhook; DM-only and allowlisted. |
+| Feishu / Lark | Yes | Yes | App credentials and user allowlist. |
+| Slack | Yes | Yes | Socket Mode; DMs and configured channel mentions. |
+| Discord | Yes | Yes | Gateway WebSocket; DM-only and allowlisted. |
+| iMessage | Yes | Yes | macOS Messages database polling and AppleScript sending. |
+| Demail | Transport only | Yes | Encrypted on-chain agent mail on Sui; generic Agent Router ingress is not yet enabled. |
 
-FractalBot is a Go-based messaging gateway inspired by [Clawdbot](https://github.com/clawdbot/clawdbot), focused on reliable channel I/O and external agent routing.
+### Routing targets
 
-**Inspired by:**
-- [Clawdbot](https://github.com/clawdbot/clawdbot) - Personal AI assistant gateway
-- [FractalMind AI](https://github.com/fractalmind-ai) - Multi-agent team architectures
+| Router | Target | Delivery model |
+| --- | --- | --- |
+| `ohMyCode` | oh-my-code agent-manager | Invokes the manager script in an existing workspace. |
+| `codexAppCDP` | ChatGPT / Codex desktop app | Resolves a project session and calls the renderer's in-process app-server bridge through CDP. |
+| `claudeDesktop` | Claude Desktop | Submits to an authenticated Claude chat exposed through CDP. |
+| Legacy fallback | Echo | Echoes supported inbound text when no Agent Router is enabled. |
 
-**Key Principles:**
-- 🦞 **Local-first** - Run on your own devices, full control
-- 🌐 **Multi-channel** - Telegram, Slack, Discord, Feishu, iMessage
-- 🔌 **Gateway-first** - Clean message ingress/egress via HTTP + CLI + WebSocket
-- 🧭 **External-agent routing** - Route tasks to oh-my-code agent-manager
-- 🔒 **Secure by default** - Channel user allowlists with deny-by-default behavior
+Desktop routes support durable file-backed inbox fallback when direct delivery is unavailable. Channel allowlists use deny-by-default behavior where supported.
 
-## ✨ Features
+## Architecture
 
-- **Gateway Control Plane** - WebSocket + HTTP server for messaging and status
-- **Multi-Channel Support** - Telegram, Slack, Discord, Feishu/Lark, iMessage
-- **Message Send API** - `POST /api/v1/message/send` + `fractalbot message send`
-- **File Download CLI/API** - Pull channel attachments via gateway auth context
-- **oh-my-code Routing** - Assign workflow with routing context injection
-- **Security Model** - Per-channel allowlists and strict default deny
+```mermaid
+flowchart LR
+    subgraph Channels[Channel adapters]
+        TG[Telegram]
+        FS[Feishu / Lark]
+        SL[Slack]
+        DC[Discord]
+        IM[iMessage]
+        DM[Demail]
+    end
 
-## 🏗️ Architecture
+    CM[Channel Manager]
+    MB[Message Bus]
+    AR{Agent Router}
 
+    subgraph Targets[Routing targets]
+        OMC[oh-my-code]
+        CA[ChatGPT / Codex App]
+        CD[Claude Desktop]
+        Echo[Echo]
+    end
+
+    TG --> CM
+    FS --> CM
+    SL --> CM
+    DC --> CM
+    IM --> CM
+    DM -. Agent ingress pending .-> CM
+    CM <--> MB
+    MB -->|Supported ingress| AR
+    AR --> OMC
+    AR --> CA
+    AR --> CD
+    AR --> Echo
+    CA -. fallback .-> CI[(Durable inbox)]
+    CD -. fallback .-> DI[(Durable inbox)]
 ```
-┌─────────────────────────────────────────┐
-│         FractalBot Gateway          │
-│      (Go WebSocket Server)           │
-└──────────┬──────────────────────────┘
-           │
-           ├─ Telegram Bot
-           ├─ Slack Bot
-           ├─ Discord Bot
-           ├─ Feishu/Lark Bot
-           ├─ iMessage Bridge
-           └─ External Agent Manager
-```
 
-**Inspired by Clawdbot's architecture but reimagined with:**
-- Go's concurrency model for parallel agent execution
-- FractalMind's process-oriented workflows
-- Enhanced multi-agent coordination
+The Gateway Server wires channel adapters, the buffered Message Bus, and the selected Agent Router. HTTP/CLI sends enter the outbound bus; normalized channel events enter the inbound bus. See [Architecture](docs/architecture.md) for component boundaries, message flows, and the current Demail ingress limitation.
 
-## 🚀 Quick Start
+## Quick start
 
-### Prerequisites
-
-- Go 1.23 or higher
-- A Telegram Bot Token (for Telegram channel)
-- Or Slack/Discord tokens (for other channels)
-
-### Installation
+Requires Go 1.23 or newer.
 
 ```bash
-# One-line install (pinned; builds and installs to ~/.local/bin)
-curl -fsSL https://raw.githubusercontent.com/fractalmind-ai/fractalbot/cb052356b79b4e679efb03a93210ab4628590076/install.sh | \
-  FRACTALBOT_REF=cb052356b79b4e679efb03a93210ab4628590076 bash
-
-# Optional: install as a systemd user service (Linux)
-curl -fsSL https://raw.githubusercontent.com/fractalmind-ai/fractalbot/cb052356b79b4e679efb03a93210ab4628590076/install.sh | \
-  FRACTALBOT_REF=cb052356b79b4e679efb03a93210ab4628590076 bash -s -- --systemd-user
-
-# Smoke check
-~/.local/bin/fractalbot --help
-
-# Clone the repository
 git clone git@github.com:fractalmind-ai/fractalbot.git
 cd fractalbot
-
-# Build
-go build -o fractalbot ./cmd/fractalbot
-
-# Run (development mode)
-./fractalbot --config ./config.yaml
-```
-
-### Configuration
-
-Create `config.yaml`:
-
-```yaml
-gateway:
-  port: 18789
-  bind: 127.0.0.1
-  # Optional: restrict allowed WebSocket origins
-  # allowedOrigins:
-  #   - "http://localhost:3000"
-
-channels:
-  telegram:
-    enabled: true
-    # DM-only; non-private chats are ignored.
-    botToken: "your_bot_token"
-    adminID: 1234567890
-    allowedUsers:
-      - 1234567890
-    # Optional: restrict to specific chat IDs
-    # allowedChats:
-    #   - 1234567890
-
-    # Recommended: long polling (local/dev friendly)
-    mode: "polling"
-    pollingTimeoutSeconds: 25
-    pollingLimit: 100
-    pollingOffsetFile: "./workspace/telegram.offset"
-
-    # Optional: webhook mode (public HTTPS required)
-    # mode: "webhook"
-    # webhookListenAddr: "0.0.0.0:18790"
-    # webhookPath: "/telegram/webhook"
-    # webhookPublicURL: "https://your-domain.example/telegram/webhook"
-    # webhookSecretToken: "replace-with-random-secret"
-    # webhookRegisterOnStart: true
-    # webhookDeleteOnStop: true
-
-agents:
-  workspace: ./workspace
-  maxConcurrent: 4
-
-  # Select the inbound agent runtime: "ohMyCode", "codexAppCDP", or "claudeDesktop".
-  # Empty preserves legacy auto-selection.
-  router: "ohMyCode"
-
-  # Optional: route channel messages to oh-my-code agent-manager
-  # (requires python3 + tmux + agent-manager installed in that workspace)
-  ohMyCode:
-    enabled: false
-    workspace: "/home/elliot245/workspace/elliot245/oh-my-code"
-    defaultAgent: "qa-1"
-    allowedAgents:
-      - "qa-1"
-      - "coder-a"
-    # FractalBot injects inbound routing context into assign prompts:
-    # channel/chat_id/user_id/username + resolved selected_agent.
-    # For Telegram outbound intent, the prompt directs the agent to
-    # prefer use-fractalbot and default recipient to current chat_id if omitted.
-    # Keep skill path/name consistent in the agent workspace:
-    # .claude/skills/use-fractalbot/SKILL.md
-
-  # Optional: route channel messages to a Codex App-managed main session.
-  # This uses CDP inside the running Codex App renderer, not an external
-  # `codex app-server --listen ...` backend.
-  codexAppCDP:
-    enabled: false
-    cdpEndpoint: "http://127.0.0.1:9222"
-    targetSelector: "Codex"
-    hostId: "local"
-    # Recommended: route by stable project + named session. The gateway resolves
-    # the current conversation id before each delivery.
-    targetProject:
-      name: "CloudBank"
-      cwd: "/Users/you/Develop/SuLabsOrg/CloudBank"
-      session: "main"
-    # Advanced override: pin to a specific /local/<conversationId>. Empty uses
-    # targetProject when configured, then the active Codex App thread.
-    conversationId: ""
-    inboxPath: "/Users/you/Develop/SuLabsOrg/CloudBank/.fractalbot/inbox"
-    fallbackToInbox: true
-    # CDP readiness / repair. Empty repairPolicy defaults to "relaunch".
-    # Supported values: "off", "status-only", "new-instance", "relaunch".
-    # With codexAppCDP enabled, the gateway starts the watchdog by default and
-    # relaunches Codex App with --remote-debugging-port when CDP is unavailable.
-    repairPolicy: "relaunch"
-    checkOnIncomingMessage: true
-    watch:
-      enabled: true
-      intervalSeconds: 60
-      cooldownSeconds: 90
-    defaultAgent: "main"
-    allowedAgents:
-      - "main"
-    deliveryTimeoutSeconds: 20
-
-  # Optional: route channel messages into an already-authenticated Claude
-  # Desktop chat target. CDP failures fall back to this private inbox.
-  claudeDesktop:
-    enabled: false
-    cdpEndpoint: "http://127.0.0.1:19334"
-    targetSelector: ""
-    inboxPath: "/Users/you/.fractalbot/claude-desktop-inbox"
-    fallbackToInbox: true
-    defaultAgent: "main"
-    allowedAgents:
-      - "main"
-    deliveryTimeoutSeconds: 20
-```
-
-### Routing Model
-
-Telegram, Slack, Discord, Feishu, and iMessage support `/agent <name> <task...>` to route tasks to a specific agent; if omitted, the active router's `defaultAgent` is used. When `allowedAgents` is set, only those names are accepted. Use `/agents` to see allowed agents; if you target a disallowed agent, the bot will suggest `/agents`.
-For routed assignments, FractalBot includes routing context (`channel`, `chat_id`, `user_id`, `username`, `selected_agent`) in the downstream prompt/envelope and explicitly hints outbound-send intent through `use-fractalbot`. If no Telegram recipient is provided, the prompt contract defaults target to current `chat_id`.
-Operator note: make sure `use-fractalbot` appears in the agent's effective available skills list and points to `.claude/skills/use-fractalbot/SKILL.md`.
-`/tool` and `/tools` are intentionally unavailable in gateway mode.
-
-#### Codex App CDP route
-
-The `codexAppCDP` router delivers through CDP into the running Codex App renderer and invokes the in-process app-server request bridge (`start-turn-for-host`). It intentionally does not call an external `codex app-server --listen ...` service.
-
-1. Launch Codex App with CDP enabled:
-
-   ```bash
-   open -na /Applications/Codex.app --args --remote-debugging-port=9222
-   ```
-
-2. Configure `agents.codexAppCDP.targetProject.cwd` plus `targetProject.session` so the gateway resolves the current Codex App conversation before each delivery. `session: "main"` uses an exact `agent_nickname` or title match when present, and otherwise resolves to the latest non-archived thread for that project cwd.
-3. Set `agents.router: codexAppCDP`, `agents.codexAppCDP.enabled: true`, and `agents.codexAppCDP.inboxPath`. Leave `conversationId` empty unless you intentionally want a pinned thread override.
-4. By default, `agents.codexAppCDP.repairPolicy` is `relaunch` and `watch.enabled` is true when `codexAppCDP` is enabled. If CDP is unavailable, FractalBot asks Codex App to quit and reopens it with `--remote-debugging-port`. Set `repairPolicy: "status-only"` or `watch.enabled: false` if you only want reporting.
-5. Keep `checkOnIncomingMessage: true` so each inbound Codex App route checks `/json/version` and `/json/list` before delivery. `cooldownSeconds` prevents repeated repair attempts.
-6. Verify `/status`: it reports `agents.router`, `agents.codex_app_cdp`, `agents.codex_app_cdp.target_project`, `agents.codex_app_cdp.resolved_conversation`, `agents.codex_app_cdp.readiness`, and `agents.last_routing` with `backend`, `status`, `envelope_id`, `inbox_path`, and any CDP error.
-
-If CDP is unavailable and `fallbackToInbox` is true, FractalBot atomically writes the normalized envelope to `inboxPath` so the Codex App-side consumer can process it later.
-
-Troubleshooting CDP readiness:
-
-```bash
-curl -fsS http://127.0.0.1:9222/json/version
-curl -fsS http://127.0.0.1:9222/json/list
-curl -sS http://127.0.0.1:18789/status | python3 -m json.tool
-```
-
-The gateway intentionally does not fall back to `codex app-server proxy` or temporary `codex app-server --listen` delivery. Messages that cannot reach the visible Codex App renderer are either reported as errors or queued to `inboxPath` when `fallbackToInbox` is enabled.
-
-#### Claude Desktop route
-
-The `claudeDesktop` router delivers an inbound prompt only to an authenticated Claude chat page exposed by an existing CDP endpoint. It does not launch Claude Desktop with debugging flags, patch the app, bypass its CDP auth guard, scrape chat history, or use AppleScript UI injection.
-
-1. Confirm CDP exposes a signed-in Claude chat target, not a login page:
-
-   ```bash
-   curl -fsS http://127.0.0.1:19334/json/version
-   curl -fsS http://127.0.0.1:19334/json/list
-   ```
-
-2. Set `agents.router: claudeDesktop`, enable `agents.claudeDesktop`, and configure both `cdpEndpoint` and an `inboxPath` with `fallbackToInbox: true`.
-3. FractalBot writes the normalized envelope and delivery prompt atomically with private file permissions when Claude Desktop is unavailable, logged out, lacks a visible compose box, or rejects the submit action.
-4. Check `/status`: `agents.claude_desktop` exposes the non-secret configuration and `agents.last_routing` records `delivered`, `queued`, or `error` with the envelope and inbox paths.
-
-Additional lifecycle commands:
-- `/agents` (list allowed agent names)
-- `/monitor <name> [lines]` (show recent agent output; lines capped to 200)
-- `/startagent <name>` (admin only)
-- `/stopagent <name>` (admin only)
-- `/doctor` (admin only)
-- `/whoami` (show your Telegram IDs)
-- `/ping` (simple health check)
-
-Slack (DM-only) uses Socket Mode (no public ports) and requires allowlisting user IDs before messages are processed:
-
-```yaml
-channels:
-  slack:
-    enabled: true
-    botToken: "xoxb-your-bot-token"
-    appToken: "xapp-your-app-token"
-    allowedUsers:
-      - "U12345678"
-```
-
-Discord (DM-only) uses the gateway websocket (no public ports) and requires allowlisting user IDs before messages are processed:
-
-```yaml
-channels:
-  discord:
-    enabled: true
-    token: "your-bot-token"
-    allowedUsers:
-      - "123456789012345678"
-```
-
-Tip: `/whoami` works in Slack/Discord DMs even before allowlisting, so users can self-identify.
-
-### Local Demo (Telegram + polling + oh-my-code)
-
-This is the fastest path to a local, end-to-end demo after the CLI entrypoint lands.
-
-1) Copy the example config:
-
-```bash
 cp config.example.yaml config.yaml
-```
 
-2) Edit the minimum fields:
-
-- `channels.telegram.botToken`
-- `channels.telegram.adminID`
-- `channels.telegram.allowedUsers` (include your Telegram user ID)
-- `agents.ohMyCode.enabled: true`
-- `agents.ohMyCode.workspace` (path to your oh-my-code repo)
-- `agents.ohMyCode.defaultAgent` (e.g. `qa-1` or `coder-a`)
-- `agents.ohMyCode.allowedAgents` (include default agent and any others you want)
-
-3) Start the gateway:
-
-```bash
-# Option A: build + run
-make build
-./fractalbot --config ./config.yaml
-
-# Option B: go run (config default is ./config.yaml)
+# Edit config.yaml to enable and configure a channel and router.
 go run ./cmd/fractalbot --config ./config.yaml
 ```
 
-4) Start the gateway and fetch your Telegram IDs:
-
-- Message: `/whoami`
-- Expected: reply includes your User ID. Add it to `channels.telegram.allowedUsers`, restart the bot, and try again.
-
-5) Send Telegram messages:
-
-- Health check:
-  - Message: `/ping`
-  - Expected: `pong`
-
-- Normal routing:
-  - Message: `Hello from demo`
-  - Expected: bot replies with agent-manager output (assignment confirmation plus recent monitor snapshot).
-- Explicit agent selection:
-  - Message: `/agent coder-a summarize current status`
-  - Expected: task is routed to `coder-a`. If not allowed, the bot replies with an `agent \"...\" is not allowed` error.
-
-If the bot is silent, verify the allowlist, and confirm `agents.ohMyCode.enabled: true` and that the agent-manager is running in the oh-my-code workspace.
-
-### Running the Gateway
+Verify the gateway:
 
 ```bash
-./fractalbot --config ./config.yaml --verbose
+curl -fsS http://127.0.0.1:18789/health
+curl -sS http://127.0.0.1:18789/status | python3 -m json.tool
 ```
 
-## 🩺 Troubleshooting
-
-If you hit startup/runtime issues (config validation, token revocation, webhook failures, channel send errors, systemd restart loops, or agent-manager timeouts), use:
-
-- [Troubleshooting: Failure Handling and Rollback](docs/troubleshooting.md)
-
-### Smoke Test (WebSocket Echo)
+Send an outbound message through the running gateway:
 
 ```bash
-# Minimal config for echo (no Telegram token required)
-cat > config.yaml <<'EOF'
-gateway:
-  port: 18789
-  bind: 127.0.0.1
-channels:
-  telegram:
-    enabled: false
-agents:
-  workspace: ./workspace
-  maxConcurrent: 1
-EOF
-
-# Terminal 1: start the gateway
-go run ./cmd/fractalbot --config config.yaml
-
-# Terminal 2: send an echo event
-go run ./cmd/ws-echo-client --url ws://127.0.0.1:18789/ws
+go run ./cmd/fractalbot --config ./config.yaml \
+  message send --channel telegram --to 1234567890 --text "hello"
 ```
 
-Expected output (JSON echo):
+Start with [`config.example.yaml`](config.example.yaml), then read [Agent routing](docs/routing.md) for runtime-specific configuration.
 
-```json
-{"kind":"event","action":"echo","data":{"text":"hello"}}
-```
+## Documentation
 
-## 🔧 Development
+- [Architecture](docs/architecture.md)
+- [Agent routing](docs/routing.md)
+- [Development and local demo](docs/development.md)
+- [Troubleshooting](docs/troubleshooting.md)
+- [Slack setup](docs/slack.md)
+- [Discord setup](docs/discord.md)
+- [iMessage setup](docs/imessage.md)
+- [Chinese guide](docs/guide-zh.md)
 
-### Project Structure
-
-```
-fractalbot/
-├── cmd/
-│   ├── fractalbot/            # Main entry point
-│   └── ws-echo-client/        # Local WS smoke-test helper
-├── internal/
-│   ├── gateway/               # WebSocket gateway server
-│   ├── agent/                 # oh-my-code routing manager
-│   ├── channels/              # Channel implementations
-│   └── config/               # Configuration management
-├── pkg/
-│   └── protocol/              # Protocol definitions
-├── docs/                      # Channel/setup docs
-├── go.mod
-├── go.sum
-├── README.md
-└── LICENSE
-```
-
-### Building
+## Development
 
 ```bash
-# Build for current platform
-go build -o fractalbot ./cmd/fractalbot
-
-# Cross-compile
-GOOS=linux GOARCH=amd64 go build -o fractalbot-linux ./cmd/fractalbot
-GOOS=darwin GOARCH=amd64 go build -o fractalbot-mac ./cmd/fractalbot
-GOOS=windows GOARCH=amd64 go build -o fractalbot.exe ./cmd/fractalbot
+make build
+make test
+make vet
 ```
 
-### Running Tests
+See [Development](docs/development.md) for the project layout, WebSocket smoke test, local demo, and cross-platform builds. Contributions should follow [CONTRIBUTING.md](CONTRIBUTING.md).
 
-```bash
-go test ./...
-go test -v -race ./...
-```
+## License
 
-## 🤝 Contributing
-
-Contributions are welcome! Please read our [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct and the process for submitting pull requests.
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🔗 Links
-
-- [FractalMind AI](https://github.com/fractalmind-ai) - Organization
-- [Clawdbot](https://github.com/clawdbot/clawdbot) - Inspiration source
-- [Agent Manager](https://github.com/fractalmind-ai/agent-manager-skill)
-- [Team Manager](https://github.com/fractalmind-ai/team-manager-skill)
-
-## 🎮 Acknowledgments
-
-- Inspired by [Clawdbot](https://github.com/clawdbot/clawdbot) by Peter Steinberger
-- Process-oriented workflows from [FractalMind AI](https://github.com/fractalmind-ai)
-- Community contributors and feedback
+FractalBot is available under the [MIT License](LICENSE).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,91 @@
+# Architecture
+
+FractalBot is a local-first messaging gateway. Channel-specific adapters normalize inbound messages, a buffered in-process bus decouples transport from routing, and one selected Agent Router delivers each task to an external runtime.
+
+## System overview
+
+```mermaid
+flowchart LR
+    subgraph Channels[Channel adapters]
+        Telegram[Telegram]
+        Feishu[Feishu / Lark]
+        Slack[Slack]
+        Discord[Discord]
+        IMessage[iMessage]
+        Demail[Demail]
+    end
+
+    subgraph Gateway[FractalBot gateway]
+        CM[Channel Manager]
+        Bus[Message Bus]
+        Router{Agent Router}
+        Server[Gateway Server]
+    end
+
+    CLI[CLI] --> HTTP[HTTP API]
+    HTTP --> Bus
+    WS[WebSocket control] --> Server
+    Server --> CM
+
+    subgraph Targets[Routing targets]
+        OMC[oh-my-code agent-manager]
+        Codex[ChatGPT / Codex App]
+        Claude[Claude Desktop]
+        Echo[Legacy echo]
+    end
+
+    subgraph Durable[Durable fallback]
+        CodexInbox[Codex App inbox]
+        ClaudeInbox[Claude Desktop inbox]
+    end
+
+    Telegram --> CM
+    Feishu --> CM
+    Slack --> CM
+    Discord --> CM
+    IMessage --> CM
+    Demail -. Agent ingress pending .-> CM
+    CM <--> Bus
+    Bus -->|Supported ingress| Router
+    Router --> OMC
+    Router --> Codex
+    Router --> Claude
+    Router --> Echo
+    Codex -. delivery failure .-> CodexInbox
+    Claude -. delivery failure .-> ClaudeInbox
+```
+
+## Components
+
+| Component | Responsibility |
+| --- | --- |
+| Gateway server | Owns `/health`, `/status`, `/ws`, and `/api/v1/message/send`; wires the runtime together. |
+| Channel Manager | Registers enabled adapters, gives each adapter an isolated lifecycle context, and sends outbound messages through per-channel workers. |
+| Message Bus | Buffers inbound and outbound work while preserving the synchronous reply contract used by channel adapters. |
+| Agent Manager | Applies the configured router, validates the selected agent, records routing telemetry, and returns an acknowledgement or reply. |
+| Channel adapters | Handle transport authentication, allowlists, normalization, provider-specific replies, and telemetry. |
+
+The six registered adapters are Telegram, Feishu/Lark, Slack, Discord, iMessage, and Demail. The first five currently enter the generic Agent Router. Demail is a bidirectional transport adapter, but its normalized `demail` messages are currently ignored by `agent.Manager.HandleIncoming`; generic Demail-to-agent routing is not yet enabled.
+
+## Inbound flow
+
+1. An enabled adapter receives a provider event and applies its allowlist and channel-specific validation.
+2. The adapter converts the event to a shared protocol message and publishes it through the Message Bus.
+3. The Agent Manager accepts supported channel messages, wraps large bodies when needed, and validates `/agent <name>` selection.
+4. The active router delivers to oh-my-code, the ChatGPT/Codex desktop app, or Claude Desktop. With no enabled router, the legacy behavior echoes the text.
+5. The adapter sends the returned acknowledgement or reply to the original conversation.
+
+## Outbound flow
+
+The CLI calls the gateway's HTTP send endpoint. HTTP and in-process callers publish an outbound envelope to the Message Bus, which selects the named channel and sends through its worker. Workers isolate provider rate limiting and return provider metadata such as message and thread IDs when available.
+
+## Reliability and security boundaries
+
+- Channel lifecycles are isolated so one adapter stopping or panicking does not cancel the others.
+- Channel allowlists default to deny where supported; Slack, Discord, and Telegram also constrain the accepted conversation shapes.
+- The desktop routers can atomically queue normalized envelopes to private inbox directories when CDP delivery is unavailable.
+- The Codex App router exposes readiness, resolved conversation, repair attempts, and last-routing telemetry through `/status`.
+- WebSocket origins can be restricted with `gateway.allowedOrigins`.
+- FractalBot does not store channel tokens outside the operator-provided configuration.
+
+See [Routing](routing.md) for router-specific behavior and configuration.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,101 @@
+# Development
+
+## Setup
+
+```bash
+git clone git@github.com:fractalmind-ai/fractalbot.git
+cd fractalbot
+go mod download
+cp config.example.yaml config.yaml
+```
+
+Edit `config.yaml` to enable at least one channel. The complete option set and inline guidance live in [`config.example.yaml`](../config.example.yaml).
+
+```bash
+go run ./cmd/fractalbot --config ./config.yaml
+```
+
+## Local Telegram demo
+
+For a polling-based Telegram-to-oh-my-code demo, set these values in `config.yaml`:
+
+- `channels.telegram.botToken`
+- `channels.telegram.adminID`
+- `channels.telegram.allowedUsers`
+- `agents.router: ohMyCode`
+- `agents.ohMyCode.enabled: true`
+- `agents.ohMyCode.workspace`
+- `agents.ohMyCode.defaultAgent` and `allowedAgents`
+
+Start the gateway:
+
+```bash
+go run ./cmd/fractalbot --config ./config.yaml
+```
+
+In a Telegram DM, use `/whoami` to confirm your user ID, `/ping` to verify the channel, then send a normal task or `/agent coder-a summarize current status`.
+
+## Build and test
+
+```bash
+make build
+make test
+make vet
+```
+
+Equivalent focused commands:
+
+```bash
+go build -o fractalbot ./cmd/fractalbot
+go test ./...
+go test -v -race ./...
+go vet ./...
+```
+
+Cross-platform builds are available through `make build-all`.
+
+## WebSocket smoke test
+
+Create a minimal config with no enabled channel:
+
+```yaml
+gateway:
+  port: 18789
+  bind: 127.0.0.1
+channels:
+  telegram:
+    enabled: false
+agents:
+  workspace: ./workspace
+  maxConcurrent: 1
+```
+
+Start the gateway in one terminal and the echo client in another:
+
+```bash
+go run ./cmd/fractalbot --config ./config.yaml
+go run ./cmd/ws-echo-client --url ws://127.0.0.1:18789/ws
+```
+
+The client should receive a JSON `echo` event.
+
+## Project structure
+
+```text
+fractalbot/
+├── cmd/
+│   ├── fractalbot/          # CLI and gateway entry point
+│   └── ws-echo-client/      # WebSocket smoke-test client
+├── internal/
+│   ├── agent/               # Agent routers and desktop delivery
+│   ├── bus/                 # In-process message bus
+│   ├── channels/            # Channel adapters and workers
+│   ├── config/              # YAML configuration
+│   └── gateway/             # HTTP and WebSocket server
+├── pkg/protocol/            # Shared protocol types
+├── docs/                    # Operator and design documentation
+├── config.example.yaml
+└── Makefile
+```
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for coding and pull request guidelines.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,130 @@
+# Agent Routing
+
+FractalBot selects one inbound runtime with `agents.router`. Supported values are `ohMyCode`, `codexAppCDP`, and `claudeDesktop`. If `router` is empty, the first enabled runtime is selected in that order; if none is enabled, supported inbound messages use the legacy echo behavior.
+
+Generic Agent Router ingress currently accepts Telegram, Feishu/Lark, Slack, Discord, and iMessage. Demail transport can receive and send messages, but Demail messages do not yet enter these Agent Routers.
+
+## Agent selection
+
+Send `/agent <name> <task>` (or `/to <name> <task>`) to select an allowed agent. Messages without an explicit selection use the active router's `defaultAgent`.
+
+When `allowedAgents` is set, only listed names are accepted. `/agents` shows the available names. Routed envelopes include `channel`, `chat_id`, `user_id`, `username`, and `selected_agent` so the target can reply through the correct channel.
+
+Common commands:
+
+| Command | Purpose |
+| --- | --- |
+| `/agents` | List allowed agent names. |
+| `/monitor <name> [lines]` | Show recent oh-my-code agent output, capped at 200 lines. |
+| `/startagent <name>` | Start an oh-my-code agent; admin only. |
+| `/stopagent <name>` | Stop an oh-my-code agent; admin only. |
+| `/doctor` | Run oh-my-code diagnostics; admin only. |
+| `/whoami` | Show channel identity values for allowlist setup. |
+| `/ping` | Check channel responsiveness. |
+
+`/tool` and `/tools` are intentionally unavailable in gateway mode.
+
+## oh-my-code
+
+The `ohMyCode` router invokes the agent-manager script in an existing oh-my-code workspace.
+
+```yaml
+agents:
+  router: "ohMyCode"
+  ohMyCode:
+    enabled: true
+    workspace: "/path/to/oh-my-code"
+    agentManagerScript: ".claude/skills/agent-manager/scripts/main.py"
+    defaultAgent: "qa-1"
+    allowedAgents:
+      - "qa-1"
+      - "coder-a"
+    assignTimeoutSeconds: 90
+```
+
+The workspace requires Python, tmux, and agent-manager. If routed agents need to send channel replies, make the `use-fractalbot` skill available in that workspace.
+
+## ChatGPT / Codex App
+
+The `codexAppCDP` router delivers into a project conversation managed by the ChatGPT/Codex desktop app. The configuration key keeps its historical `codexAppCDP` name. Delivery uses the running renderer's CDP endpoint and in-process `start-turn-for-host` bridge; it does not start a separate `codex app-server --listen` backend.
+
+```yaml
+agents:
+  router: "codexAppCDP"
+  codexAppCDP:
+    enabled: true
+    cdpEndpoint: "http://127.0.0.1:9222"
+    targetSelector: "Codex"
+    hostId: "local"
+    targetProject:
+      name: "CloudBank"
+      cwd: "/Users/you/Develop/SuLabsOrg/CloudBank"
+      session: "main"
+    conversationId: ""
+    inboxPath: "/Users/you/Develop/SuLabsOrg/CloudBank/.fractalbot/inbox"
+    fallbackToInbox: true
+    repairPolicy: "relaunch"
+    checkOnIncomingMessage: true
+    watch:
+      enabled: true
+      intervalSeconds: 60
+      cooldownSeconds: 90
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+    deliveryTimeoutSeconds: 20
+```
+
+Launch the installed desktop bundle with CDP enabled. Current releases use `ChatGPT.app`; older installations or local aliases may expose `Codex.app`.
+
+```bash
+open -na /Applications/ChatGPT.app --args --remote-debugging-port=9222
+curl -fsS http://127.0.0.1:9222/json/version
+curl -fsS http://127.0.0.1:9222/json/list
+```
+
+Prefer `targetProject.cwd` plus `targetProject.session` over a pinned `conversationId`. FractalBot resolves the current non-archived conversation before each delivery. A configured `conversationId` remains an explicit override.
+
+Repair policies are `off`, `status-only`, `new-instance`, and `relaunch`. The default for an enabled route is `relaunch`, with the watchdog enabled. Set `status-only` when FractalBot should report readiness without controlling the app lifecycle.
+
+When direct delivery fails and `fallbackToInbox` is true, FractalBot atomically writes the normalized envelope to `inboxPath` for later consumption.
+
+## Claude Desktop
+
+The `claudeDesktop` router submits to an already authenticated Claude chat page exposed by CDP.
+
+```yaml
+agents:
+  router: "claudeDesktop"
+  claudeDesktop:
+    enabled: true
+    cdpEndpoint: "http://127.0.0.1:19334"
+    targetSelector: ""
+    inboxPath: "/Users/you/.fractalbot/claude-desktop-inbox"
+    fallbackToInbox: true
+    defaultAgent: "main"
+    allowedAgents:
+      - "main"
+    deliveryTimeoutSeconds: 20
+```
+
+The selected CDP target must be a signed-in Claude chat, not a login page:
+
+```bash
+curl -fsS http://127.0.0.1:19334/json/version
+curl -fsS http://127.0.0.1:19334/json/list
+```
+
+FractalBot does not launch Claude Desktop, patch the application, bypass its CDP authentication guard, scrape chat history, or inject input through AppleScript. If the target is unavailable, logged out, lacks a compose box, or rejects submission, a configured fallback inbox receives the normalized envelope and delivery prompt with private file permissions.
+
+## Observability
+
+Use the status endpoint to inspect the selected router and most recent outcome:
+
+```bash
+curl -sS http://127.0.0.1:18789/status | python3 -m json.tool
+```
+
+For desktop routes, `agents.last_routing` records the backend, status (`delivered`, `queued`, or `error`), selected agent, envelope ID, inbox path, and delivery error. The Codex App route also reports CDP readiness and the resolved project conversation.
+
+See [Troubleshooting](troubleshooting.md) for startup and delivery failures.


### PR DESCRIPTION
## Summary

- replace the outdated ASCII architecture sketch with GitHub-rendered Mermaid diagrams
- document all six channel adapters, three Agent Routers, desktop inbox fallbacks, and the current Demail ingress limitation
- reduce README from 446 to 127 lines and move routing, architecture, local demo, build, and test details into focused docs
- add a compact channel and routing-target capability matrix

## Validation

- `go test ./...`
- rendered both Mermaid blocks with `@mermaid-js/mermaid-cli`
- verified all local links in the changed Markdown files
- `git diff --check`

## Screenshots

Not applicable; documentation-only change with Mermaid rendered by GitHub.