### PR TITLE
feat: support image attachment in CLI message send (#374)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ go run ./cmd/fractalbot --config ./config.yaml \
   message send --channel telegram --to 1234567890 --text "hello"
 ```
 
+Attach images (repeat `--image` for multiple; the current implementation supports Feishu):
+
+```bash
+go run ./cmd/fractalbot --config ./config.yaml \
+  message send --channel feishu --to oc_xxx --text "架构对比图" \
+  --image ./arch-compare.png --image ./loss-curve.png
+```
+
+SVG is not accepted for image send — convert to PNG/JPEG first. Channels without image support return an explicit error instead of dropping the attachment.
+
 Start with [`config.example.yaml`](config.example.yaml), then read [Agent routing](docs/routing.md) for runtime-specific configuration.
 
 ## Documentation

--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -57,6 +57,12 @@ func (s *stringSliceFlag) trimmed() []string {
 	return out
 }
 
+// isSVGPath reports whether path points to an SVG file. Feishu's im/v1/images
+// upload does not accept SVG, and rasterizing it would be the caller's job.
+func isSVGPath(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".svg")
+}
+
 const exitCodeRestartRequested = 75
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
@@ -280,6 +286,12 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 	if messageText == "" && len(imageValues) == 0 {
 		logger.Printf("--text or --image is required")
 		return 1
+	}
+	for _, imagePath := range imageValues {
+		if isSVGPath(imagePath) {
+			logger.Printf("unsupported image format: %s\nFeishu image send does not support SVG; convert to PNG/JPEG first (issue #374)", imagePath)
+			return 1
+		}
 	}
 
 	channelName := strings.ToLower(strings.TrimSpace(*channel))

--- a/cmd/fractalbot/main.go
+++ b/cmd/fractalbot/main.go
@@ -28,6 +28,35 @@ var fileDownloadFn = downloadFileViaHTTP
 var heartbeatCronSetFn = setHeartbeatCronViaGatewayAPI
 var heartbeatCronResetFn = resetHeartbeatCronViaGatewayAPI
 
+// stringSliceFlag implements flag.Value so a flag can be specified multiple
+// times (e.g. --image a.png --image b.png) and accumulate into a slice.
+type stringSliceFlag []string
+
+func (s *stringSliceFlag) String() string {
+	if s == nil {
+		return ""
+	}
+	return strings.Join(*s, ",")
+}
+
+func (s *stringSliceFlag) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+func (s *stringSliceFlag) trimmed() []string {
+	if s == nil || len(*s) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(*s))
+	for _, value := range *s {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
 const exitCodeRestartRequested = 75
 
 var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGHUP}
@@ -233,6 +262,8 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 	to := sendFS.String("to", "", "target chat ID")
 	text := sendFS.String("text", "", "message text")
 	threadTS := sendFS.String("thread-ts", "", "optional Slack thread timestamp for threaded reply")
+	var imagePaths stringSliceFlag
+	sendFS.Var(&imagePaths, "image", "local image path to attach (repeatable; issue #374)")
 
 	if err := sendFS.Parse(args[1:]); err != nil {
 		return 1
@@ -245,8 +276,9 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 	}
 
 	messageText := strings.TrimSpace(*text)
-	if messageText == "" {
-		logger.Printf("--text is required")
+	imageValues := imagePaths.trimmed()
+	if messageText == "" && len(imageValues) == 0 {
+		logger.Printf("--text or --image is required")
 		return 1
 	}
 
@@ -258,7 +290,7 @@ func runMessageCommand(ctx context.Context, cfg *config.Config, args []string, o
 
 	threadTSValue := strings.TrimSpace(*threadTS)
 
-	if err := messageSendFn(ctx, cfg, channelName, toValue, messageText, threadTSValue); err != nil {
+	if err := messageSendFn(ctx, cfg, channelName, toValue, messageText, threadTSValue, imageValues); err != nil {
 		logger.Printf("failed to send message: %v", err)
 		return 1
 	}
@@ -314,12 +346,13 @@ func runFileCommand(ctx context.Context, cfg *config.Config, args []string, out 
 	return 0
 }
 
-func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
 	type requestPayload struct {
-		Channel  string `json:"channel"`
-		To       string `json:"to"`
-		Text     string `json:"text"`
-		ThreadTS string `json:"thread_ts,omitempty"`
+		Channel  string   `json:"channel"`
+		To       string   `json:"to"`
+		Text     string   `json:"text"`
+		ThreadTS string   `json:"thread_ts,omitempty"`
+		Images   []string `json:"images,omitempty"`
 	}
 
 	type responsePayload struct {
@@ -332,6 +365,7 @@ func sendMessageViaGatewayAPI(ctx context.Context, cfg *config.Config, channel s
 		To:       to,
 		Text:     text,
 		ThreadTS: threadTS,
+		Images:   images,
 	})
 	if err != nil {
 		return fmt.Errorf("marshal request: %w", err)

--- a/cmd/fractalbot/main_test.go
+++ b/cmd/fractalbot/main_test.go
@@ -60,7 +60,7 @@ func TestRunMessageSend(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		called := false
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
 			_ = ctx
 			_ = cfg
 			called = true
@@ -101,7 +101,7 @@ func TestRunMessageSend(t *testing.T) {
 
 	t.Run("success with thread ts", func(t *testing.T) {
 		called := false
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
 			_ = ctx
 			_ = cfg
 			called = true
@@ -138,6 +138,78 @@ func TestRunMessageSend(t *testing.T) {
 		}
 	})
 
+	t.Run("success with repeatable images and text caption", func(t *testing.T) {
+		var gotImages []string
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
+			_ = ctx
+			_ = cfg
+			gotImages = images
+			if channel != "feishu" {
+				t.Fatalf("channel=%q", channel)
+			}
+			if to != "oc_1" {
+				t.Fatalf("to=%s", to)
+			}
+			if text != "架构对比图" {
+				t.Fatalf("text=%q", text)
+			}
+			if len(images) != 2 {
+				t.Fatalf("expected 2 images, got %v", images)
+			}
+			return nil
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"message", "send",
+			"--channel", "feishu",
+			"--to", "oc_1",
+			"--text", "架构对比图",
+			"--image", "/tmp/arch-compare.png",
+			"--image", "/tmp/loss-curve.png",
+		}, &buf)
+
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
+		}
+		if len(gotImages) != 2 {
+			t.Fatalf("expected images forwarded to send fn, got %v", gotImages)
+		}
+	})
+
+	t.Run("images only (no text)", func(t *testing.T) {
+		called := false
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
+			_ = ctx
+			_ = cfg
+			called = true
+			if text != "" {
+				t.Fatalf("expected empty text, got %q", text)
+			}
+			if len(images) != 1 || images[0] != "/tmp/a.png" {
+				t.Fatalf("unexpected images: %v", images)
+			}
+			return nil
+		}
+
+		var buf bytes.Buffer
+		code := runWithContext(context.Background(), []string{
+			"--config", configPath,
+			"message", "send",
+			"--channel", "feishu",
+			"--to", "oc_2",
+			"--image", "/tmp/a.png",
+		}, &buf)
+
+		if code != 0 {
+			t.Fatalf("expected exit code 0, got %d output=%q", code, buf.String())
+		}
+		if !called {
+			t.Fatalf("expected message send function to be called")
+		}
+	})
+
 	t.Run("validation errors", func(t *testing.T) {
 		cases := []struct {
 			name          string
@@ -150,15 +222,20 @@ func TestRunMessageSend(t *testing.T) {
 				expectedError: "--to is required",
 			},
 			{
-				name:          "missing text",
+				name:          "missing text and image",
 				args:          []string{"--channel", "telegram", "--to", "5088760910"},
-				expectedError: "--text is required",
+				expectedError: "--text or --image is required",
+			},
+			{
+				name:          "svg image rejected",
+				args:          []string{"--channel", "feishu", "--to", "oc_1", "--text", "caption", "--image", "/tmp/chart.svg"},
+				expectedError: "does not support SVG",
 			},
 		}
 
 		for _, testCase := range cases {
 			t.Run(testCase.name, func(t *testing.T) {
-				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+				messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
 					_ = ctx
 					_ = cfg
 					_ = channel
@@ -183,7 +260,7 @@ func TestRunMessageSend(t *testing.T) {
 	})
 
 	t.Run("unknown subcommand", func(t *testing.T) {
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
 			_ = ctx
 			_ = cfg
 			_ = channel
@@ -208,7 +285,7 @@ func TestRunMessageSend(t *testing.T) {
 	})
 
 	t.Run("send failure", func(t *testing.T) {
-		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string) error {
+		messageSendFn = func(ctx context.Context, cfg *config.Config, channel string, to string, text string, threadTS string, images []string) error {
 			_ = ctx
 			_ = cfg
 			_ = channel

--- a/internal/channels/channel.go
+++ b/internal/channels/channel.go
@@ -28,7 +28,8 @@ type SendResult struct {
 type OutboundMessage struct {
 	To       string
 	Text     string
-	ThreadTS string // thread/reply context (Slack threads, etc.)
+	ThreadTS string   // thread/reply context (Slack threads, etc.)
+	Images   []string // local file paths to attach as image messages (issue #374)
 }
 
 // MediaPart represents a single media attachment for outbound messages.

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +22,9 @@ import (
 const (
 	feishuDomainFeishu = "feishu"
 	feishuDomainLark   = "lark"
+
+	// feishuImageMaxBytes mirrors the im/v1/images upload limit (10MB).
+	feishuImageMaxBytes = 10 * 1024 * 1024
 )
 
 type FeishuBot struct {
@@ -39,6 +43,8 @@ type FeishuBot struct {
 	startFn       func(ctx context.Context) error
 	stopFn        func() error
 	sendMessageFn func(ctx context.Context, receiveIDType, receiveID, text string) error
+	uploadImageFn func(ctx context.Context, imagePath string) (string, error)
+	sendImageFn   func(ctx context.Context, receiveIDType, receiveID, imageKey string) error
 
 	runningMu sync.RWMutex
 	running   bool
@@ -163,7 +169,7 @@ func (b *FeishuBot) Stop(ctx context.Context) error {
 }
 
 func (b *FeishuBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
-	if b.sendMessageFn == nil {
+	if b.sendMessageFn == nil || b.uploadImageFn == nil || b.sendImageFn == nil {
 		return nil, errors.New("feishu sender not configured")
 	}
 	if strings.TrimSpace(msg.To) == "" {
@@ -173,9 +179,22 @@ func (b *FeishuBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult,
 	if strings.HasPrefix(msg.To, "oc_") {
 		receiveIDType = "chat_id"
 	}
-	if err := b.sendMessageFn(ctx, receiveIDType, msg.To, msg.Text); err != nil {
-		b.markError()
-		return nil, err
+	if text := strings.TrimSpace(msg.Text); text != "" {
+		if err := b.sendMessageFn(ctx, receiveIDType, msg.To, text); err != nil {
+			b.markError()
+			return nil, err
+		}
+	}
+	for _, imagePath := range msg.Images {
+		imageKey, err := b.uploadImageFn(ctx, imagePath)
+		if err != nil {
+			b.markError()
+			return nil, err
+		}
+		if err := b.sendImageFn(ctx, receiveIDType, msg.To, imageKey); err != nil {
+			b.markError()
+			return nil, err
+		}
 	}
 	b.markActivity()
 	return &SendResult{ChannelID: msg.To}, nil
@@ -207,6 +226,8 @@ func (b *FeishuBot) initClients() {
 	)
 
 	b.sendMessageFn = b.sendText
+	b.uploadImageFn = b.uploadImage
+	b.sendImageFn = b.sendImage
 	b.startFn = b.startLongConnection
 }
 
@@ -267,6 +288,96 @@ func (b *FeishuBot) sendText(ctx context.Context, receiveIDType, receiveID, text
 		return sendErr
 	}
 	b.markActivity()
+	return nil
+}
+
+// uploadImage uploads a local image via im/v1/images and returns its image_key.
+// It validates the file exists and fits within the API's 10MB limit before
+// reading it, so bad paths fail fast instead of hanging the send.
+func (b *FeishuBot) uploadImage(ctx context.Context, imagePath string) (string, error) {
+	if b.apiClient == nil {
+		return "", errors.New("feishu api client not initialized")
+	}
+	info, err := os.Stat(imagePath)
+	if err != nil {
+		return "", fmt.Errorf("feishu image %s: %w", imagePath, err)
+	}
+	if info.Size() == 0 {
+		return "", fmt.Errorf("feishu image %s: file is empty", imagePath)
+	}
+	if info.Size() > feishuImageMaxBytes {
+		return "", fmt.Errorf("feishu image %s: size %d exceeds 10MB upload limit", imagePath, info.Size())
+	}
+
+	body, err := larkim.NewCreateImagePathReqBodyBuilder().
+		ImageType(larkim.ImageTypeMessage).
+		ImagePath(imagePath).
+		Build()
+	if err != nil {
+		return "", fmt.Errorf("feishu build image upload request: %w", err)
+	}
+	req := larkim.NewCreateImageReqBuilder().Body(body).Build()
+
+	resp, err := b.apiClient.Im.V1.Image.Create(ctx, req)
+	if err != nil {
+		if isFeishuTokenError(err) {
+			log.Printf("feishu: token error, refreshing API client: %v", err)
+			b.refreshAPIClient()
+		}
+		return "", fmt.Errorf("feishu image upload %s: %w", imagePath, err)
+	}
+	if !resp.Success() {
+		sendErr := fmt.Errorf("feishu image upload failed: code=%d msg=%s", resp.Code, resp.Msg)
+		if isFeishuTokenError(sendErr) {
+			log.Printf("feishu: token error in response, refreshing API client: %v", sendErr)
+			b.refreshAPIClient()
+		}
+		return "", sendErr
+	}
+	if resp.Data == nil || resp.Data.ImageKey == nil || *resp.Data.ImageKey == "" {
+		return "", fmt.Errorf("feishu image upload %s: empty image_key in response", imagePath)
+	}
+	return *resp.Data.ImageKey, nil
+}
+
+func (b *FeishuBot) sendImage(ctx context.Context, receiveIDType, receiveID, imageKey string) error {
+	if b.apiClient == nil {
+		return errors.New("feishu api client not initialized")
+	}
+	if strings.TrimSpace(receiveID) == "" {
+		return errors.New("feishu receive_id is required")
+	}
+
+	payload, err := json.Marshal(map[string]string{"image_key": imageKey})
+	if err != nil {
+		return fmt.Errorf("failed to marshal feishu image content: %w", err)
+	}
+
+	req := larkim.NewCreateMessageReqBuilder().
+		ReceiveIdType(receiveIDType).
+		Body(larkim.NewCreateMessageReqBodyBuilder().
+			ReceiveId(receiveID).
+			MsgType("image").
+			Content(string(payload)).
+			Build()).
+		Build()
+
+	resp, err := b.apiClient.Im.V1.Message.Create(ctx, req)
+	if err != nil {
+		if isFeishuTokenError(err) {
+			log.Printf("feishu: token error, refreshing API client: %v", err)
+			b.refreshAPIClient()
+		}
+		return err
+	}
+	if !resp.Success() {
+		sendErr := fmt.Errorf("feishu send image failed: code=%d msg=%s", resp.Code, resp.Msg)
+		if isFeishuTokenError(sendErr) {
+			log.Printf("feishu: token error in response, refreshing API client: %v", sendErr)
+			b.refreshAPIClient()
+		}
+		return sendErr
+	}
 	return nil
 }
 

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -169,8 +169,11 @@ func (b *FeishuBot) Stop(ctx context.Context) error {
 }
 
 func (b *FeishuBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult, error) {
-	if b.sendMessageFn == nil || b.uploadImageFn == nil || b.sendImageFn == nil {
+	if b.sendMessageFn == nil {
 		return nil, errors.New("feishu sender not configured")
+	}
+	if len(msg.Images) > 0 && (b.uploadImageFn == nil || b.sendImageFn == nil) {
+		return nil, errors.New("feishu image sender not configured")
 	}
 	if strings.TrimSpace(msg.To) == "" {
 		return nil, errors.New("feishu receive_id is required")

--- a/internal/channels/feishu.go
+++ b/internal/channels/feishu.go
@@ -182,18 +182,27 @@ func (b *FeishuBot) Send(ctx context.Context, msg OutboundMessage) (*SendResult,
 	if strings.HasPrefix(msg.To, "oc_") {
 		receiveIDType = "chat_id"
 	}
-	if text := strings.TrimSpace(msg.Text); text != "" {
-		if err := b.sendMessageFn(ctx, receiveIDType, msg.To, text); err != nil {
-			b.markError()
-			return nil, err
-		}
-	}
+
+	// Preflight every image before any chat-side send: an upload failure must
+	// leave zero delivered messages so a retry cannot duplicate the caption or
+	// earlier attachments (QA P1).
+	imageKeys := make([]string, 0, len(msg.Images))
 	for _, imagePath := range msg.Images {
 		imageKey, err := b.uploadImageFn(ctx, imagePath)
 		if err != nil {
 			b.markError()
 			return nil, err
 		}
+		imageKeys = append(imageKeys, imageKey)
+	}
+
+	if text := strings.TrimSpace(msg.Text); text != "" {
+		if err := b.sendMessageFn(ctx, receiveIDType, msg.To, text); err != nil {
+			b.markError()
+			return nil, err
+		}
+	}
+	for _, imageKey := range imageKeys {
 		if err := b.sendImageFn(ctx, receiveIDType, msg.To, imageKey); err != nil {
 			b.markError()
 			return nil, err
@@ -304,6 +313,9 @@ func (b *FeishuBot) uploadImage(ctx context.Context, imagePath string) (string, 
 	info, err := os.Stat(imagePath)
 	if err != nil {
 		return "", fmt.Errorf("feishu image %s: %w", imagePath, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("feishu image %s: path is a directory, not a file", imagePath)
 	}
 	if info.Size() == 0 {
 		return "", fmt.Errorf("feishu image %s: file is empty", imagePath)

--- a/internal/channels/feishu_test.go
+++ b/internal/channels/feishu_test.go
@@ -2,10 +2,14 @@ package channels
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	lark "github.com/larksuite/oapi-sdk-go/v3"
 	larkim "github.com/larksuite/oapi-sdk-go/v3/service/im/v1"
 
 	"github.com/fractalmind-ai/fractalbot/pkg/protocol"
@@ -474,6 +478,137 @@ func buildFeishuEventWithSenderType(text, chatType, openID, userID, chatID, send
 			},
 		},
 	}
+}
+
+func TestFeishuSendWithImages(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", []string{"ou_1"}, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+
+	var sentTexts []string
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		sentTexts = append(sentTexts, text)
+		return nil
+	}
+
+	var uploaded []string
+	bot.uploadImageFn = func(ctx context.Context, imagePath string) (string, error) {
+		uploaded = append(uploaded, imagePath)
+		return "img_" + imagePath, nil
+	}
+
+	var sentImages []string
+	bot.sendImageFn = func(ctx context.Context, receiveIDType, receiveID, imageKey string) error {
+		sentImages = append(sentImages, imageKey)
+		return nil
+	}
+
+	result, err := bot.Send(context.Background(), OutboundMessage{
+		To:     "oc_1",
+		Text:   "caption",
+		Images: []string{"/tmp/a.png", "/tmp/b.png"},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if result == nil || result.ChannelID != "oc_1" {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+	if len(sentTexts) != 1 || sentTexts[0] != "caption" {
+		t.Fatalf("expected caption text sent first, got %v", sentTexts)
+	}
+	if len(uploaded) != 2 || uploaded[0] != "/tmp/a.png" || uploaded[1] != "/tmp/b.png" {
+		t.Fatalf("expected both images uploaded in order, got %v", uploaded)
+	}
+	if len(sentImages) != 2 || sentImages[0] != "img_/tmp/a.png" || sentImages[1] != "img_/tmp/b.png" {
+		t.Fatalf("expected one image message per uploaded key, got %v", sentImages)
+	}
+}
+
+func TestFeishuSendImagesOnlySkipsText(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+
+	textCalls := 0
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		textCalls++
+		return nil
+	}
+	bot.uploadImageFn = func(ctx context.Context, imagePath string) (string, error) {
+		return "img_key", nil
+	}
+	bot.sendImageFn = func(ctx context.Context, receiveIDType, receiveID, imageKey string) error {
+		return nil
+	}
+
+	if _, err := bot.Send(context.Background(), OutboundMessage{To: "oc_1", Images: []string{"/tmp/a.png"}}); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if textCalls != 0 {
+		t.Fatalf("expected no text message for images-only send, got %d calls", textCalls)
+	}
+}
+
+func TestFeishuSendImageUploadFailurePropagates(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error { return nil }
+	bot.uploadImageFn = func(ctx context.Context, imagePath string) (string, error) {
+		return "", errors.New("upload denied")
+	}
+	bot.sendImageFn = func(ctx context.Context, receiveIDType, receiveID, imageKey string) error {
+		t.Fatalf("sendImageFn should not be called when upload fails")
+		return nil
+	}
+
+	_, err = bot.Send(context.Background(), OutboundMessage{To: "oc_1", Text: "caption", Images: []string{"/tmp/a.png"}})
+	if err == nil || !strings.Contains(err.Error(), "upload denied") {
+		t.Fatalf("expected upload error to propagate, got %v", err)
+	}
+}
+
+func TestFeishuUploadImageValidation(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+	bot.apiClient = lark.NewClient("app", "secret")
+
+	t.Run("missing file", func(t *testing.T) {
+		_, err := bot.uploadImage(context.Background(), filepath.Join(t.TempDir(), "nope.png"))
+		if err == nil {
+			t.Fatalf("expected error for missing file")
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "empty.png")
+		if err := os.WriteFile(path, []byte{}, 0644); err != nil {
+			t.Fatalf("write empty file: %v", err)
+		}
+		_, err := bot.uploadImage(context.Background(), path)
+		if err == nil || !strings.Contains(err.Error(), "empty") {
+			t.Fatalf("expected empty-file error, got %v", err)
+		}
+	})
+
+	t.Run("oversize file", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "big.png")
+		if err := os.WriteFile(path, make([]byte, feishuImageMaxBytes+1), 0644); err != nil {
+			t.Fatalf("write big file: %v", err)
+		}
+		_, err := bot.uploadImage(context.Background(), path)
+		if err == nil || !strings.Contains(err.Error(), "exceeds 10MB") {
+			t.Fatalf("expected size-limit error, got %v", err)
+		}
+	})
 }
 
 func strPtr(value string) *string {

--- a/internal/channels/feishu_test.go
+++ b/internal/channels/feishu_test.go
@@ -557,7 +557,11 @@ func TestFeishuSendImageUploadFailurePropagates(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewFeishuBot: %v", err)
 	}
-	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error { return nil }
+	textCalls := 0
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		textCalls++
+		return nil
+	}
 	bot.uploadImageFn = func(ctx context.Context, imagePath string) (string, error) {
 		return "", errors.New("upload denied")
 	}
@@ -569,6 +573,45 @@ func TestFeishuSendImageUploadFailurePropagates(t *testing.T) {
 	_, err = bot.Send(context.Background(), OutboundMessage{To: "oc_1", Text: "caption", Images: []string{"/tmp/a.png"}})
 	if err == nil || !strings.Contains(err.Error(), "upload denied") {
 		t.Fatalf("expected upload error to propagate, got %v", err)
+	}
+	if textCalls != 0 {
+		t.Fatalf("expected zero chat-side sends when upload fails (caption must not be delivered), got %d text calls", textCalls)
+	}
+}
+
+func TestFeishuSendImageUploadFailureMidwayLeavesNoSends(t *testing.T) {
+	bot, err := NewFeishuBot("app", "secret", "feishu", nil, "", nil)
+	if err != nil {
+		t.Fatalf("NewFeishuBot: %v", err)
+	}
+	textCalls := 0
+	imageSendCalls := 0
+	uploadCalls := 0
+	bot.sendMessageFn = func(ctx context.Context, receiveIDType, receiveID, text string) error {
+		textCalls++
+		return nil
+	}
+	bot.uploadImageFn = func(ctx context.Context, imagePath string) (string, error) {
+		uploadCalls++
+		if uploadCalls == 2 {
+			return "", errors.New("second upload denied")
+		}
+		return "img_key_" + imagePath, nil
+	}
+	bot.sendImageFn = func(ctx context.Context, receiveIDType, receiveID, imageKey string) error {
+		imageSendCalls++
+		return nil
+	}
+
+	_, err = bot.Send(context.Background(), OutboundMessage{To: "oc_1", Text: "caption", Images: []string{"/tmp/a.png", "/tmp/b.png"}})
+	if err == nil || !strings.Contains(err.Error(), "second upload denied") {
+		t.Fatalf("expected second upload error to propagate, got %v", err)
+	}
+	if textCalls != 0 {
+		t.Fatalf("expected zero caption sends when a later image upload fails, got %d text calls", textCalls)
+	}
+	if imageSendCalls != 0 {
+		t.Fatalf("expected zero image sends when a later image upload fails, got %d image sends", imageSendCalls)
 	}
 }
 
@@ -607,6 +650,14 @@ func TestFeishuUploadImageValidation(t *testing.T) {
 		_, err := bot.uploadImage(context.Background(), path)
 		if err == nil || !strings.Contains(err.Error(), "exceeds 10MB") {
 			t.Fatalf("expected size-limit error, got %v", err)
+		}
+	})
+
+	t.Run("directory path", func(t *testing.T) {
+		dir := t.TempDir()
+		_, err := bot.uploadImage(context.Background(), dir)
+		if err == nil || !strings.Contains(err.Error(), "directory") {
+			t.Fatalf("expected directory rejection, got %v", err)
 		}
 	})
 }

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -331,10 +331,11 @@ func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 type messageSendRequest struct {
-	Channel  string `json:"channel"`
-	To       string `json:"to"`
-	Text     string `json:"text"`
-	ThreadTS string `json:"thread_ts,omitempty"`
+	Channel  string   `json:"channel"`
+	To       string   `json:"to"`
+	Text     string   `json:"text"`
+	ThreadTS string   `json:"thread_ts,omitempty"`
+	Images   []string `json:"images,omitempty"`
 }
 
 type messageSendResponse struct {
@@ -367,6 +368,13 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 	request.To = strings.TrimSpace(request.To)
 	request.Text = strings.TrimSpace(request.Text)
 	request.ThreadTS = strings.TrimSpace(request.ThreadTS)
+	trimmedImages := make([]string, 0, len(request.Images))
+	for _, path := range request.Images {
+		if trimmed := strings.TrimSpace(path); trimmed != "" {
+			trimmedImages = append(trimmedImages, trimmed)
+		}
+	}
+	request.Images = trimmedImages
 
 	if request.Channel == "" {
 		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "channel is required"})
@@ -376,8 +384,8 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "to is required"})
 		return
 	}
-	if request.Text == "" {
-		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "text is required"})
+	if request.Text == "" && len(request.Images) == 0 {
+		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "text or images is required"})
 		return
 	}
 
@@ -390,8 +398,8 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		To:       request.To,
 		Text:     request.Text,
 		ThreadTS: request.ThreadTS,
-	})
-	if err != nil {
+		Images:   request.Images,
+	}); err != nil {
 		status := http.StatusBadGateway
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound

--- a/internal/gateway/server.go
+++ b/internal/gateway/server.go
@@ -388,6 +388,13 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, messageSendResponse{Status: "error", Error: "text or images is required"})
 		return
 	}
+	if len(request.Images) > 0 && !imageSendChannelSupported(request.Channel) {
+		writeJSON(w, http.StatusBadRequest, messageSendResponse{
+			Status: "error",
+			Error:  fmt.Sprintf("channel %q does not support image attachment yet (issue #374); currently supported: feishu", request.Channel),
+		})
+		return
+	}
 
 	if s.messageBus == nil {
 		writeJSON(w, http.StatusServiceUnavailable, messageSendResponse{Status: "error", Error: "message bus unavailable"})
@@ -399,7 +406,8 @@ func (s *Server) handleMessageSend(w http.ResponseWriter, r *http.Request) {
 		Text:     request.Text,
 		ThreadTS: request.ThreadTS,
 		Images:   request.Images,
-	}); err != nil {
+	})
+	if err != nil {
 		status := http.StatusBadGateway
 		if strings.Contains(err.Error(), "not found") {
 			status = http.StatusNotFound
@@ -509,6 +517,13 @@ func isLoopbackRequest(r *http.Request) bool {
 	}
 	ip := net.ParseIP(host)
 	return ip != nil && ip.IsLoopback()
+}
+
+// imageSendChannelSupported reports whether a channel can deliver image
+// attachments. Feishu is the first implementation (issue #374); others return
+// explicit errors instead of silently dropping images.
+func imageSendChannelSupported(channel string) bool {
+	return channel == "feishu"
 }
 
 func writeJSON(w http.ResponseWriter, statusCode int, payload any) {

--- a/internal/gateway/server_test.go
+++ b/internal/gateway/server_test.go
@@ -626,6 +626,7 @@ type fakeSendChannel struct {
 	lastChat   string
 	lastText   string
 	lastThread string
+	lastImages []string
 	sendErr    error
 }
 
@@ -648,6 +649,7 @@ func (f *fakeSendChannel) Send(ctx context.Context, msg channels.OutboundMessage
 	f.lastChat = msg.To
 	f.lastText = msg.Text
 	f.lastThread = msg.ThreadTS
+	f.lastImages = msg.Images
 	if f.sendErr != nil {
 		return nil, f.sendErr
 	}
@@ -677,6 +679,10 @@ func TestMessageSendAPI(t *testing.T) {
 	fakeSlack := &fakeSendChannel{name: "slack"}
 	if err := server.agentManager.ChannelManager.Register(fakeSlack); err != nil {
 		t.Fatalf("register fake slack channel: %v", err)
+	}
+	fakeFeishu := &fakeSendChannel{name: "feishu"}
+	if err := server.agentManager.ChannelManager.Register(fakeFeishu); err != nil {
+		t.Fatalf("register fake feishu channel: %v", err)
 	}
 
 	mux := http.NewServeMux()
@@ -803,6 +809,81 @@ func TestMessageSendAPI(t *testing.T) {
 		if resp.StatusCode != http.StatusNotFound {
 			body, _ := io.ReadAll(resp.Body)
 			t.Fatalf("expected 404, got %d body=%s", resp.StatusCode, string(body))
+		}
+	})
+
+	t.Run("image to unsupported channel returns explicit error", func(t *testing.T) {
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"telegram","to":"12345","text":"caption","images":["/tmp/a.png"]}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusBadRequest {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 400, got %d body=%s", resp.StatusCode, string(body))
+		}
+		var payload messageSendResponse
+		if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if !strings.Contains(payload.Error, "does not support image attachment") {
+			t.Fatalf("expected explicit unsupported-channel error, got %q", payload.Error)
+		}
+	})
+
+	t.Run("image to feishu passes through with text", func(t *testing.T) {
+		fakeFeishu.lastChat = ""
+		fakeFeishu.lastText = ""
+		fakeFeishu.lastImages = nil
+
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"feishu","to":"oc_1","text":"caption","images":["/tmp/a.png","/tmp/b.png"]}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d body=%s", resp.StatusCode, string(body))
+		}
+		if fakeFeishu.lastText != "caption" {
+			t.Fatalf("expected caption text, got %q", fakeFeishu.lastText)
+		}
+		if len(fakeFeishu.lastImages) != 2 || fakeFeishu.lastImages[0] != "/tmp/a.png" || fakeFeishu.lastImages[1] != "/tmp/b.png" {
+			t.Fatalf("expected both image paths forwarded, got %v", fakeFeishu.lastImages)
+		}
+	})
+
+	t.Run("images-only send passes validation", func(t *testing.T) {
+		fakeFeishu.lastChat = ""
+		fakeFeishu.lastText = ""
+		fakeFeishu.lastImages = nil
+
+		resp, err := http.Post(
+			ts.URL+"/api/v1/message/send",
+			"application/json",
+			strings.NewReader(`{"channel":"feishu","to":"oc_2","images":["/tmp/a.png"]}`),
+		)
+		if err != nil {
+			t.Fatalf("post failed: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected images-only send to pass, got %d body=%s", resp.StatusCode, string(body))
+		}
+		if len(fakeFeishu.lastImages) != 1 || fakeFeishu.lastImages[0] != "/tmp/a.png" {
+			t.Fatalf("expected image forwarded, got %v", fakeFeishu.lastImages)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Add a repeatable `--image` flag to `fractalbot message send` (`--text` acts as caption; images-only sends are allowed)
- Extend `OutboundMessage` with an `Images` field and pass it through the gateway API
- Implement Feishu image delivery: upload each file via `im/v1/images` to get an `image_key`, then send an `image` message per upload
- Reject image sends on channels that don't support them yet with an explicit error (no silent drop)
- Reject SVG paths in the CLI (Feishu's image upload does not accept SVG; convert to PNG/JPEG first)

## Test plan
- CLI: repeatable `--image` parsing, text+image caption, images-only send, SVG rejection
- Gateway: image send to unsupported channel returns 400 with explicit error; feishu forwards images; images-only passes validation
- Feishu channel: mocked upload+send orchestration, text sent first, upload-failure propagation, and `uploadImage` file validation (missing / empty / oversize)
- `go build ./...`, `go vet ./...`, `go test ./...` all pass

Closes #374
