### PR TITLE
feat: add unified Agent Runtime heartbeat scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ flowchart LR
     CM[Channel Manager]
     MB[Message Bus]
     AR{Agent Router}
+    HB[Cron Heartbeat Scheduler]
 
     subgraph Targets[Routing targets]
         OMC[oh-my-code]
@@ -62,6 +63,9 @@ flowchart LR
     DM -. Agent ingress pending .-> CM
     CM <--> MB
     MB -->|Supported ingress| AR
+    HB -->|Explicit runtime and agent| OMC
+    HB -->|Explicit runtime and agent| CA
+    HB -->|Explicit runtime and agent| CD
     AR --> OMC
     AR --> CA
     AR --> CD
@@ -105,6 +109,7 @@ Start with [`config.example.yaml`](config.example.yaml), then read [Agent routin
 
 - [Architecture](docs/architecture.md)
 - [Agent routing](docs/routing.md)
+- [Agent heartbeats](docs/heartbeat.md)
 - [Development and local demo](docs/development.md)
 - [Troubleshooting](docs/troubleshooting.md)
 - [Slack setup](docs/slack.md)

--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -24,6 +25,8 @@ import (
 
 var messageSendFn = sendMessageViaGatewayAPI
 var fileDownloadFn = downloadFileViaHTTP
+var heartbeatCronSetFn = setHeartbeatCronViaGatewayAPI
+var heartbeatCronResetFn = resetHeartbeatCronViaGatewayAPI
 
 const exitCodeRestartRequested = 75
 
@@ -141,8 +144,73 @@ func runCommand(ctx context.Context, cfg *config.Config, args []string, out io.W
 		return runMessageCommand(ctx, cfg, args[1:], out, logger)
 	case "file":
 		return runFileCommand(ctx, cfg, args[1:], out, logger)
+	case "heartbeat":
+		return runHeartbeatCommand(ctx, cfg, args[1:], out, logger)
 	default:
 		logger.Printf("unknown command: %s", args[0])
+		return 1
+	}
+}
+
+func runHeartbeatCommand(ctx context.Context, cfg *config.Config, args []string, out io.Writer, logger *log.Logger) int {
+	if len(args) < 2 || strings.ToLower(strings.TrimSpace(args[0])) != "cron" {
+		logger.Printf("heartbeat command requires a cron subcommand (set or reset)")
+		return 1
+	}
+
+	switch strings.ToLower(strings.TrimSpace(args[1])) {
+	case "set":
+		setFS := flag.NewFlagSet("heartbeat cron set", flag.ContinueOnError)
+		setFS.SetOutput(out)
+		job := setFS.String("job", "", "heartbeat job ID")
+		profile := setFS.String("profile", "", "operator-approved cron profile")
+		reason := setFS.String("reason", "", "reason for reducing heartbeat frequency")
+		if err := setFS.Parse(args[2:]); err != nil {
+			return 1
+		}
+		jobID := strings.TrimSpace(*job)
+		profileName := strings.TrimSpace(*profile)
+		reasonText := strings.TrimSpace(*reason)
+		if jobID == "" {
+			logger.Printf("--job is required")
+			return 1
+		}
+		if profileName == "" {
+			logger.Printf("--profile is required")
+			return 1
+		}
+		if reasonText == "" {
+			logger.Printf("--reason is required")
+			return 1
+		}
+		if err := heartbeatCronSetFn(ctx, cfg, jobID, profileName, reasonText); err != nil {
+			logger.Printf("failed to set heartbeat cron: %v", err)
+			return 1
+		}
+		fmt.Fprintf(out, "Heartbeat job %s now uses cron profile %s\n", jobID, profileName)
+		return 0
+
+	case "reset":
+		resetFS := flag.NewFlagSet("heartbeat cron reset", flag.ContinueOnError)
+		resetFS.SetOutput(out)
+		job := resetFS.String("job", "", "heartbeat job ID")
+		if err := resetFS.Parse(args[2:]); err != nil {
+			return 1
+		}
+		jobID := strings.TrimSpace(*job)
+		if jobID == "" {
+			logger.Printf("--job is required")
+			return 1
+		}
+		if err := heartbeatCronResetFn(ctx, cfg, jobID); err != nil {
+			logger.Printf("failed to reset heartbeat cron: %v", err)
+			return 1
+		}
+		fmt.Fprintf(out, "Heartbeat job %s restored to its default cron\n", jobID)
+		return 0
+
+	default:
+		logger.Printf("unknown heartbeat cron subcommand: %s", args[1])
 		return 1
 	}
 }
@@ -300,6 +368,10 @@ func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel s
 }
 
 func gatewaySendEndpoint(cfg *config.Config) string {
+	return gatewayAPIEndpoint(cfg, "/api/v1/message/send")
+}
+
+func gatewayAPIEndpoint(cfg *config.Config, path string) string {
 	bind := "127.0.0.1"
 	port := 18789
 
@@ -316,7 +388,58 @@ func gatewaySendEndpoint(cfg *config.Config) string {
 		bind = "127.0.0.1"
 	}
 
-	return fmt.Sprintf("http://%s/api/v1/message/send", net.JoinHostPort(bind, strconv.Itoa(port)))
+	return fmt.Sprintf("http://%s%s", net.JoinHostPort(bind, strconv.Itoa(port)), path)
+}
+
+func setHeartbeatCronViaGatewayAPI(ctx context.Context, cfg *config.Config, jobID, profile, reason string) error {
+	payload, err := json.Marshal(heartbeatCronRequest{Profile: profile, Reason: reason})
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	return callHeartbeatCronAPI(ctx, cfg, http.MethodPut, jobID, bytes.NewReader(payload))
+}
+
+func resetHeartbeatCronViaGatewayAPI(ctx context.Context, cfg *config.Config, jobID string) error {
+	return callHeartbeatCronAPI(ctx, cfg, http.MethodDelete, jobID, nil)
+}
+
+type heartbeatCronRequest struct {
+	Profile string `json:"profile"`
+	Reason  string `json:"reason"`
+}
+
+func callHeartbeatCronAPI(ctx context.Context, cfg *config.Config, method, jobID string, body io.Reader) error {
+	path := "/api/v1/heartbeat/jobs/" + url.PathEscape(strings.TrimSpace(jobID)) + "/cron"
+	endpoint := gatewayAPIEndpoint(cfg, path)
+	request, err := http.NewRequestWithContext(ctx, method, endpoint, body)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("request %s failed: %w", endpoint, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		responseBody, _ := io.ReadAll(io.LimitReader(response.Body, 64*1024))
+		message := strings.TrimSpace(string(responseBody))
+		var parsed struct {
+			Error string `json:"error"`
+		}
+		if len(responseBody) > 0 && json.Unmarshal(responseBody, &parsed) == nil && strings.TrimSpace(parsed.Error) != "" {
+			message = parsed.Error
+		}
+		if message == "" {
+			message = http.StatusText(response.StatusCode)
+		}
+		return fmt.Errorf("gateway API error (%d): %s", response.StatusCode, message)
+	}
+	return nil
 }
 
 func downloadFileViaHTTP(ctx context.Context, cfg *config.Config, channel, fileURL, outputPath string) error {

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -336,6 +339,134 @@ func TestRunFileDownload(t *testing.T) {
 			t.Fatalf("unexpected output: %q", buf.String())
 		}
 	})
+}
+
+func TestRunHeartbeatCronCommands(t *testing.T) {
+	configPath := writeMinimalConfig(t)
+	originalSet := heartbeatCronSetFn
+	originalReset := heartbeatCronResetFn
+	t.Cleanup(func() {
+		heartbeatCronSetFn = originalSet
+		heartbeatCronResetFn = originalReset
+	})
+
+	t.Run("set", func(t *testing.T) {
+		called := false
+		heartbeatCronSetFn = func(ctx context.Context, cfg *config.Config, jobID, profile, reason string) error {
+			called = true
+			if jobID != "cloudbank-main" || profile != "idle" || reason != "no actionable tasks" {
+				t.Fatalf("unexpected set arguments: job=%q profile=%q reason=%q", jobID, profile, reason)
+			}
+			return nil
+		}
+		var output bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"heartbeat", "cron", "set",
+			"--job", "cloudbank-main",
+			"--profile", "idle",
+			"--reason", "no actionable tasks",
+		}, &output)
+		if code != 0 || !called {
+			t.Fatalf("code=%d called=%t output=%q", code, called, output.String())
+		}
+		if !strings.Contains(output.String(), "now uses cron profile idle") {
+			t.Fatalf("unexpected output: %q", output.String())
+		}
+	})
+
+	t.Run("reset", func(t *testing.T) {
+		called := false
+		heartbeatCronResetFn = func(ctx context.Context, cfg *config.Config, jobID string) error {
+			called = true
+			if jobID != "cloudbank-main" {
+				t.Fatalf("jobID=%q", jobID)
+			}
+			return nil
+		}
+		var output bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"heartbeat", "cron", "reset",
+			"--job", "cloudbank-main",
+		}, &output)
+		if code != 0 || !called {
+			t.Fatalf("code=%d called=%t output=%q", code, called, output.String())
+		}
+		if !strings.Contains(output.String(), "restored to its default cron") {
+			t.Fatalf("unexpected output: %q", output.String())
+		}
+	})
+
+	t.Run("validation", func(t *testing.T) {
+		for _, test := range []struct {
+			name string
+			args []string
+			want string
+		}{
+			{name: "missing job", args: []string{"heartbeat", "cron", "set", "--profile", "idle", "--reason", "idle"}, want: "--job is required"},
+			{name: "missing profile", args: []string{"heartbeat", "cron", "set", "--job", "job-1", "--reason", "idle"}, want: "--profile is required"},
+			{name: "missing reason", args: []string{"heartbeat", "cron", "set", "--job", "job-1", "--profile", "idle"}, want: "--reason is required"},
+			{name: "reset missing job", args: []string{"heartbeat", "cron", "reset"}, want: "--job is required"},
+		} {
+			t.Run(test.name, func(t *testing.T) {
+				var output bytes.Buffer
+				args := append([]string{"--config", configPath}, test.args...)
+				if code := runWithContext(context.Background(), args, &output); code == 0 || !strings.Contains(output.String(), test.want) {
+					t.Fatalf("code=%d output=%q want=%q", code, output.String(), test.want)
+				}
+			})
+		}
+	})
+}
+
+func TestHeartbeatCronGatewayAPIRequests(t *testing.T) {
+	type observedRequest struct {
+		method  string
+		path    string
+		profile string
+		reason  string
+	}
+	observed := make(chan observedRequest, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		request := observedRequest{method: r.Method, path: r.URL.Path}
+		if r.Method == http.MethodPut {
+			var payload heartbeatCronRequest
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			request.profile = payload.Profile
+			request.reason = payload.Reason
+		}
+		observed <- request
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer server.Close()
+
+	host, portText, err := net.SplitHostPort(server.Listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Gateway: &config.GatewayConfig{Bind: host, Port: port}}
+	if err := setHeartbeatCronViaGatewayAPI(context.Background(), cfg, "cloudbank-main", "idle", "no actionable tasks"); err != nil {
+		t.Fatalf("setHeartbeatCronViaGatewayAPI: %v", err)
+	}
+	if err := resetHeartbeatCronViaGatewayAPI(context.Background(), cfg, "cloudbank-main"); err != nil {
+		t.Fatalf("resetHeartbeatCronViaGatewayAPI: %v", err)
+	}
+	setRequest := <-observed
+	resetRequest := <-observed
+	if setRequest.method != http.MethodPut || setRequest.path != "/api/v1/heartbeat/jobs/cloudbank-main/cron" || setRequest.profile != "idle" || setRequest.reason != "no actionable tasks" {
+		t.Fatalf("unexpected set request: %#v", setRequest)
+	}
+	if resetRequest.method != http.MethodDelete || resetRequest.path != "/api/v1/heartbeat/jobs/cloudbank-main/cron" {
+		t.Fatalf("unexpected reset request: %#v", resetRequest)
+	}
 }
 
 func TestDownloadFileViaHTTPSlackAuth(t *testing.T) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -221,3 +221,25 @@ agents:
     allowedAgents:
       - "main"
     deliveryTimeoutSeconds: 20
+
+  # Optional: cron-based autonomous wakeups. Each job explicitly targets one
+  # enabled runtime and an agent allowed by that runtime. Heartbeats do not use
+  # agents.router and do not impersonate a messaging channel.
+  # heartbeat:
+  #   enabled: true
+  #   statePath: "./workspace/heartbeat-state.json"
+  #   maxConcurrent: 2
+  #   jobs:
+  #     - id: "cloudbank-main"
+  #       runtime: "codexAppCDP"
+  #       agent: "main"
+  #       # Inline text only; file-backed instructions are not supported.
+  #       text: "Inspect the current project and continue any actionable work."
+  #       cron: "*/10 * * * *"
+  #       timezone: "Asia/Shanghai"
+  #       # The Agent may select only these operator-approved schedules, and
+  #       # only when it determines that there is no actionable work.
+  #       agentCronProfiles:
+  #         idle: "0 * * * *"
+  #         deep-idle: "0 */6 * * *"
+  #       resetCronOnInbound: true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,10 +20,12 @@ flowchart LR
         Bus[Message Bus]
         Router{Agent Router}
         Server[Gateway Server]
+        Heartbeat[Cron Heartbeat Scheduler]
     end
 
     CLI[CLI] --> HTTP[HTTP API]
     HTTP --> Bus
+    HTTP -->|Local cron profile control| Heartbeat
     WS[WebSocket control] --> Server
     Server --> CM
 
@@ -51,6 +53,9 @@ flowchart LR
     Router --> Codex
     Router --> Claude
     Router --> Echo
+    Heartbeat -->|Explicit runtime and agent| OMC
+    Heartbeat -->|Explicit runtime and agent| Codex
+    Heartbeat -->|Explicit runtime and agent| Claude
     Codex -. delivery failure .-> CodexInbox
     Claude -. delivery failure .-> ClaudeInbox
 ```
@@ -63,6 +68,7 @@ flowchart LR
 | Channel Manager | Registers enabled adapters, gives each adapter an isolated lifecycle context, and sends outbound messages through per-channel workers. |
 | Message Bus | Buffers inbound and outbound work while preserving the synchronous reply contract used by channel adapters. |
 | Agent Manager | Applies the configured router, validates the selected agent, records routing telemetry, and returns an acknowledgement or reply. |
+| Heartbeat Scheduler | Calculates explicit-timezone cron jobs, persists effective profiles, and dispatches autonomous wakeups directly to a configured Runtime and Agent. |
 | Channel adapters | Handle transport authentication, allowlists, normalization, provider-specific replies, and telemetry. |
 
 The six registered adapters are Telegram, Feishu/Lark, Slack, Discord, iMessage, and Demail. The first five currently enter the generic Agent Router. Demail is a bidirectional transport adapter, but its normalized `demail` messages are currently ignored by `agent.Manager.HandleIncoming`; generic Demail-to-agent routing is not yet enabled.
@@ -78,6 +84,12 @@ The six registered adapters are Telegram, Feishu/Lark, Slack, Discord, iMessage,
 ## Outbound flow
 
 The CLI calls the gateway's HTTP send endpoint. HTTP and in-process callers publish an outbound envelope to the Message Bus, which selects the named channel and sends through its worker. Workers isolate provider rate limiting and return provider metadata such as message and thread IDs when available.
+
+## Heartbeat flow
+
+Heartbeat jobs bypass the selected Agent Router and address `ohMyCode`, `codexAppCDP`, or `claudeDesktop` explicitly. The scheduler sends an autonomous envelope with job, run, schedule, expiry, target Agent, and inline instruction metadata. It does not synthesize a channel or chat identity and never sends a channel acknowledgement.
+
+Desktop fallback inboxes coalesce queued heartbeats by job so an unavailable app does not accumulate stale wakeups. Agents normally do not report back to the scheduler. Only an Agent that finds no actionable work may select an operator-approved lower-frequency cron profile through the loopback API; matching user activity can restore the configured default cron. See [Agent heartbeats](heartbeat.md).
 
 ## Reliability and security boundaries
 

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -1,0 +1,83 @@
+# Agent Heartbeats
+
+FractalBot can wake supported Agent Runtimes on explicit-timezone cron schedules. A heartbeat asks an Agent to inspect and advance its work; it is not a runtime readiness probe and it is not a synthetic channel message.
+
+Supported targets are `ohMyCode`, `codexAppCDP`, and `claudeDesktop`. Each job selects its Runtime and Agent directly, independently of the inbound `agents.router` setting.
+
+## Configuration
+
+The target Runtime must be enabled, and the job's Agent must be accepted by its `defaultAgent` or `allowedAgents` configuration.
+
+```yaml
+agents:
+  heartbeat:
+    enabled: true
+    statePath: "./workspace/heartbeat-state.json"
+    maxConcurrent: 2
+    jobs:
+      - id: "cloudbank-main"
+        runtime: "codexAppCDP"
+        agent: "main"
+        text: "Inspect the current project and continue any actionable work."
+        cron: "*/10 * * * *"
+        timezone: "Asia/Shanghai"
+        agentCronProfiles:
+          idle: "0 * * * *"
+          deep-idle: "0 */6 * * *"
+        resetCronOnInbound: true
+```
+
+`text` is the complete inline instruction. Heartbeat prompt files are not supported. Cron expressions use the standard five-field format, and every job requires an IANA timezone.
+
+The configured `cron` remains the default. `agentCronProfiles` contains the only alternative schedules an Agent may select; arbitrary Agent-provided cron expressions are rejected.
+
+## Schedule adjustment
+
+A normal heartbeat requires no callback. Only when the Agent determines that there is no actionable work should it reduce the frequency:
+
+```bash
+fractalbot heartbeat cron set \
+  --job cloudbank-main \
+  --profile idle \
+  --reason "no actionable tasks"
+```
+
+Setting the active profile again is a successful no-op. Restore the configured default with:
+
+```bash
+fractalbot heartbeat cron reset --job cloudbank-main
+```
+
+The equivalent loopback-only API is:
+
+```http
+PUT /api/v1/heartbeat/jobs/cloudbank-main/cron
+Content-Type: application/json
+
+{"profile":"idle","reason":"no actionable tasks"}
+```
+
+```http
+DELETE /api/v1/heartbeat/jobs/cloudbank-main/cron
+```
+
+When `resetCronOnInbound` is true, a normal user message successfully routed to the same Runtime and Agent also restores the default cron. Rejected, malformed, or unrelated messages do not reset it.
+
+## Delivery behavior
+
+- One run per job may be in flight; overlapping ticks are skipped.
+- `maxConcurrent` limits dispatches across all jobs.
+- The effective profile and delivery telemetry are written atomically to `statePath`.
+- Restart preserves the effective profile but calculates the next future occurrence. Missed heartbeats are never replayed.
+- Codex App and Claude Desktop inbox fallback uses a stable key per job. A newer queued heartbeat replaces the older unconsumed heartbeat.
+- Runtime delivery errors receive a bounded exponential-backoff retry. The final failure is recorded without changing the Agent-selected schedule.
+
+## Status
+
+`GET /status` includes a redacted `heartbeat` section with configured and effective cron, timezone, next run, in-flight state, last dispatch result, and schedule-change audit fields.
+
+```bash
+curl -sS http://127.0.0.1:18789/status | python3 -m json.tool
+```
+
+The inline instruction is not included in status output.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fractalmind-ai/fractal-demail/gas-station-adapter v0.0.0-20260703092431-07048eacc6b7
 	github.com/gorilla/websocket v1.5.3
 	github.com/larksuite/oapi-sdk-go/v3 v3.5.3
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/slack-go/slack v0.17.3
 	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/larksuite/oapi-sdk-go/v3 v3.5.3 h1:xvf8Dv29kBXC5/DNDCLhHkAFW8l/0LlQJi
 github.com/larksuite/oapi-sdk-go/v3 v3.5.3/go.mod h1:ZEplY+kwuIrj/nqw5uSCINNATcH3KdxSN7y+UxYY5fI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/slack-go/slack v0.17.3 h1:zV5qO3Q+WJAQ/XwbGfNFrRMaJ5T/naqaonyPV/1TP4g=
 github.com/slack-go/slack v0.17.3/go.mod h1:X+UqOufi3LYQHDnMG1vxf0J8asC6+WllXrVrhl8/Prk=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/internal/agent/claude_desktop.go
+++ b/internal/agent/claude_desktop.go
@@ -209,7 +209,7 @@ func writeClaudeDesktopInboxEnvelope(inboxPath string, envelope ClaudeDesktopEnv
 	if err := os.MkdirAll(inboxPath, 0700); err != nil {
 		return "", fmt.Errorf("create Claude Desktop inbox: %w", err)
 	}
-	name := fmt.Sprintf("%s-%s.json", time.Now().UTC().Format("20060102T150405.000000000Z"), envelope.ID)
+	name := appInboxEnvelopeName(envelope)
 	finalPath := filepath.Join(inboxPath, name)
 	tmp, err := os.CreateTemp(inboxPath, "."+name+"-*.tmp")
 	if err != nil {

--- a/internal/agent/codex_app_cdp.go
+++ b/internal/agent/codex_app_cdp.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -45,6 +46,12 @@ const (
 type InboundAppEnvelope struct {
 	ID            string                `json:"id"`
 	ReceivedAt    string                `json:"received_at"`
+	Source        string                `json:"source,omitempty"`
+	JobID         string                `json:"job_id,omitempty"`
+	RunID         string                `json:"run_id,omitempty"`
+	ScheduledAt   string                `json:"scheduled_at,omitempty"`
+	ExpiresAt     string                `json:"expires_at,omitempty"`
+	CoalesceKey   string                `json:"coalesce_key,omitempty"`
 	Channel       string                `json:"channel"`
 	ChatID        string                `json:"chat_id,omitempty"`
 	ThreadTS      string                `json:"thread_ts,omitempty"`
@@ -962,7 +969,7 @@ func writeCodexAppInboxEnvelope(inboxPath string, envelope CodexAppEnvelope) (st
 	if err := os.MkdirAll(inboxPath, 0700); err != nil {
 		return "", fmt.Errorf("create Codex App inbox: %w", err)
 	}
-	name := fmt.Sprintf("%s-%s.json", time.Now().UTC().Format("20060102T150405.000000000Z"), envelope.ID)
+	name := appInboxEnvelopeName(envelope)
 	finalPath := filepath.Join(inboxPath, name)
 	tmp, err := os.CreateTemp(inboxPath, "."+name+"-*.tmp")
 	if err != nil {
@@ -984,6 +991,14 @@ func writeCodexAppInboxEnvelope(inboxPath string, envelope CodexAppEnvelope) (st
 		return "", fmt.Errorf("commit Codex App inbox envelope: %w", err)
 	}
 	return finalPath, nil
+}
+
+func appInboxEnvelopeName(envelope InboundAppEnvelope) string {
+	if key := strings.TrimSpace(envelope.CoalesceKey); key != "" {
+		digest := sha256.Sum256([]byte(key))
+		return fmt.Sprintf("heartbeat-%x.json", digest[:12])
+	}
+	return fmt.Sprintf("%s-%s.json", time.Now().UTC().Format("20060102T150405.000000000Z"), envelope.ID)
 }
 
 type cdpTarget struct {

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fractalmind-ai/fractalbot/internal/agentruntime"
 	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
@@ -50,6 +51,8 @@ type Manager struct {
 	cdpMonitorDone      chan struct{}
 	cdpReadiness        *CodexAppCDPReadinessStatus
 	cdpResolvedTarget   *CodexAppCDPResolvedConversationStatus
+	inboundHookMu       sync.RWMutex
+	inboundRoutedHook   func(runtimeName, agentName string)
 }
 
 type RoutingOutcome struct {
@@ -155,6 +158,7 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 		if err != nil {
 			return "", err
 		}
+		m.notifyInboundRouted(agentruntime.CodexAppCDP, agentName)
 		out = normalizeUserReply(out)
 		if out == "" {
 			return "", nil
@@ -171,6 +175,7 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 		if err != nil {
 			return "", err
 		}
+		m.notifyInboundRouted(agentruntime.ClaudeDesktop, agentName)
 		out = normalizeUserReply(out)
 		if out == "" {
 			return "", nil
@@ -187,6 +192,7 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 		if err != nil {
 			return "", err
 		}
+		m.notifyInboundRouted(agentruntime.OhMyCode, agentName)
 		out = normalizeUserReply(out)
 		if out == "" {
 			return "", nil
@@ -198,6 +204,40 @@ func (m *Manager) HandleIncoming(ctx context.Context, msg *protocol.Message) (st
 	}
 
 	return fmt.Sprintf("echo: %s", text), nil
+}
+
+// SetInboundRoutedHook registers a callback invoked after a normal channel
+// message is successfully dispatched to an Agent Runtime.
+func (m *Manager) SetInboundRoutedHook(hook func(runtimeName, agentName string)) {
+	m.inboundHookMu.Lock()
+	m.inboundRoutedHook = hook
+	m.inboundHookMu.Unlock()
+}
+
+func (m *Manager) notifyInboundRouted(runtimeName, agentName string) {
+	agentName = strings.TrimSpace(agentName)
+	if agentName == "" && m.config != nil {
+		switch runtimeName {
+		case agentruntime.OhMyCode:
+			if m.config.OhMyCode != nil {
+				agentName = strings.TrimSpace(m.config.OhMyCode.DefaultAgent)
+			}
+		case agentruntime.CodexAppCDP:
+			if m.config.CodexAppCDP != nil {
+				agentName = strings.TrimSpace(m.config.CodexAppCDP.DefaultAgent)
+			}
+		case agentruntime.ClaudeDesktop:
+			if m.config.ClaudeDesktop != nil {
+				agentName = strings.TrimSpace(m.config.ClaudeDesktop.DefaultAgent)
+			}
+		}
+	}
+	m.inboundHookMu.RLock()
+	hook := m.inboundRoutedHook
+	m.inboundHookMu.RUnlock()
+	if hook != nil {
+		hook(runtimeName, agentName)
+	}
 }
 
 func (m *Manager) activeRouter() string {

--- a/internal/agent/runtime_dispatch.go
+++ b/internal/agent/runtime_dispatch.go
@@ -1,0 +1,176 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/agentruntime"
+)
+
+// DispatchRuntime delivers a non-channel wakeup to an explicitly selected
+// Agent Runtime. The result confirms delivery or queueing, not task completion.
+func (m *Manager) DispatchRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {
+	request.Runtime = strings.TrimSpace(request.Runtime)
+	request.Agent = strings.TrimSpace(request.Agent)
+	request.Text = strings.TrimSpace(request.Text)
+	result := agentruntime.DispatchResult{Runtime: request.Runtime, Agent: request.Agent}
+	if request.Text == "" {
+		result.Status = "error"
+		result.Error = "runtime dispatch text is required"
+		return result
+	}
+
+	switch request.Runtime {
+	case agentruntime.OhMyCode:
+		return m.dispatchOhMyCodeRuntime(ctx, request)
+	case agentruntime.CodexAppCDP:
+		return m.dispatchCodexAppRuntime(ctx, request)
+	case agentruntime.ClaudeDesktop:
+		return m.dispatchClaudeDesktopRuntime(ctx, request)
+	default:
+		result.Status = "error"
+		result.Error = fmt.Sprintf("unsupported Agent Runtime %q", request.Runtime)
+		return result
+	}
+}
+
+func (m *Manager) dispatchOhMyCodeRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {
+	result := agentruntime.DispatchResult{Runtime: request.Runtime, Agent: request.Agent}
+	workspace, script, err := m.resolveOhMyCodeWorkspaceAndScript()
+	if err != nil {
+		return runtimeDispatchError(result, err)
+	}
+	name, err := m.validateOhMyCodeAgent(request.Agent)
+	if err != nil {
+		return runtimeDispatchError(result, err)
+	}
+	result.Agent = name
+
+	timeout := defaultOhMyCodeAssignTimeout
+	if m.config.OhMyCode.AssignTimeoutSeconds > 0 {
+		timeout = time.Duration(m.config.OhMyCode.AssignTimeoutSeconds) * time.Second
+	}
+	dispatchCtx := ctx
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		dispatchCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	if _, err := runOhMyCodeAgentManager(dispatchCtx, workspace, script, buildRuntimePrompt(request), "assign", name); err != nil {
+		return runtimeDispatchError(result, err)
+	}
+	result.Status = "assigned"
+	return result
+}
+
+func (m *Manager) dispatchCodexAppRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {
+	result := agentruntime.DispatchResult{Runtime: request.Runtime, Agent: request.Agent}
+	if m.config == nil || m.config.CodexAppCDP == nil || !m.config.CodexAppCDP.Enabled {
+		return runtimeDispatchError(result, errors.New("agents.codexAppCDP is not enabled"))
+	}
+	name, err := m.validateCodexAppAgent(request.Agent)
+	if err != nil {
+		return runtimeDispatchError(result, err)
+	}
+	result.Agent = name
+	envelope := buildRuntimeAppEnvelope(request, name)
+	delivery := m.deliverCodexAppEnvelope(ctx, m.config.CodexAppCDP, envelope, buildRuntimePrompt(request))
+	result.Status = delivery.Status
+	result.EnvelopeID = delivery.EnvelopeID
+	result.InboxPath = delivery.InboxPath
+	if delivery.Error != nil {
+		result.Error = delivery.Error.Error()
+	}
+	return result
+}
+
+func (m *Manager) dispatchClaudeDesktopRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {
+	result := agentruntime.DispatchResult{Runtime: request.Runtime, Agent: request.Agent}
+	if m.config == nil || m.config.ClaudeDesktop == nil || !m.config.ClaudeDesktop.Enabled {
+		return runtimeDispatchError(result, errors.New("agents.claudeDesktop is not enabled"))
+	}
+	name, err := m.validateClaudeDesktopAgent(request.Agent)
+	if err != nil {
+		return runtimeDispatchError(result, err)
+	}
+	result.Agent = name
+	envelope := buildRuntimeAppEnvelope(request, name)
+	delivery := m.deliverClaudeDesktopEnvelope(ctx, m.config.ClaudeDesktop, envelope, buildRuntimePrompt(request))
+	result.Status = delivery.Status
+	result.EnvelopeID = delivery.EnvelopeID
+	result.InboxPath = delivery.InboxPath
+	if delivery.Error != nil {
+		result.Error = delivery.Error.Error()
+	}
+	return result
+}
+
+func runtimeDispatchError(result agentruntime.DispatchResult, err error) agentruntime.DispatchResult {
+	result.Status = "error"
+	if err != nil {
+		result.Error = err.Error()
+	}
+	return result
+}
+
+func buildRuntimeAppEnvelope(request agentruntime.DispatchRequest, agentName string) InboundAppEnvelope {
+	receivedAt := time.Now().UTC()
+	scheduledAt := request.ScheduledAt
+	if scheduledAt.IsZero() {
+		scheduledAt = receivedAt
+	}
+	return InboundAppEnvelope{
+		ID:            newEnvelopeID(),
+		ReceivedAt:    receivedAt.Format(time.RFC3339Nano),
+		Source:        strings.TrimSpace(request.Source),
+		JobID:         strings.TrimSpace(request.JobID),
+		RunID:         strings.TrimSpace(request.RunID),
+		ScheduledAt:   scheduledAt.UTC().Format(time.RFC3339Nano),
+		ExpiresAt:     formatOptionalRuntimeTime(request.ExpiresAt),
+		CoalesceKey:   strings.TrimSpace(request.CoalesceKey),
+		SelectedAgent: strings.TrimSpace(agentName),
+		Text:          strings.TrimSpace(request.Text),
+	}
+}
+
+func buildRuntimePrompt(request agentruntime.DispatchRequest) string {
+	profiles := append([]string(nil), request.CronProfiles...)
+	sort.Strings(profiles)
+	var builder strings.Builder
+	builder.WriteString("# FractalBot Heartbeat\n\n")
+	builder.WriteString(fmt.Sprintf("- job_id: %s\n", strings.TrimSpace(request.JobID)))
+	builder.WriteString(fmt.Sprintf("- run_id: %s\n", strings.TrimSpace(request.RunID)))
+	builder.WriteString(fmt.Sprintf("- runtime: %s\n", strings.TrimSpace(request.Runtime)))
+	builder.WriteString(fmt.Sprintf("- agent: %s\n", strings.TrimSpace(request.Agent)))
+	if !request.ScheduledAt.IsZero() {
+		builder.WriteString(fmt.Sprintf("- scheduled_at: %s\n", request.ScheduledAt.UTC().Format(time.RFC3339Nano)))
+	}
+	if !request.ExpiresAt.IsZero() {
+		builder.WriteString(fmt.Sprintf("- expires_at: %s\n", request.ExpiresAt.UTC().Format(time.RFC3339Nano)))
+	}
+	builder.WriteString("\nThis is an autonomous wakeup, not a chat message. Do not reply to a messaging channel unless the task itself requires it.\n\n")
+	builder.WriteString("Instruction:\n")
+	builder.WriteString(strings.TrimSpace(request.Text))
+	builder.WriteString("\n")
+	if len(profiles) > 0 {
+		builder.WriteString("\nIf and only if there is no actionable work, you may reduce this heartbeat frequency with:\n")
+		builder.WriteString(fmt.Sprintf("fractalbot heartbeat cron set --job %s --profile <profile> --reason \"no actionable tasks\"\n", strings.TrimSpace(request.JobID)))
+		builder.WriteString("Allowed profiles: ")
+		builder.WriteString(strings.Join(profiles, ", "))
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+func formatOptionalRuntimeTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+var _ agentruntime.Dispatcher = (*Manager)(nil)

--- a/internal/agent/runtime_dispatch_test.go
+++ b/internal/agent/runtime_dispatch_test.go
@@ -1,0 +1,174 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/agentruntime"
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+func TestDispatchRuntimeSupportsOhMyCode(t *testing.T) {
+	workspace := t.TempDir()
+	script := filepath.Join(workspace, "agent_manager.py")
+	scriptBody := `import sys
+prompt = sys.stdin.read()
+if "# FractalBot Heartbeat" not in prompt or "job_id: job-1" not in prompt:
+    raise SystemExit("missing heartbeat context")
+print("assigned")
+`
+	if err := os.WriteFile(script, []byte(scriptBody), 0700); err != nil {
+		t.Fatalf("write agent manager: %v", err)
+	}
+	manager := NewManager(&config.AgentsConfig{OhMyCode: &config.OhMyCodeConfig{
+		Enabled:            true,
+		Workspace:          workspace,
+		AgentManagerScript: script,
+		DefaultAgent:       "main",
+		AllowedAgents:      []string{"main"},
+	}})
+	result := manager.DispatchRuntime(context.Background(), runtimeTestRequest(agentruntime.OhMyCode, "run-1"))
+	if result.Status != "assigned" || result.Error != "" || result.Agent != "main" {
+		t.Fatalf("unexpected ohMyCode result: %#v", result)
+	}
+}
+
+func TestDispatchRuntimeCoalescesCodexAppHeartbeatInbox(t *testing.T) {
+	inbox := filepath.Join(t.TempDir(), "codex-inbox")
+	manager := NewManager(&config.AgentsConfig{CodexAppCDP: &config.CodexAppCDPConfig{
+		Enabled:       true,
+		InboxPath:     inbox,
+		DefaultAgent:  "main",
+		AllowedAgents: []string{"main"},
+	}})
+
+	first := manager.DispatchRuntime(context.Background(), runtimeTestRequest(agentruntime.CodexAppCDP, "run-1"))
+	secondRequest := runtimeTestRequest(agentruntime.CodexAppCDP, "run-2")
+	secondRequest.Text = "newest instruction"
+	second := manager.DispatchRuntime(context.Background(), secondRequest)
+	if first.Status != "queued" || second.Status != "queued" || first.InboxPath != second.InboxPath {
+		t.Fatalf("heartbeat deliveries were not coalesced: first=%#v second=%#v", first, second)
+	}
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 || !strings.HasPrefix(entries[0].Name(), "heartbeat-") {
+		t.Fatalf("expected one stable heartbeat file, got %#v", entries)
+	}
+	data, err := os.ReadFile(second.InboxPath)
+	if err != nil {
+		t.Fatalf("read heartbeat envelope: %v", err)
+	}
+	var envelope CodexAppEnvelope
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		t.Fatalf("decode heartbeat envelope: %v", err)
+	}
+	assertRuntimeEnvelope(t, envelope, "run-2", "newest instruction")
+}
+
+func TestDispatchRuntimeCoalescesClaudeDesktopHeartbeatInbox(t *testing.T) {
+	inbox := filepath.Join(t.TempDir(), "claude-inbox")
+	manager := NewManager(&config.AgentsConfig{ClaudeDesktop: &config.ClaudeDesktopConfig{
+		Enabled:       true,
+		InboxPath:     inbox,
+		DefaultAgent:  "main",
+		AllowedAgents: []string{"main"},
+	}})
+
+	first := manager.DispatchRuntime(context.Background(), runtimeTestRequest(agentruntime.ClaudeDesktop, "run-1"))
+	secondRequest := runtimeTestRequest(agentruntime.ClaudeDesktop, "run-2")
+	secondRequest.Text = "newest instruction"
+	second := manager.DispatchRuntime(context.Background(), secondRequest)
+	if first.Status != "queued" || second.Status != "queued" || first.InboxPath != second.InboxPath {
+		t.Fatalf("heartbeat deliveries were not coalesced: first=%#v second=%#v", first, second)
+	}
+	entries, err := os.ReadDir(inbox)
+	if err != nil {
+		t.Fatalf("read inbox: %v", err)
+	}
+	if len(entries) != 1 || !strings.HasPrefix(entries[0].Name(), "heartbeat-") {
+		t.Fatalf("expected one stable heartbeat file, got %#v", entries)
+	}
+	data, err := os.ReadFile(second.InboxPath)
+	if err != nil {
+		t.Fatalf("read heartbeat envelope: %v", err)
+	}
+	var queued claudeDesktopInboxEnvelope
+	if err := json.Unmarshal(data, &queued); err != nil {
+		t.Fatalf("decode heartbeat envelope: %v", err)
+	}
+	assertRuntimeEnvelope(t, queued.Envelope, "run-2", "newest instruction")
+	if !strings.Contains(queued.Prompt, "This is an autonomous wakeup, not a chat message") {
+		t.Fatalf("heartbeat prompt missing autonomous context: %q", queued.Prompt)
+	}
+	if strings.Contains(queued.Prompt, "channel:") || strings.Contains(queued.Prompt, "chat_id:") {
+		t.Fatalf("heartbeat prompt contains synthetic channel identity: %q", queued.Prompt)
+	}
+}
+
+func TestDispatchRuntimeRejectsInvalidTargetAndText(t *testing.T) {
+	manager := NewManager(&config.AgentsConfig{})
+	request := runtimeTestRequest("unknown", "run-1")
+	result := manager.DispatchRuntime(context.Background(), request)
+	if result.Status != "error" || !strings.Contains(result.Error, "unsupported Agent Runtime") {
+		t.Fatalf("unexpected unsupported runtime result: %#v", result)
+	}
+	request.Text = " "
+	result = manager.DispatchRuntime(context.Background(), request)
+	if result.Status != "error" || !strings.Contains(result.Error, "text is required") {
+		t.Fatalf("unexpected empty text result: %#v", result)
+	}
+}
+
+func TestBuildRuntimePromptOnlyOffersConfiguredProfiles(t *testing.T) {
+	request := runtimeTestRequest(agentruntime.CodexAppCDP, "run-1")
+	request.CronProfiles = []string{"deep-idle", "idle"}
+	prompt := buildRuntimePrompt(request)
+	for _, expected := range []string{
+		"fractalbot heartbeat cron set --job job-1 --profile <profile>",
+		"Allowed profiles: deep-idle, idle",
+		"If and only if there is no actionable work",
+	} {
+		if !strings.Contains(prompt, expected) {
+			t.Fatalf("prompt missing %q: %s", expected, prompt)
+		}
+	}
+	if strings.Contains(prompt, "channel:") || strings.Contains(prompt, "chat_id:") {
+		t.Fatalf("runtime prompt contains channel identity: %s", prompt)
+	}
+}
+
+func runtimeTestRequest(runtimeName, runID string) agentruntime.DispatchRequest {
+	scheduledAt := time.Date(2026, 7, 26, 2, 0, 0, 0, time.UTC)
+	return agentruntime.DispatchRequest{
+		Runtime:      runtimeName,
+		Agent:        "main",
+		Text:         "inspect actionable work",
+		Source:       "heartbeat",
+		JobID:        "job-1",
+		RunID:        runID,
+		ScheduledAt:  scheduledAt,
+		ExpiresAt:    scheduledAt.Add(10 * time.Minute),
+		CoalesceKey:  "heartbeat:job-1",
+		CronProfiles: []string{"idle"},
+	}
+}
+
+func assertRuntimeEnvelope(t *testing.T, envelope InboundAppEnvelope, runID, text string) {
+	t.Helper()
+	if envelope.Source != "heartbeat" || envelope.JobID != "job-1" || envelope.RunID != runID || envelope.CoalesceKey != "heartbeat:job-1" {
+		t.Fatalf("unexpected heartbeat metadata: %#v", envelope)
+	}
+	if envelope.SelectedAgent != "main" || envelope.Text != text || envelope.ScheduledAt == "" || envelope.ExpiresAt == "" {
+		t.Fatalf("unexpected heartbeat envelope: %#v", envelope)
+	}
+	if envelope.Channel != "" || envelope.ChatID != "" || envelope.UserID != "" || envelope.Username != "" {
+		t.Fatalf("heartbeat envelope contains synthetic channel identity: %#v", envelope)
+	}
+}

--- a/internal/agentruntime/runtime.go
+++ b/internal/agentruntime/runtime.go
@@ -1,0 +1,45 @@
+// Package agentruntime defines the runtime-neutral delivery contract shared by
+// the Agent Manager and autonomous schedulers.
+package agentruntime
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	OhMyCode      = "ohMyCode"
+	CodexAppCDP   = "codexAppCDP"
+	ClaudeDesktop = "claudeDesktop"
+)
+
+// DispatchRequest is an internal agent wakeup that is not associated with a
+// messaging channel.
+type DispatchRequest struct {
+	Runtime      string
+	Agent        string
+	Text         string
+	Source       string
+	JobID        string
+	RunID        string
+	ScheduledAt  time.Time
+	ExpiresAt    time.Time
+	CoalesceKey  string
+	CronProfiles []string
+}
+
+// DispatchResult reports whether a runtime accepted, queued, or rejected a
+// wakeup. It does not imply that the agent completed the resulting work.
+type DispatchResult struct {
+	Runtime    string
+	Agent      string
+	Status     string
+	EnvelopeID string
+	InboxPath  string
+	Error      string
+}
+
+// Dispatcher routes a request to an explicitly selected Agent Runtime.
+type Dispatcher interface {
+	DispatchRuntime(ctx context.Context, request DispatchRequest) DispatchResult
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
+	"github.com/robfig/cron/v3"
 	"gopkg.in/yaml.v3"
 )
 
@@ -283,6 +285,26 @@ type ClaudeDesktopConfig struct {
 	DeliveryTimeoutSeconds int `yaml:"deliveryTimeoutSeconds,omitempty"`
 }
 
+// HeartbeatConfig schedules runtime-neutral agent wakeups.
+type HeartbeatConfig struct {
+	Enabled       bool                 `yaml:"enabled,omitempty"`
+	StatePath     string               `yaml:"statePath,omitempty"`
+	MaxConcurrent int                  `yaml:"maxConcurrent,omitempty"`
+	Jobs          []HeartbeatJobConfig `yaml:"jobs,omitempty"`
+}
+
+// HeartbeatJobConfig targets one Agent Runtime and agent on a cron schedule.
+type HeartbeatJobConfig struct {
+	ID                 string            `yaml:"id"`
+	Runtime            string            `yaml:"runtime"`
+	Agent              string            `yaml:"agent"`
+	Text               string            `yaml:"text"`
+	Cron               string            `yaml:"cron"`
+	Timezone           string            `yaml:"timezone"`
+	AgentCronProfiles  map[string]string `yaml:"agentCronProfiles,omitempty"`
+	ResetCronOnInbound bool              `yaml:"resetCronOnInbound,omitempty"`
+}
+
 // AgentsConfig contains gateway-side agent routing settings.
 type AgentsConfig struct {
 	Workspace     string               `yaml:"workspace"`
@@ -291,6 +313,7 @@ type AgentsConfig struct {
 	OhMyCode      *OhMyCodeConfig      `yaml:"ohMyCode,omitempty"`
 	CodexAppCDP   *CodexAppCDPConfig   `yaml:"codexAppCDP,omitempty"`
 	ClaudeDesktop *ClaudeDesktopConfig `yaml:"claudeDesktop,omitempty"`
+	Heartbeat     *HeartbeatConfig     `yaml:"heartbeat,omitempty"`
 }
 
 // ResolveConfigPath returns the config file path using this priority:
@@ -382,6 +405,9 @@ func validateConfig(cfg *Config) error {
 	if err := validateClaudeDesktopConfig(cfg); err != nil {
 		return err
 	}
+	if err := validateHeartbeatConfig(cfg); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -414,6 +440,135 @@ func validateClaudeDesktopConfig(cfg *Config) error {
 		return fmt.Errorf("agents.claudeDesktop.deliveryTimeoutSeconds: must be >= 0")
 	}
 	return nil
+}
+
+func validateHeartbeatConfig(cfg *Config) error {
+	if cfg == nil || cfg.Agents == nil || cfg.Agents.Heartbeat == nil {
+		return nil
+	}
+	heartbeat := cfg.Agents.Heartbeat
+	if heartbeat.MaxConcurrent < 0 {
+		return fmt.Errorf("agents.heartbeat.maxConcurrent: must be >= 0")
+	}
+	if !heartbeat.Enabled {
+		return nil
+	}
+	if len(heartbeat.Jobs) == 0 {
+		return fmt.Errorf("agents.heartbeat.jobs: at least one job is required when heartbeat is enabled")
+	}
+
+	seenIDs := make(map[string]struct{}, len(heartbeat.Jobs))
+	for idx := range heartbeat.Jobs {
+		job := &heartbeat.Jobs[idx]
+		prefix := fmt.Sprintf("agents.heartbeat.jobs[%d]", idx)
+		job.ID = strings.TrimSpace(job.ID)
+		job.Runtime = strings.TrimSpace(job.Runtime)
+		job.Agent = strings.TrimSpace(job.Agent)
+		job.Text = strings.TrimSpace(job.Text)
+		job.Cron = strings.TrimSpace(job.Cron)
+		job.Timezone = strings.TrimSpace(job.Timezone)
+
+		if job.ID == "" {
+			return fmt.Errorf("%s.id: required", prefix)
+		}
+		if err := validateAgentName(job.ID); err != nil {
+			return fmt.Errorf("%s.id: %w", prefix, err)
+		}
+		if _, exists := seenIDs[job.ID]; exists {
+			return fmt.Errorf("%s.id: duplicate heartbeat job %q", prefix, job.ID)
+		}
+		seenIDs[job.ID] = struct{}{}
+
+		if job.Agent == "" {
+			return fmt.Errorf("%s.agent: required", prefix)
+		}
+		if err := validateAgentName(job.Agent); err != nil {
+			return fmt.Errorf("%s.agent: %w", prefix, err)
+		}
+		if job.Text == "" {
+			return fmt.Errorf("%s.text: required", prefix)
+		}
+		if job.Cron == "" {
+			return fmt.Errorf("%s.cron: required", prefix)
+		}
+		if job.Timezone == "" {
+			return fmt.Errorf("%s.timezone: required", prefix)
+		}
+		if _, err := time.LoadLocation(job.Timezone); err != nil {
+			return fmt.Errorf("%s.timezone: %w", prefix, err)
+		}
+		if _, err := parseHeartbeatCron(job.Cron, job.Timezone); err != nil {
+			return fmt.Errorf("%s.cron: %w", prefix, err)
+		}
+		if err := validateHeartbeatRuntimeTarget(cfg.Agents, job.Runtime, job.Agent); err != nil {
+			return fmt.Errorf("%s.runtime: %w", prefix, err)
+		}
+
+		normalizedProfiles := make(map[string]string, len(job.AgentCronProfiles))
+		for rawProfile, rawExpression := range job.AgentCronProfiles {
+			profile := strings.TrimSpace(rawProfile)
+			expression := strings.TrimSpace(rawExpression)
+			if profile == "" {
+				return fmt.Errorf("%s.agentCronProfiles: profile name is required", prefix)
+			}
+			if err := validateAgentName(profile); err != nil {
+				return fmt.Errorf("%s.agentCronProfiles[%q]: %w", prefix, profile, err)
+			}
+			if expression == "" {
+				return fmt.Errorf("%s.agentCronProfiles[%q]: cron expression is required", prefix, profile)
+			}
+			if _, err := parseHeartbeatCron(expression, job.Timezone); err != nil {
+				return fmt.Errorf("%s.agentCronProfiles[%q]: %w", prefix, profile, err)
+			}
+			if _, exists := normalizedProfiles[profile]; exists {
+				return fmt.Errorf("%s.agentCronProfiles: duplicate profile %q", prefix, profile)
+			}
+			normalizedProfiles[profile] = expression
+		}
+		job.AgentCronProfiles = normalizedProfiles
+	}
+	return nil
+}
+
+func parseHeartbeatCron(expression, timezone string) (cron.Schedule, error) {
+	return cron.ParseStandard("CRON_TZ=" + strings.TrimSpace(timezone) + " " + strings.TrimSpace(expression))
+}
+
+func validateHeartbeatRuntimeTarget(agents *AgentsConfig, runtimeName, agentName string) error {
+	switch runtimeName {
+	case "ohMyCode":
+		if agents.OhMyCode == nil || !agents.OhMyCode.Enabled {
+			return fmt.Errorf("ohMyCode runtime is not enabled")
+		}
+		return validateHeartbeatAgentAllowed("agents.ohMyCode", agentName, agents.OhMyCode.DefaultAgent, agents.OhMyCode.AllowedAgents)
+	case "codexAppCDP":
+		if agents.CodexAppCDP == nil || !agents.CodexAppCDP.Enabled {
+			return fmt.Errorf("codexAppCDP runtime is not enabled")
+		}
+		return validateHeartbeatAgentAllowed("agents.codexAppCDP", agentName, agents.CodexAppCDP.DefaultAgent, agents.CodexAppCDP.AllowedAgents)
+	case "claudeDesktop":
+		if agents.ClaudeDesktop == nil || !agents.ClaudeDesktop.Enabled {
+			return fmt.Errorf("claudeDesktop runtime is not enabled")
+		}
+		return validateHeartbeatAgentAllowed("agents.claudeDesktop", agentName, agents.ClaudeDesktop.DefaultAgent, agents.ClaudeDesktop.AllowedAgents)
+	default:
+		return fmt.Errorf("unsupported runtime %q", runtimeName)
+	}
+}
+
+func validateHeartbeatAgentAllowed(prefix, agentName, defaultAgent string, allowedAgents []string) error {
+	if len(allowedAgents) == 0 {
+		if strings.TrimSpace(defaultAgent) != agentName {
+			return fmt.Errorf("agent %q is not allowed by %s", agentName, prefix)
+		}
+		return nil
+	}
+	for _, allowed := range allowedAgents {
+		if strings.TrimSpace(allowed) == agentName {
+			return nil
+		}
+	}
+	return fmt.Errorf("agent %q is not allowed by %s.allowedAgents", agentName, prefix)
 }
 
 func validateOhMyCodeConfig(cfg *Config) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -442,6 +442,203 @@ func TestLoadConfigRequiresClaudeDesktopEndpointOrInboxWhenEnabled(t *testing.T)
 	}
 }
 
+func TestLoadConfigAcceptsHeartbeatJobs(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`agents:
+  workspace: ./workspace
+  codexAppCDP:
+    enabled: true
+    inboxPath: ./workspace/codex-inbox
+    defaultAgent: main
+    allowedAgents: [main]
+  heartbeat:
+    enabled: true
+    statePath: ./workspace/heartbeat-state.json
+    maxConcurrent: 2
+    jobs:
+      - id: " cloudbank-main "
+        runtime: " codexAppCDP "
+        agent: " main "
+        text: " Inspect actionable work. "
+        cron: " */10 * * * * "
+        timezone: " Asia/Shanghai "
+        agentCronProfiles:
+          " idle ": " 0 * * * * "
+        resetCronOnInbound: true
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	job := cfg.Agents.Heartbeat.Jobs[0]
+	if job.ID != "cloudbank-main" || job.Runtime != "codexAppCDP" || job.Agent != "main" {
+		t.Fatalf("heartbeat target was not normalized: %#v", job)
+	}
+	if job.Text != "Inspect actionable work." || job.Cron != "*/10 * * * *" || job.Timezone != "Asia/Shanghai" {
+		t.Fatalf("heartbeat fields were not normalized: %#v", job)
+	}
+	if got := job.AgentCronProfiles["idle"]; got != "0 * * * *" || len(job.AgentCronProfiles) != 1 {
+		t.Fatalf("profiles=%#v", job.AgentCronProfiles)
+	}
+}
+
+func TestValidateHeartbeatConfigRejectsInvalidJobs(t *testing.T) {
+	tests := []struct {
+		name      string
+		mutate    func(*Config)
+		wantError string
+	}{
+		{
+			name: "missing jobs",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs = nil
+			},
+			wantError: "at least one job",
+		},
+		{
+			name: "invalid cron",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].Cron = "sometimes"
+			},
+			wantError: ".cron",
+		},
+		{
+			name: "missing timezone",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].Timezone = ""
+			},
+			wantError: ".timezone: required",
+		},
+		{
+			name: "invalid timezone",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].Timezone = "Mars/Olympus"
+			},
+			wantError: ".timezone",
+		},
+		{
+			name: "unsupported runtime",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].Runtime = "other"
+			},
+			wantError: "unsupported runtime",
+		},
+		{
+			name: "runtime disabled",
+			mutate: func(cfg *Config) {
+				cfg.Agents.CodexAppCDP.Enabled = false
+			},
+			wantError: "runtime is not enabled",
+		},
+		{
+			name: "agent not allowed",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].Agent = "other"
+			},
+			wantError: "not allowed",
+		},
+		{
+			name: "duplicate job id",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs = append(cfg.Agents.Heartbeat.Jobs, cfg.Agents.Heartbeat.Jobs[0])
+			},
+			wantError: "duplicate heartbeat job",
+		},
+		{
+			name: "invalid profile cron",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].AgentCronProfiles["idle"] = "never"
+			},
+			wantError: "agentCronProfiles",
+		},
+		{
+			name: "duplicate normalized profile",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].AgentCronProfiles[" idle "] = "0 */2 * * *"
+			},
+			wantError: "duplicate profile",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := validHeartbeatConfig()
+			test.mutate(cfg)
+			err := validateConfig(cfg)
+			if err == nil || !strings.Contains(err.Error(), test.wantError) {
+				t.Fatalf("error=%v want substring %q", err, test.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateHeartbeatSupportsEveryRuntime(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime string
+		setup   func(*AgentsConfig)
+	}{
+		{
+			name:    "ohMyCode",
+			runtime: "ohMyCode",
+			setup: func(agents *AgentsConfig) {
+				agents.OhMyCode = &OhMyCodeConfig{Enabled: true, Workspace: "/tmp/oh-my-code", DefaultAgent: "main", AllowedAgents: []string{"main"}}
+			},
+		},
+		{
+			name:    "codexAppCDP",
+			runtime: "codexAppCDP",
+			setup:   func(*AgentsConfig) {},
+		},
+		{
+			name:    "claudeDesktop",
+			runtime: "claudeDesktop",
+			setup: func(agents *AgentsConfig) {
+				agents.ClaudeDesktop = &ClaudeDesktopConfig{Enabled: true, InboxPath: "/tmp/claude-inbox", DefaultAgent: "main", AllowedAgents: []string{"main"}}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := validHeartbeatConfig()
+			test.setup(cfg.Agents)
+			cfg.Agents.Heartbeat.Jobs[0].Runtime = test.runtime
+			if err := validateConfig(cfg); err != nil {
+				t.Fatalf("validateConfig: %v", err)
+			}
+		})
+	}
+}
+
+func validHeartbeatConfig() *Config {
+	return &Config{Agents: &AgentsConfig{
+		CodexAppCDP: &CodexAppCDPConfig{
+			Enabled:       true,
+			InboxPath:     "/tmp/codex-inbox",
+			DefaultAgent:  "main",
+			AllowedAgents: []string{"main"},
+		},
+		Heartbeat: &HeartbeatConfig{
+			Enabled:       true,
+			MaxConcurrent: 2,
+			Jobs: []HeartbeatJobConfig{{
+				ID:       "cloudbank-main",
+				Runtime:  "codexAppCDP",
+				Agent:    "main",
+				Text:     "Inspect actionable work.",
+				Cron:     "*/10 * * * *",
+				Timezone: "Asia/Shanghai",
+				AgentCronProfiles: map[string]string{
+					"idle": "0 * * * *",
+				},
+			}},
+		},
+	}}
+}
+
 func TestLoadConfigParsesDemailChannel(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	content := []byte(strings.Join([]string{

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/fractalmind-ai/fractalbot/internal/bus"
 	"github.com/fractalmind-ai/fractalbot/internal/channels"
 	"github.com/fractalmind-ai/fractalbot/internal/config"
+	"github.com/fractalmind-ai/fractalbot/internal/heartbeat"
 	"github.com/gorilla/websocket"
 )
 
@@ -30,6 +32,7 @@ type Server struct {
 	httpServer   *http.Server
 	agentManager *agent.Manager
 	messageBus   *bus.MessageBus
+	heartbeat    *heartbeat.Scheduler
 	startTime    time.Time
 }
 
@@ -45,6 +48,20 @@ func NewServer(cfg *config.Config) (*Server, error) {
 	// Initialize agent manager
 	agentManager := agent.NewManager(cfg.Agents)
 	agentManager.ChannelManager = channelManager
+
+	var heartbeatConfig *config.HeartbeatConfig
+	var workspace string
+	if cfg.Agents != nil {
+		heartbeatConfig = cfg.Agents.Heartbeat
+		workspace = cfg.Agents.Workspace
+	}
+	heartbeatScheduler, err := heartbeat.New(heartbeatConfig, workspace, agentManager)
+	if err != nil {
+		return nil, fmt.Errorf("initialize heartbeat scheduler: %w", err)
+	}
+	if heartbeatScheduler != nil {
+		agentManager.SetInboundRoutedHook(heartbeatScheduler.ResetForInbound)
+	}
 
 	// Initialize message bus — decouples channels from agent router
 	messageBus := bus.New(agentManager, channelManager, 64, 64)
@@ -63,6 +80,7 @@ func NewServer(cfg *config.Config) (*Server, error) {
 		clients:      make(map[string]*Client),
 		agentManager: agentManager,
 		messageBus:   messageBus,
+		heartbeat:    heartbeatScheduler,
 	}, nil
 }
 
@@ -79,6 +97,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// Status endpoint
 	mux.HandleFunc("/status", s.handleStatus)
 	mux.HandleFunc("/api/v1/message/send", s.handleMessageSend)
+	mux.HandleFunc("/api/v1/heartbeat/jobs/", s.handleHeartbeatCron)
 
 	if s.startTime.IsZero() {
 		s.startTime = time.Now()
@@ -104,6 +123,9 @@ func (s *Server) Start(ctx context.Context) error {
 	if err := s.agentManager.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start agent manager: %w", err)
 	}
+	if err := s.heartbeat.Start(ctx); err != nil {
+		return fmt.Errorf("failed to start heartbeat scheduler: %w", err)
+	}
 
 	go func() {
 		log.Printf("🌐 HTTP server listening on %s", s.httpServer.Addr)
@@ -120,6 +142,10 @@ func (s *Server) Start(ctx context.Context) error {
 func (s *Server) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
+
+	if err := s.heartbeat.Stop(ctx); err != nil {
+		return fmt.Errorf("failed to stop heartbeat scheduler: %w", err)
+	}
 
 	// Close bus first — drain pending messages while channels still run
 	if s.messageBus != nil {
@@ -277,11 +303,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 type statusResponse struct {
-	Status        string          `json:"status"`
-	ActiveClients int             `json:"active_clients"`
-	Uptime        string          `json:"uptime"`
-	Channels      []channelStatus `json:"channels,omitempty"`
-	Agents        *agentStatus    `json:"agents,omitempty"`
+	Status        string            `json:"status"`
+	ActiveClients int               `json:"active_clients"`
+	Uptime        string            `json:"uptime"`
+	Channels      []channelStatus   `json:"channels,omitempty"`
+	Agents        *agentStatus      `json:"agents,omitempty"`
+	Heartbeat     *heartbeat.Status `json:"heartbeat,omitempty"`
 }
 
 func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
@@ -296,6 +323,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 		Uptime:        uptime.String(),
 		Channels:      s.channelStatus(),
 		Agents:        s.agentStatus(),
+		Heartbeat:     s.heartbeat.Status(),
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -387,6 +415,92 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, http.StatusOK, resp)
+}
+
+type heartbeatCronRequest struct {
+	Profile string `json:"profile"`
+	Reason  string `json:"reason"`
+}
+
+type heartbeatCronResponse struct {
+	Status string               `json:"status"`
+	Job    *heartbeat.JobStatus `json:"job,omitempty"`
+	Error  string               `json:"error,omitempty"`
+}
+
+func (s *Server) handleHeartbeatCron(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRequest(r) {
+		writeJSON(w, http.StatusForbidden, heartbeatCronResponse{Status: "error", Error: "heartbeat schedule API is restricted to loopback clients"})
+		return
+	}
+	if r.Method != http.MethodPut && r.Method != http.MethodDelete {
+		w.Header().Set("Allow", http.MethodPut+", "+http.MethodDelete)
+		writeJSON(w, http.StatusMethodNotAllowed, heartbeatCronResponse{Status: "error", Error: "method not allowed"})
+		return
+	}
+
+	jobID, ok := heartbeatJobIDFromPath(r.URL.Path)
+	if !ok {
+		writeJSON(w, http.StatusNotFound, heartbeatCronResponse{Status: "error", Error: "heartbeat cron endpoint not found"})
+		return
+	}
+	heartbeatStatus := s.heartbeat.Status()
+	if heartbeatStatus == nil || !heartbeatStatus.Enabled {
+		writeJSON(w, http.StatusServiceUnavailable, heartbeatCronResponse{Status: "error", Error: "heartbeat scheduler is disabled"})
+		return
+	}
+
+	var (
+		status heartbeat.JobStatus
+		err    error
+	)
+	if r.Method == http.MethodPut {
+		var request heartbeatCronRequest
+		decoder := json.NewDecoder(io.LimitReader(r.Body, 64*1024))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&request); err != nil {
+			writeJSON(w, http.StatusBadRequest, heartbeatCronResponse{Status: "error", Error: "invalid JSON payload"})
+			return
+		}
+		status, err = s.heartbeat.SetProfile(jobID, request.Profile, request.Reason, "local-api")
+	} else {
+		status, err = s.heartbeat.ResetProfile(jobID, "manual reset", "local-api")
+	}
+	if err != nil {
+		statusCode := http.StatusBadRequest
+		if strings.Contains(err.Error(), "not found") {
+			statusCode = http.StatusNotFound
+		}
+		writeJSON(w, statusCode, heartbeatCronResponse{Status: "error", Error: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, heartbeatCronResponse{Status: "ok", Job: &status})
+}
+
+func heartbeatJobIDFromPath(path string) (string, bool) {
+	const prefix = "/api/v1/heartbeat/jobs/"
+	const suffix = "/cron"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return "", false
+	}
+	jobID := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	jobID = strings.Trim(jobID, "/")
+	if jobID == "" || strings.Contains(jobID, "/") {
+		return "", false
+	}
+	return jobID, true
+}
+
+func isLoopbackRequest(r *http.Request) bool {
+	if r == nil {
+		return false
+	}
+	host, _, err := net.SplitHostPort(strings.TrimSpace(r.RemoteAddr))
+	if err != nil {
+		host = strings.Trim(strings.TrimSpace(r.RemoteAddr), "[]")
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, payload any) {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -923,3 +923,171 @@ func TestStatusEndpointReportsCodexAppCDPDefaultRepairAndWatch(t *testing.T) {
 		t.Fatalf("unexpected target_project: %#v", targetProject)
 	}
 }
+
+func TestHeartbeatCronAPIAndStatus(t *testing.T) {
+	inbox := filepath.Join(t.TempDir(), "inbox")
+	cfg := heartbeatGatewayConfig(t, inbox)
+	server, err := NewServer(cfg)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/heartbeat/jobs/", server.handleHeartbeatCron)
+	mux.HandleFunc("/status", server.handleStatus)
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	request, err := http.NewRequest(http.MethodPut, ts.URL+"/api/v1/heartbeat/jobs/cloudbank-main/cron", strings.NewReader(`{"profile":"idle","reason":"no actionable tasks"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("set profile request: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("set profile status=%d body=%s", response.StatusCode, body)
+	}
+	var setPayload heartbeatCronResponse
+	if err := json.NewDecoder(response.Body).Decode(&setPayload); err != nil {
+		t.Fatalf("decode set response: %v", err)
+	}
+	if setPayload.Job == nil || setPayload.Job.EffectiveProfile != "idle" || setPayload.Job.EffectiveCron != "0 * * * *" {
+		t.Fatalf("unexpected set response: %#v", setPayload)
+	}
+
+	statusResponse, err := http.Get(ts.URL + "/status")
+	if err != nil {
+		t.Fatalf("status request: %v", err)
+	}
+	statusData, err := io.ReadAll(statusResponse.Body)
+	statusResponse.Body.Close()
+	if err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if !strings.Contains(string(statusData), `"effective_profile":"idle"`) || !strings.Contains(string(statusData), `"last_schedule_reason":"no actionable tasks"`) {
+		t.Fatalf("status missing heartbeat profile: %s", statusData)
+	}
+	if strings.Contains(string(statusData), "secret heartbeat instruction") {
+		t.Fatalf("status leaked heartbeat instruction: %s", statusData)
+	}
+
+	resetRequest, err := http.NewRequest(http.MethodDelete, ts.URL+"/api/v1/heartbeat/jobs/cloudbank-main/cron", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resetResponse, err := http.DefaultClient.Do(resetRequest)
+	if err != nil {
+		t.Fatalf("reset profile request: %v", err)
+	}
+	defer resetResponse.Body.Close()
+	if resetResponse.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resetResponse.Body)
+		t.Fatalf("reset profile status=%d body=%s", resetResponse.StatusCode, body)
+	}
+	var resetPayload heartbeatCronResponse
+	if err := json.NewDecoder(resetResponse.Body).Decode(&resetPayload); err != nil {
+		t.Fatalf("decode reset response: %v", err)
+	}
+	if resetPayload.Job == nil || resetPayload.Job.EffectiveProfile != "" || resetPayload.Job.EffectiveCron != "*/10 * * * *" {
+		t.Fatalf("unexpected reset response: %#v", resetPayload)
+	}
+}
+
+func TestHeartbeatCronAPIRejectsInvalidAndRemoteRequests(t *testing.T) {
+	server, err := NewServer(heartbeatGatewayConfig(t, filepath.Join(t.TempDir(), "inbox")))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	t.Run("invalid profile", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPut, "/api/v1/heartbeat/jobs/cloudbank-main/cron", strings.NewReader(`{"profile":"arbitrary","reason":"idle"}`))
+		request.RemoteAddr = "127.0.0.1:12345"
+		response := httptest.NewRecorder()
+		server.handleHeartbeatCron(response, request)
+		if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "not allowed") {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("missing reason", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPut, "/api/v1/heartbeat/jobs/cloudbank-main/cron", strings.NewReader(`{"profile":"idle"}`))
+		request.RemoteAddr = "[::1]:12345"
+		response := httptest.NewRecorder()
+		server.handleHeartbeatCron(response, request)
+		if response.Code != http.StatusBadRequest || !strings.Contains(response.Body.String(), "reason is required") {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+
+	t.Run("remote client", func(t *testing.T) {
+		request := httptest.NewRequest(http.MethodPut, "/api/v1/heartbeat/jobs/cloudbank-main/cron", strings.NewReader(`{"profile":"idle","reason":"idle"}`))
+		request.RemoteAddr = "203.0.113.20:4567"
+		response := httptest.NewRecorder()
+		server.handleHeartbeatCron(response, request)
+		if response.Code != http.StatusForbidden {
+			t.Fatalf("status=%d body=%s", response.Code, response.Body.String())
+		}
+	})
+}
+
+func TestHeartbeatProfileResetsAfterMatchingInboundRoute(t *testing.T) {
+	server, err := NewServer(heartbeatGatewayConfig(t, filepath.Join(t.TempDir(), "inbox")))
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if _, err := server.heartbeat.SetProfile("cloudbank-main", "idle", "no actionable tasks", "agent"); err != nil {
+		t.Fatalf("SetProfile: %v", err)
+	}
+
+	_, err = server.agentManager.HandleIncoming(context.Background(), &protocol.Message{Data: map[string]interface{}{
+		"channel": "feishu",
+		"text":    "new user task",
+		"chat_id": "oc_1",
+	}})
+	if err != nil {
+		t.Fatalf("HandleIncoming: %v", err)
+	}
+	job := server.heartbeat.Status().Jobs[0]
+	if job.EffectiveProfile != "" || job.LastScheduleReason != "normal inbound activity" {
+		t.Fatalf("matching inbound did not reset heartbeat: %#v", job)
+	}
+}
+
+func heartbeatGatewayConfig(t *testing.T, inbox string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Gateway:  &config.GatewayConfig{Bind: "127.0.0.1", Port: 0},
+		Channels: &config.ChannelsConfig{},
+		Agents: &config.AgentsConfig{
+			Workspace: t.TempDir(),
+			Router:    "codexAppCDP",
+			CodexAppCDP: &config.CodexAppCDPConfig{
+				Enabled:       true,
+				InboxPath:     inbox,
+				DefaultAgent:  "main",
+				AllowedAgents: []string{"main"},
+			},
+			Heartbeat: &config.HeartbeatConfig{
+				Enabled:       true,
+				MaxConcurrent: 1,
+				Jobs: []config.HeartbeatJobConfig{{
+					ID:       "cloudbank-main",
+					Runtime:  "codexAppCDP",
+					Agent:    "main",
+					Text:     "secret heartbeat instruction",
+					Cron:     "*/10 * * * *",
+					Timezone: "Asia/Shanghai",
+					AgentCronProfiles: map[string]string{
+						"idle": "0 * * * *",
+					},
+					ResetCronOnInbound: true,
+				}},
+			},
+		},
+	}
+}

--- a/internal/heartbeat/scheduler.go
+++ b/internal/heartbeat/scheduler.go
@@ -1,0 +1,560 @@
+// Package heartbeat schedules runtime-neutral agent wakeups.
+package heartbeat
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/agentruntime"
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+	"github.com/robfig/cron/v3"
+)
+
+const (
+	defaultStateFilename = "heartbeat-state.json"
+	defaultMaxConcurrent = 1
+	defaultTickInterval  = time.Second
+	maxDispatchAttempts  = 3
+	initialRetryDelay    = time.Second
+)
+
+// Status is the redacted scheduler state exposed by the gateway.
+type Status struct {
+	Enabled       bool        `json:"enabled"`
+	MaxConcurrent int         `json:"max_concurrent,omitempty"`
+	Jobs          []JobStatus `json:"jobs,omitempty"`
+}
+
+// JobStatus contains schedule and delivery telemetry without instruction text.
+type JobStatus struct {
+	ID                    string `json:"id"`
+	Runtime               string `json:"runtime"`
+	Agent                 string `json:"agent"`
+	ConfiguredCron        string `json:"configured_cron"`
+	EffectiveProfile      string `json:"effective_profile,omitempty"`
+	EffectiveCron         string `json:"effective_cron"`
+	Timezone              string `json:"timezone"`
+	NextRunAt             string `json:"next_run_at,omitempty"`
+	InFlight              bool   `json:"in_flight"`
+	LastScheduledAt       string `json:"last_scheduled_at,omitempty"`
+	LastDispatchAt        string `json:"last_dispatch_at,omitempty"`
+	LastDispatchStatus    string `json:"last_dispatch_status,omitempty"`
+	LastDispatchError     string `json:"last_dispatch_error,omitempty"`
+	LastEnvelopeID        string `json:"last_envelope_id,omitempty"`
+	LastInboxPath         string `json:"last_inbox_path,omitempty"`
+	LastScheduleReason    string `json:"last_schedule_reason,omitempty"`
+	LastScheduleUpdatedBy string `json:"last_schedule_updated_by,omitempty"`
+	LastScheduleUpdatedAt string `json:"last_schedule_updated_at,omitempty"`
+}
+
+type compiledJob struct {
+	config           config.HeartbeatJobConfig
+	defaultSchedule  cron.Schedule
+	profileSchedules map[string]cron.Schedule
+	state            persistedJobState
+	inFlight         bool
+}
+
+// Scheduler owns cron state, dispatch concurrency, and profile overrides.
+type Scheduler struct {
+	config       *config.HeartbeatConfig
+	dispatcher   agentruntime.Dispatcher
+	statePath    string
+	now          func() time.Time
+	tickInterval time.Duration
+	retryDelay   func(attempt int) time.Duration
+
+	mu      sync.RWMutex
+	jobs    map[string]*compiledJob
+	started bool
+	cancel  context.CancelFunc
+	done    chan struct{}
+	ctx     context.Context
+
+	semaphore  chan struct{}
+	dispatchWg sync.WaitGroup
+}
+
+// New creates a scheduler and restores persisted profile overrides. Missed
+// executions are intentionally ignored; every next run is computed from now.
+func New(cfg *config.HeartbeatConfig, workspace string, dispatcher agentruntime.Dispatcher) (*Scheduler, error) {
+	return newScheduler(cfg, workspace, dispatcher, time.Now, defaultTickInterval)
+}
+
+func newScheduler(cfg *config.HeartbeatConfig, workspace string, dispatcher agentruntime.Dispatcher, now func() time.Time, tickInterval time.Duration) (*Scheduler, error) {
+	if cfg == nil {
+		return nil, nil
+	}
+	if now == nil {
+		now = time.Now
+	}
+	if tickInterval <= 0 {
+		tickInterval = defaultTickInterval
+	}
+	maxConcurrent := cfg.MaxConcurrent
+	if maxConcurrent <= 0 {
+		maxConcurrent = defaultMaxConcurrent
+	}
+	scheduler := &Scheduler{
+		config:       cfg,
+		dispatcher:   dispatcher,
+		statePath:    resolveStatePath(cfg.StatePath, workspace),
+		now:          now,
+		tickInterval: tickInterval,
+		retryDelay:   dispatchRetryDelay,
+		jobs:         make(map[string]*compiledJob, len(cfg.Jobs)),
+		semaphore:    make(chan struct{}, maxConcurrent),
+	}
+	if !cfg.Enabled {
+		return scheduler, nil
+	}
+	if dispatcher == nil {
+		return nil, errors.New("heartbeat dispatcher is required")
+	}
+
+	for idx := range cfg.Jobs {
+		jobConfig := cfg.Jobs[idx]
+		defaultSchedule, err := parseSchedule(jobConfig.Cron, jobConfig.Timezone)
+		if err != nil {
+			return nil, fmt.Errorf("compile heartbeat job %q: %w", jobConfig.ID, err)
+		}
+		job := &compiledJob{
+			config:           jobConfig,
+			defaultSchedule:  defaultSchedule,
+			profileSchedules: make(map[string]cron.Schedule, len(jobConfig.AgentCronProfiles)),
+		}
+		for profile, expression := range jobConfig.AgentCronProfiles {
+			schedule, err := parseSchedule(expression, jobConfig.Timezone)
+			if err != nil {
+				return nil, fmt.Errorf("compile heartbeat job %q profile %q: %w", jobConfig.ID, profile, err)
+			}
+			job.profileSchedules[profile] = schedule
+		}
+		scheduler.jobs[jobConfig.ID] = job
+	}
+
+	if err := scheduler.loadState(); err != nil {
+		return nil, err
+	}
+	base := scheduler.now()
+	for _, job := range scheduler.jobs {
+		job.state.NextRunAt = job.effectiveSchedule().Next(base)
+		job.state.InFlight = false
+	}
+	return scheduler, nil
+}
+
+// Start launches the cron loop. It is safe to call Start once.
+func (s *Scheduler) Start(ctx context.Context) error {
+	if s == nil || s.config == nil || !s.config.Enabled {
+		return nil
+	}
+	s.mu.Lock()
+	if s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	s.ctx, s.cancel = context.WithCancel(ctx)
+	s.done = make(chan struct{})
+	s.started = true
+	runCtx := s.ctx
+	done := s.done
+	s.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(s.tickInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-runCtx.Done():
+				return
+			case <-ticker.C:
+				s.runDue(s.now())
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop cancels scheduling and waits for in-flight dispatch calls.
+func (s *Scheduler) Stop(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	if !s.started {
+		s.mu.Unlock()
+		return nil
+	}
+	cancel := s.cancel
+	done := s.done
+	s.started = false
+	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	waitDone := make(chan struct{})
+	go func() {
+		s.dispatchWg.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// SetProfile applies an operator-approved profile and recalculates the next run.
+func (s *Scheduler) SetProfile(jobID, profile, reason, updatedBy string) (JobStatus, error) {
+	if s == nil || s.config == nil || !s.config.Enabled {
+		return JobStatus{}, errors.New("heartbeat scheduler is disabled")
+	}
+	jobID = strings.TrimSpace(jobID)
+	profile = strings.TrimSpace(profile)
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return JobStatus{}, errors.New("schedule change reason is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[jobID]
+	if !ok {
+		return JobStatus{}, fmt.Errorf("heartbeat job %q not found", jobID)
+	}
+	if _, ok := job.profileSchedules[profile]; !ok {
+		return JobStatus{}, fmt.Errorf("heartbeat profile %q is not allowed for job %q", profile, jobID)
+	}
+	if job.state.EffectiveProfile == profile {
+		return s.jobStatusLocked(job), nil
+	}
+	previous := job.state
+	now := s.now()
+	job.state.EffectiveProfile = profile
+	job.state.ScheduleReason = reason
+	job.state.ScheduleUpdatedBy = strings.TrimSpace(updatedBy)
+	job.state.ScheduleUpdatedAt = now
+	job.state.NextRunAt = job.effectiveSchedule().Next(now)
+	if err := s.saveStateLocked(); err != nil {
+		job.state = previous
+		return JobStatus{}, err
+	}
+	return s.jobStatusLocked(job), nil
+}
+
+// ResetProfile restores a job to its configured cron.
+func (s *Scheduler) ResetProfile(jobID, reason, updatedBy string) (JobStatus, error) {
+	if s == nil || s.config == nil || !s.config.Enabled {
+		return JobStatus{}, errors.New("heartbeat scheduler is disabled")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[strings.TrimSpace(jobID)]
+	if !ok {
+		return JobStatus{}, fmt.Errorf("heartbeat job %q not found", strings.TrimSpace(jobID))
+	}
+	if job.state.EffectiveProfile == "" {
+		return s.jobStatusLocked(job), nil
+	}
+	previous := job.state
+	now := s.now()
+	job.state.EffectiveProfile = ""
+	job.state.ScheduleReason = strings.TrimSpace(reason)
+	job.state.ScheduleUpdatedBy = strings.TrimSpace(updatedBy)
+	job.state.ScheduleUpdatedAt = now
+	job.state.NextRunAt = job.defaultSchedule.Next(now)
+	if err := s.saveStateLocked(); err != nil {
+		job.state = previous
+		return JobStatus{}, err
+	}
+	return s.jobStatusLocked(job), nil
+}
+
+// ResetForInbound restores matching idle jobs after a normal inbound message
+// was successfully routed to the same Runtime and Agent.
+func (s *Scheduler) ResetForInbound(runtimeName, agentName string) {
+	if s == nil || s.config == nil || !s.config.Enabled {
+		return
+	}
+	runtimeName = strings.TrimSpace(runtimeName)
+	agentName = strings.TrimSpace(agentName)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	changed := false
+	now := s.now()
+	previous := make(map[string]persistedJobState)
+	for id, job := range s.jobs {
+		if !job.config.ResetCronOnInbound || job.config.Runtime != runtimeName || job.config.Agent != agentName || job.state.EffectiveProfile == "" {
+			continue
+		}
+		previous[id] = job.state
+		job.state.EffectiveProfile = ""
+		job.state.ScheduleReason = "normal inbound activity"
+		job.state.ScheduleUpdatedBy = "gateway"
+		job.state.ScheduleUpdatedAt = now
+		job.state.NextRunAt = job.defaultSchedule.Next(now)
+		changed = true
+	}
+	if changed {
+		if err := s.saveStateLocked(); err != nil {
+			for id, state := range previous {
+				s.jobs[id].state = state
+			}
+			log.Printf("heartbeat: persist inbound cron reset: %v", err)
+		}
+	}
+}
+
+// Status returns a stable, redacted snapshot.
+func (s *Scheduler) Status() *Status {
+	if s == nil || s.config == nil {
+		return nil
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	status := &Status{Enabled: s.config.Enabled, MaxConcurrent: cap(s.semaphore)}
+	ids := make([]string, 0, len(s.jobs))
+	for id := range s.jobs {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		status.Jobs = append(status.Jobs, s.jobStatusLocked(s.jobs[id]))
+	}
+	return status
+}
+
+func (s *Scheduler) runDue(now time.Time) {
+	if s == nil || s.config == nil || !s.config.Enabled {
+		return
+	}
+	type dueDispatch struct {
+		jobID   string
+		request agentruntime.DispatchRequest
+	}
+	var due []dueDispatch
+
+	s.mu.Lock()
+	for id, job := range s.jobs {
+		if job.state.NextRunAt.IsZero() {
+			job.state.NextRunAt = job.effectiveSchedule().Next(now)
+			continue
+		}
+		if job.state.NextRunAt.After(now) {
+			continue
+		}
+		scheduledAt := job.state.NextRunAt
+		job.state.NextRunAt = job.effectiveSchedule().Next(now)
+		job.state.LastScheduledAt = scheduledAt
+		if job.inFlight {
+			job.state.LastDispatchStatus = "skipped_overlap"
+			continue
+		}
+		select {
+		case s.semaphore <- struct{}{}:
+			job.inFlight = true
+			job.state.InFlight = true
+			runID := newRunID()
+			profiles := make([]string, 0, len(job.profileSchedules))
+			for profile := range job.profileSchedules {
+				profiles = append(profiles, profile)
+			}
+			due = append(due, dueDispatch{
+				jobID: id,
+				request: agentruntime.DispatchRequest{
+					Runtime:      job.config.Runtime,
+					Agent:        job.config.Agent,
+					Text:         job.config.Text,
+					Source:       "heartbeat",
+					JobID:        id,
+					RunID:        runID,
+					ScheduledAt:  scheduledAt,
+					ExpiresAt:    job.state.NextRunAt,
+					CoalesceKey:  "heartbeat:" + id,
+					CronProfiles: profiles,
+				},
+			})
+		default:
+			job.state.LastDispatchStatus = "skipped_capacity"
+		}
+	}
+	if err := s.saveStateLocked(); err != nil {
+		log.Printf("heartbeat: persist scheduled state: %v", err)
+	}
+	dispatchContext := s.ctx
+	if dispatchContext == nil {
+		dispatchContext = context.Background()
+	}
+	for _, item := range due {
+		s.dispatchWg.Add(1)
+		go s.dispatch(dispatchContext, item.jobID, item.request)
+	}
+	s.mu.Unlock()
+}
+
+func (s *Scheduler) dispatch(ctx context.Context, jobID string, request agentruntime.DispatchRequest) {
+	defer s.dispatchWg.Done()
+	defer func() { <-s.semaphore }()
+	result := agentruntime.DispatchResult{Status: "error", Error: "heartbeat dispatch did not run"}
+	for attempt := 1; attempt <= maxDispatchAttempts; attempt++ {
+		result = s.dispatcher.DispatchRuntime(ctx, request)
+		if strings.TrimSpace(result.Status) != "error" || attempt == maxDispatchAttempts {
+			break
+		}
+		delay := s.retryDelay(attempt)
+		if delay <= 0 {
+			continue
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			result.Status = "error"
+			result.Error = ctx.Err().Error()
+			attempt = maxDispatchAttempts
+		case <-timer.C:
+		}
+	}
+	now := s.now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	job, ok := s.jobs[jobID]
+	if !ok {
+		return
+	}
+	job.inFlight = false
+	job.state.InFlight = false
+	job.state.LastDispatchAt = now
+	job.state.LastDispatchStatus = strings.TrimSpace(result.Status)
+	job.state.LastDispatchError = strings.TrimSpace(result.Error)
+	job.state.LastEnvelopeID = strings.TrimSpace(result.EnvelopeID)
+	job.state.LastInboxPath = strings.TrimSpace(result.InboxPath)
+	if err := s.saveStateLocked(); err != nil {
+		log.Printf("heartbeat: persist dispatch result: %v", err)
+	}
+}
+
+func dispatchRetryDelay(attempt int) time.Duration {
+	if attempt <= 0 {
+		return 0
+	}
+	return initialRetryDelay << (attempt - 1)
+}
+
+func (job *compiledJob) effectiveSchedule() cron.Schedule {
+	if schedule, ok := job.profileSchedules[job.state.EffectiveProfile]; ok {
+		return schedule
+	}
+	return job.defaultSchedule
+}
+
+func (job *compiledJob) effectiveCron() string {
+	if expression, ok := job.config.AgentCronProfiles[job.state.EffectiveProfile]; ok {
+		return expression
+	}
+	return job.config.Cron
+}
+
+func (s *Scheduler) jobStatusLocked(job *compiledJob) JobStatus {
+	return JobStatus{
+		ID:                    job.config.ID,
+		Runtime:               job.config.Runtime,
+		Agent:                 job.config.Agent,
+		ConfiguredCron:        job.config.Cron,
+		EffectiveProfile:      job.state.EffectiveProfile,
+		EffectiveCron:         job.effectiveCron(),
+		Timezone:              job.config.Timezone,
+		NextRunAt:             formatTime(job.state.NextRunAt),
+		InFlight:              job.state.InFlight,
+		LastScheduledAt:       formatTime(job.state.LastScheduledAt),
+		LastDispatchAt:        formatTime(job.state.LastDispatchAt),
+		LastDispatchStatus:    job.state.LastDispatchStatus,
+		LastDispatchError:     job.state.LastDispatchError,
+		LastEnvelopeID:        job.state.LastEnvelopeID,
+		LastInboxPath:         job.state.LastInboxPath,
+		LastScheduleReason:    job.state.ScheduleReason,
+		LastScheduleUpdatedBy: job.state.ScheduleUpdatedBy,
+		LastScheduleUpdatedAt: formatTime(job.state.ScheduleUpdatedAt),
+	}
+}
+
+func parseSchedule(expression, timezone string) (cron.Schedule, error) {
+	return cron.ParseStandard("CRON_TZ=" + strings.TrimSpace(timezone) + " " + strings.TrimSpace(expression))
+}
+
+func resolveStatePath(configuredPath, workspace string) string {
+	if path := strings.TrimSpace(configuredPath); path != "" {
+		return filepath.Clean(path)
+	}
+	if strings.TrimSpace(workspace) == "" {
+		workspace = "./workspace"
+	}
+	return filepath.Join(filepath.Clean(workspace), defaultStateFilename)
+}
+
+func newRunID() string {
+	data := make([]byte, 16)
+	if _, err := rand.Read(data); err == nil {
+		return hex.EncodeToString(data)
+	}
+	return fmt.Sprintf("%d", time.Now().UnixNano())
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func (s *Scheduler) loadState() error {
+	data, err := os.ReadFile(s.statePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read heartbeat state: %w", err)
+	}
+	state, err := decodePersistedState(data)
+	if err != nil {
+		return fmt.Errorf("decode heartbeat state: %w", err)
+	}
+	for id, persisted := range state.Jobs {
+		job, ok := s.jobs[id]
+		if !ok {
+			continue
+		}
+		if persisted.EffectiveProfile != "" {
+			if _, allowed := job.profileSchedules[persisted.EffectiveProfile]; !allowed {
+				persisted.EffectiveProfile = ""
+			}
+		}
+		persisted.InFlight = false
+		job.state = persisted
+	}
+	return nil
+}

--- a/internal/heartbeat/scheduler_test.go
+++ b/internal/heartbeat/scheduler_test.go
@@ -1,0 +1,361 @@
+package heartbeat
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fractalmind-ai/fractalbot/internal/agentruntime"
+	"github.com/fractalmind-ai/fractalbot/internal/config"
+)
+
+type testClock struct {
+	mu  sync.RWMutex
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.now
+}
+
+func (c *testClock) Set(value time.Time) {
+	c.mu.Lock()
+	c.now = value
+	c.mu.Unlock()
+}
+
+type recordingDispatcher struct {
+	mu       sync.Mutex
+	requests []agentruntime.DispatchRequest
+	result   agentruntime.DispatchResult
+	block    <-chan struct{}
+	started  chan struct{}
+}
+
+func (d *recordingDispatcher) DispatchRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {
+	d.mu.Lock()
+	d.requests = append(d.requests, request)
+	d.mu.Unlock()
+	if d.started != nil {
+		select {
+		case d.started <- struct{}{}:
+		default:
+		}
+	}
+	if d.block != nil {
+		select {
+		case <-d.block:
+		case <-ctx.Done():
+			return agentruntime.DispatchResult{Status: "error", Error: ctx.Err().Error()}
+		}
+	}
+	return d.result
+}
+
+func (d *recordingDispatcher) Requests() []agentruntime.DispatchRequest {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]agentruntime.DispatchRequest(nil), d.requests...)
+}
+
+func heartbeatTestConfig(statePath string) *config.HeartbeatConfig {
+	return &config.HeartbeatConfig{
+		Enabled:       true,
+		StatePath:     statePath,
+		MaxConcurrent: 2,
+		Jobs: []config.HeartbeatJobConfig{{
+			ID:       "cloudbank-main",
+			Runtime:  agentruntime.CodexAppCDP,
+			Agent:    "main",
+			Text:     "secret operator instruction",
+			Cron:     "*/10 * * * *",
+			Timezone: "Asia/Shanghai",
+			AgentCronProfiles: map[string]string{
+				"idle": "0 * * * *",
+			},
+			ResetCronOnInbound: true,
+		}},
+	}
+}
+
+func TestSchedulerCalculatesTimezoneAndDispatchesRuntimeEnvelope(t *testing.T) {
+	base := time.Date(2026, 7, 26, 1, 55, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	dispatcher := &recordingDispatcher{result: agentruntime.DispatchResult{
+		Status:     "queued",
+		EnvelopeID: "env-1",
+		InboxPath:  "/tmp/inbox/heartbeat.json",
+	}}
+	scheduler, err := newScheduler(heartbeatTestConfig(""), t.TempDir(), dispatcher, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+
+	status := scheduler.Status()
+	if len(status.Jobs) != 1 || status.Jobs[0].NextRunAt != "2026-07-26T02:00:00Z" {
+		t.Fatalf("unexpected next run for Asia/Shanghai cron: %#v", status)
+	}
+
+	due := time.Date(2026, 7, 26, 2, 0, 0, 0, time.UTC)
+	clock.Set(due)
+	scheduler.runDue(due)
+	waitForScheduler(t, scheduler, func(job JobStatus) bool { return job.LastDispatchStatus == "queued" })
+
+	requests := dispatcher.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("dispatch count=%d want 1", len(requests))
+	}
+	request := requests[0]
+	if request.Runtime != agentruntime.CodexAppCDP || request.Agent != "main" || request.Source != "heartbeat" {
+		t.Fatalf("unexpected runtime request: %#v", request)
+	}
+	if request.JobID != "cloudbank-main" || request.RunID == "" || request.CoalesceKey != "heartbeat:cloudbank-main" {
+		t.Fatalf("missing heartbeat envelope metadata: %#v", request)
+	}
+	if !request.ScheduledAt.Equal(due) || !request.ExpiresAt.Equal(due.Add(10*time.Minute)) {
+		t.Fatalf("unexpected schedule window: scheduled=%s expires=%s", request.ScheduledAt, request.ExpiresAt)
+	}
+	if len(request.CronProfiles) != 1 || request.CronProfiles[0] != "idle" {
+		t.Fatalf("cron profiles=%v", request.CronProfiles)
+	}
+}
+
+func TestSchedulerProfileIsIdempotentPersistsAndSkipsMissedRuns(t *testing.T) {
+	statePath := t.TempDir() + "/heartbeat-state.json"
+	base := time.Date(2026, 7, 26, 0, 5, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	cfg := heartbeatTestConfig(statePath)
+	scheduler, err := newScheduler(cfg, "", &recordingDispatcher{}, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+
+	first, err := scheduler.SetProfile("cloudbank-main", "idle", "no actionable tasks", "agent")
+	if err != nil {
+		t.Fatalf("SetProfile: %v", err)
+	}
+	if first.EffectiveCron != "0 * * * *" || first.NextRunAt != "2026-07-26T01:00:00Z" {
+		t.Fatalf("unexpected profile status: %#v", first)
+	}
+
+	clock.Set(base.Add(20 * time.Minute))
+	second, err := scheduler.SetProfile("cloudbank-main", "idle", "still idle", "agent")
+	if err != nil {
+		t.Fatalf("idempotent SetProfile: %v", err)
+	}
+	if second.NextRunAt != first.NextRunAt || second.LastScheduleReason != first.LastScheduleReason || second.LastScheduleUpdatedAt != first.LastScheduleUpdatedAt {
+		t.Fatalf("repeated profile update was not a no-op: first=%#v second=%#v", first, second)
+	}
+
+	restartTime := time.Date(2026, 7, 26, 4, 12, 0, 0, time.UTC)
+	clock.Set(restartTime)
+	restarted, err := newScheduler(cfg, "", &recordingDispatcher{}, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("restart scheduler: %v", err)
+	}
+	restartedJob := restarted.Status().Jobs[0]
+	if restartedJob.EffectiveProfile != "idle" {
+		t.Fatalf("effective profile not restored: %#v", restartedJob)
+	}
+	if restartedJob.NextRunAt != "2026-07-26T05:00:00Z" {
+		t.Fatalf("restart should calculate next future run, got %s", restartedJob.NextRunAt)
+	}
+
+	if _, err := restarted.SetProfile("cloudbank-main", "arbitrary", "idle", "agent"); err == nil || !strings.Contains(err.Error(), "not allowed") {
+		t.Fatalf("expected profile allowlist error, got %v", err)
+	}
+}
+
+func TestSchedulerInboundResetRequiresMatchingTarget(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, 7, 26, 0, 5, 0, 0, time.UTC)}
+	scheduler, err := newScheduler(heartbeatTestConfig(""), t.TempDir(), &recordingDispatcher{}, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+	if _, err := scheduler.SetProfile("cloudbank-main", "idle", "no actionable tasks", "agent"); err != nil {
+		t.Fatalf("SetProfile: %v", err)
+	}
+
+	scheduler.ResetForInbound(agentruntime.ClaudeDesktop, "main")
+	if got := scheduler.Status().Jobs[0].EffectiveProfile; got != "idle" {
+		t.Fatalf("mismatched runtime reset profile=%q", got)
+	}
+	scheduler.ResetForInbound(agentruntime.CodexAppCDP, "other")
+	if got := scheduler.Status().Jobs[0].EffectiveProfile; got != "idle" {
+		t.Fatalf("mismatched agent reset profile=%q", got)
+	}
+
+	clock.Set(time.Date(2026, 7, 26, 0, 7, 0, 0, time.UTC))
+	scheduler.ResetForInbound(agentruntime.CodexAppCDP, "main")
+	job := scheduler.Status().Jobs[0]
+	if job.EffectiveProfile != "" || job.EffectiveCron != "*/10 * * * *" || job.NextRunAt != "2026-07-26T00:10:00Z" {
+		t.Fatalf("matching inbound did not restore default cron: %#v", job)
+	}
+	if job.LastScheduleReason != "normal inbound activity" || job.LastScheduleUpdatedBy != "gateway" {
+		t.Fatalf("missing inbound reset audit: %#v", job)
+	}
+}
+
+func TestSchedulerSkipsOverlappingRun(t *testing.T) {
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	dispatcher := &recordingDispatcher{
+		result:  agentruntime.DispatchResult{Status: "delivered"},
+		block:   release,
+		started: started,
+	}
+	cfg := heartbeatTestConfig("")
+	cfg.Jobs[0].Cron = "* * * * *"
+	scheduler, err := newScheduler(cfg, t.TempDir(), dispatcher, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+	firstDue := base.Add(time.Minute)
+	clock.Set(firstDue)
+	scheduler.runDue(firstDue)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("first dispatch did not start")
+	}
+	secondDue := base.Add(2 * time.Minute)
+	clock.Set(secondDue)
+	scheduler.runDue(secondDue)
+	job := scheduler.Status().Jobs[0]
+	if job.LastDispatchStatus != "skipped_overlap" || !job.InFlight {
+		t.Fatalf("expected overlap skip while in flight: %#v", job)
+	}
+	if len(dispatcher.Requests()) != 1 {
+		t.Fatalf("overlapping run dispatched more than once")
+	}
+
+	close(release)
+	waitForScheduler(t, scheduler, func(job JobStatus) bool { return !job.InFlight })
+}
+
+func TestSchedulerEnforcesGlobalCapacityAndRecordsFailure(t *testing.T) {
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	release := make(chan struct{})
+	started := make(chan struct{}, 1)
+	dispatcher := &recordingDispatcher{
+		result:  agentruntime.DispatchResult{Status: "error", Error: "runtime unavailable"},
+		block:   release,
+		started: started,
+	}
+	cfg := heartbeatTestConfig("")
+	cfg.MaxConcurrent = 1
+	cfg.Jobs[0].Cron = "* * * * *"
+	second := cfg.Jobs[0]
+	second.ID = "cloudbank-secondary"
+	cfg.Jobs = append(cfg.Jobs, second)
+	scheduler, err := newScheduler(cfg, t.TempDir(), dispatcher, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+	scheduler.retryDelay = func(int) time.Duration { return 0 }
+
+	due := base.Add(time.Minute)
+	clock.Set(due)
+	scheduler.runDue(due)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("capacity-limited dispatch did not start")
+	}
+	statuses := scheduler.Status().Jobs
+	skipped := 0
+	for _, status := range statuses {
+		if status.LastDispatchStatus == "skipped_capacity" {
+			skipped++
+		}
+	}
+	if skipped != 1 || len(dispatcher.Requests()) != 1 {
+		t.Fatalf("capacity result statuses=%#v requests=%d", statuses, len(dispatcher.Requests()))
+	}
+
+	close(release)
+	waitForScheduler(t, scheduler, func(_ JobStatus) bool {
+		for _, status := range scheduler.Status().Jobs {
+			if status.LastDispatchStatus == "error" && status.LastDispatchError == "runtime unavailable" {
+				return true
+			}
+		}
+		return false
+	})
+	if got := len(dispatcher.Requests()); got != maxDispatchAttempts {
+		t.Fatalf("dispatch attempts=%d want %d", got, maxDispatchAttempts)
+	}
+}
+
+func TestSchedulerStatusDoesNotExposeInstruction(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)}
+	scheduler, err := newScheduler(heartbeatTestConfig(""), t.TempDir(), &recordingDispatcher{}, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+	encoded, err := json.Marshal(scheduler.Status())
+	if err != nil {
+		t.Fatalf("marshal status: %v", err)
+	}
+	if strings.Contains(string(encoded), "secret operator instruction") || strings.Contains(string(encoded), `"text"`) {
+		t.Fatalf("status leaked instruction: %s", encoded)
+	}
+}
+
+func TestSchedulerStopCancelsRetryBackoff(t *testing.T) {
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	started := make(chan struct{}, 1)
+	dispatcher := &recordingDispatcher{
+		result:  agentruntime.DispatchResult{Status: "error", Error: "runtime unavailable"},
+		started: started,
+	}
+	cfg := heartbeatTestConfig("")
+	cfg.Jobs[0].Cron = "* * * * *"
+	scheduler, err := newScheduler(cfg, t.TempDir(), dispatcher, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+	if err := scheduler.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	due := base.Add(time.Minute)
+	clock.Set(due)
+	scheduler.runDue(due)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("dispatch did not enter retry path")
+	}
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+	if err := scheduler.Stop(stopCtx); err != nil {
+		t.Fatalf("Stop did not cancel retry backoff: %v", err)
+	}
+	job := scheduler.Status().Jobs[0]
+	if job.InFlight || job.LastDispatchStatus != "error" || job.LastDispatchError != context.Canceled.Error() {
+		t.Fatalf("unexpected status after canceled retry: %#v", job)
+	}
+}
+
+func waitForScheduler(t *testing.T, scheduler *Scheduler, predicate func(JobStatus) bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		status := scheduler.Status()
+		if status != nil && len(status.Jobs) > 0 && predicate(status.Jobs[0]) {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("scheduler condition not reached: %#v", scheduler.Status())
+}

--- a/internal/heartbeat/state.go
+++ b/internal/heartbeat/state.go
@@ -1,0 +1,92 @@
+package heartbeat
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const persistedStateVersion = 1
+
+type persistedState struct {
+	Version int                          `json:"version"`
+	Jobs    map[string]persistedJobState `json:"jobs"`
+}
+
+type persistedJobState struct {
+	EffectiveProfile   string    `json:"effective_profile,omitempty"`
+	NextRunAt          time.Time `json:"next_run_at,omitempty"`
+	InFlight           bool      `json:"in_flight,omitempty"`
+	LastScheduledAt    time.Time `json:"last_scheduled_at,omitempty"`
+	LastDispatchAt     time.Time `json:"last_dispatch_at,omitempty"`
+	LastDispatchStatus string    `json:"last_dispatch_status,omitempty"`
+	LastDispatchError  string    `json:"last_dispatch_error,omitempty"`
+	LastEnvelopeID     string    `json:"last_envelope_id,omitempty"`
+	LastInboxPath      string    `json:"last_inbox_path,omitempty"`
+	ScheduleReason     string    `json:"schedule_reason,omitempty"`
+	ScheduleUpdatedBy  string    `json:"schedule_updated_by,omitempty"`
+	ScheduleUpdatedAt  time.Time `json:"schedule_updated_at,omitempty"`
+}
+
+func decodePersistedState(data []byte) (persistedState, error) {
+	var state persistedState
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&state); err != nil {
+		return persistedState{}, err
+	}
+	if state.Version != persistedStateVersion {
+		return persistedState{}, fmt.Errorf("unsupported heartbeat state version %d", state.Version)
+	}
+	if state.Jobs == nil {
+		state.Jobs = make(map[string]persistedJobState)
+	}
+	return state, nil
+}
+
+func (s *Scheduler) saveStateLocked() error {
+	if s == nil || s.config == nil || !s.config.Enabled {
+		return nil
+	}
+	state := persistedState{Version: persistedStateVersion, Jobs: make(map[string]persistedJobState, len(s.jobs))}
+	for id, job := range s.jobs {
+		state.Jobs[id] = job.state
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode heartbeat state: %w", err)
+	}
+	data = append(data, '\n')
+	directory := filepath.Dir(s.statePath)
+	if err := os.MkdirAll(directory, 0700); err != nil {
+		return fmt.Errorf("create heartbeat state directory: %w", err)
+	}
+	tmp, err := os.CreateTemp(directory, ".heartbeat-state-*.tmp")
+	if err != nil {
+		return fmt.Errorf("create heartbeat state temp file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("set heartbeat state permissions: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write heartbeat state: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync heartbeat state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close heartbeat state: %w", err)
+	}
+	if err := os.Rename(tmpPath, s.statePath); err != nil {
+		return fmt.Errorf("commit heartbeat state: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add a persistent explicit-timezone cron scheduler for `ohMyCode`, `codexAppCDP`, and `claudeDesktop`
- dispatch runtime-neutral heartbeat envelopes without synthetic channel identity and coalesce desktop inbox fallback by job
- add operator-approved cron profiles, inbound reset, bounded retry, overlap and global concurrency controls
- expose redacted heartbeat status plus loopback-only cron profile API and CLI commands
- document configuration, schedule adjustment, delivery behavior, and architecture

## Test plan

- `go test ./...`
- `go test -race ./internal/heartbeat ./internal/agent ./internal/gateway`
- `go vet ./...`
- `go build ./cmd/fractalbot`
- local Gateway and CLI smoke test for profile set, `/status`, persisted state, and reset
- `git diff --check`

Closes #372