### PR TITLE
feat: add completion-aware ohMyCode heartbeats

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -243,3 +243,15 @@ agents:
   #         idle: "0 * * * *"
   #         deep-idle: "0 */6 * * *"
   #       resetCronOnInbound: true
+  #
+  #     # Optional completion-aware ohMyCode delivery. This calls
+  #     # `agent-manager heartbeat run main --timeout 8m0s` instead of generic
+  #     # `assign`, so the job remains in flight until the heartbeat reaches a
+  #     # terminal ACK, skip, or failure. `text` is not required in this mode.
+  #     - id: "main-native-heartbeat"
+  #       runtime: "ohMyCode"
+  #       agent: "main"
+  #       dispatchMode: "heartbeatRun"
+  #       timeoutSeconds: 480
+  #       cron: "*/5 * * * *"
+  #       timezone: "Asia/Shanghai"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ The CLI calls the gateway's HTTP send endpoint. HTTP and in-process callers publ
 
 Heartbeat jobs bypass the selected Agent Router and address `ohMyCode`, `codexAppCDP`, or `claudeDesktop` explicitly. The scheduler sends an autonomous envelope with job, run, schedule, expiry, target Agent, and inline instruction metadata. It does not synthesize a channel or chat identity and never sends a channel acknowledgement.
 
-Desktop fallback inboxes coalesce queued heartbeats by job so an unavailable app does not accumulate stale wakeups. Agents normally do not report back to the scheduler. Only an Agent that finds no actionable work may select an operator-approved lower-frequency cron profile through the loopback API; matching user activity can restore the configured default cron. See [Agent heartbeats](heartbeat.md).
+Desktop fallback inboxes coalesce queued heartbeats by job so an unavailable app does not accumulate stale wakeups. Generic Runtime delivery normally reports acceptance rather than task completion. An `ohMyCode` job may opt into `dispatchMode: heartbeatRun`; that adapter delegates to agent-manager's native heartbeat lifecycle and holds the in-flight lease through its terminal result. Only an Agent that finds no actionable work may select an operator-approved lower-frequency cron profile through the loopback API; matching user activity can restore the configured default cron. See [Agent heartbeats](heartbeat.md).
 
 ## Reliability and security boundaries
 

--- a/docs/heartbeat.md
+++ b/docs/heartbeat.md
@@ -31,6 +31,35 @@ agents:
 
 The configured `cron` remains the default. `agentCronProfiles` contains the only alternative schedules an Agent may select; arbitrary Agent-provided cron expressions are rejected.
 
+### Completion-aware ohMyCode heartbeats
+
+By default, an `ohMyCode` heartbeat uses the existing generic `agent-manager assign` delivery. That preserves custom `text` instructions, but successful delivery only means that agent-manager accepted the task; it does not mean the heartbeat work finished.
+
+Set `dispatchMode: heartbeatRun` when agent-manager's native heartbeat lifecycle should remain authoritative:
+
+```yaml
+agents:
+  ohMyCode:
+    enabled: true
+    workspace: "/absolute/path/to/workspace"
+    defaultAgent: "main"
+    allowedAgents: ["main"]
+  heartbeat:
+    enabled: true
+    jobs:
+      - id: "main"
+        runtime: "ohMyCode"
+        agent: "main"
+        dispatchMode: "heartbeatRun"
+        timeoutSeconds: 480
+        cron: "*/5 * * * *"
+        timezone: "Asia/Shanghai"
+```
+
+This mode calls `agent-manager heartbeat run <agent> --timeout <duration>`. The job stays in flight until agent-manager returns a terminal ACK, skip, or failure, so overlapping ticks are coalesced for the full lifecycle rather than only for task assignment. The HB ID printed by agent-manager is recorded as `last_envelope_id` in `/status`.
+
+`text` is optional and not delivered in this mode because agent-manager owns the canonical heartbeat prompt. `timeoutSeconds` defaults to 480 and may be set from 1 to 86400 seconds; zero selects the default. A terminal agent-manager failure is recorded as `heartbeat_failed` and is not retried by FractalBot, avoiding duplicate heartbeat execution. Generic runtime delivery errors keep the existing bounded retry behavior.
+
 ## Schedule adjustment
 
 A normal heartbeat requires no callback. Only when the Agent determines that there is no actionable work should it reduce the frequency:
@@ -71,10 +100,11 @@ When `resetCronOnInbound` is true, a normal user message successfully routed to 
 - Restart preserves the effective profile but calculates the next future occurrence. Missed heartbeats are never replayed.
 - Codex App and Claude Desktop inbox fallback uses a stable key per job. A newer queued heartbeat replaces the older unconsumed heartbeat.
 - Runtime delivery errors receive a bounded exponential-backoff retry. The final failure is recorded without changing the Agent-selected schedule.
+- `ohMyCode` jobs using `dispatchMode: heartbeatRun` hold the in-flight lease through agent-manager's terminal result and do not retry terminal heartbeat failures.
 
 ## Status
 
-`GET /status` includes a redacted `heartbeat` section with configured and effective cron, timezone, next run, in-flight state, last dispatch result, and schedule-change audit fields.
+`GET /status` includes a redacted `heartbeat` section with configured and effective cron, timezone, dispatch mode and timeout, next run, in-flight state, last dispatch result, and schedule-change audit fields.
 
 ```bash
 curl -sS http://127.0.0.1:18789/status | python3 -m json.tool

--- a/internal/agent/manager.go
+++ b/internal/agent/manager.go
@@ -486,10 +486,10 @@ func runOhMyCodeAgentManager(ctx context.Context, workspace, script, stdin strin
 
 	if err != nil {
 		if errText != "" {
-			return "", fmt.Errorf("oh-my-code agent-manager failed: %s", errText)
+			return outText, fmt.Errorf("oh-my-code agent-manager failed: %s", errText)
 		}
 		if outText != "" {
-			return "", fmt.Errorf("oh-my-code agent-manager failed: %s", outText)
+			return outText, fmt.Errorf("oh-my-code agent-manager failed: %s", outText)
 		}
 		return "", fmt.Errorf("oh-my-code agent-manager failed: %w", err)
 	}

--- a/internal/agent/runtime_dispatch.go
+++ b/internal/agent/runtime_dispatch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -11,14 +12,33 @@ import (
 	"github.com/fractalmind-ai/fractalbot/internal/agentruntime"
 )
 
+const (
+	defaultOhMyCodeHeartbeatMaxRuntime = 8 * time.Minute
+	ohMyCodeHeartbeatCommandGrace      = 30 * time.Second
+)
+
+var ohMyCodeHeartbeatIDPattern = regexp.MustCompile(`(?m)^\s*HB_ID:\s*([A-Za-z0-9_-]+)\s*$`)
+
 // DispatchRuntime delivers a non-channel wakeup to an explicitly selected
-// Agent Runtime. The result confirms delivery or queueing, not task completion.
+// Agent Runtime. Generic results confirm delivery or queueing; explicit
+// completion-aware modes may wait for a terminal lifecycle result.
 func (m *Manager) DispatchRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {
 	request.Runtime = strings.TrimSpace(request.Runtime)
 	request.Agent = strings.TrimSpace(request.Agent)
 	request.Text = strings.TrimSpace(request.Text)
+	request.DispatchMode = strings.TrimSpace(request.DispatchMode)
 	result := agentruntime.DispatchResult{Runtime: request.Runtime, Agent: request.Agent}
-	if request.Text == "" {
+	if request.DispatchMode != "" && request.DispatchMode != agentruntime.DispatchModeHeartbeatRun {
+		result.Status = "error"
+		result.Error = fmt.Sprintf("unsupported runtime dispatch mode %q", request.DispatchMode)
+		return result
+	}
+	if request.DispatchMode == agentruntime.DispatchModeHeartbeatRun && (request.Runtime != agentruntime.OhMyCode || strings.TrimSpace(request.Source) != "heartbeat") {
+		result.Status = "error"
+		result.Error = "heartbeatRun dispatch mode requires an ohMyCode heartbeat request"
+		return result
+	}
+	if request.Text == "" && request.DispatchMode != agentruntime.DispatchModeHeartbeatRun {
 		result.Status = "error"
 		result.Error = "runtime dispatch text is required"
 		return result
@@ -50,6 +70,39 @@ func (m *Manager) dispatchOhMyCodeRuntime(ctx context.Context, request agentrunt
 	}
 	result.Agent = name
 
+	// Heartbeat scheduler deliveries must retain agent-manager's heartbeat
+	// execution contract. Generic assign only proves that tmux accepted a task;
+	// heartbeat run blocks through the terminal ACK/skip/failure audit outcome.
+	// A terminal failure deliberately uses a non-"error" status so the
+	// scheduler does not inject an unsafe duplicate retry.
+	if request.DispatchMode == agentruntime.DispatchModeHeartbeatRun {
+		maxRuntime := request.Timeout
+		if maxRuntime <= 0 {
+			maxRuntime = defaultOhMyCodeHeartbeatMaxRuntime
+		}
+		dispatchCtx, cancel := context.WithTimeout(ctx, maxRuntime+ohMyCodeHeartbeatCommandGrace)
+		defer cancel()
+		output, runErr := runOhMyCodeAgentManager(
+			dispatchCtx,
+			workspace,
+			script,
+			"",
+			"heartbeat",
+			"run",
+			name,
+			"--timeout",
+			maxRuntime.String(),
+		)
+		result.EnvelopeID = parseOhMyCodeHeartbeatID(output)
+		if runErr != nil {
+			result.Status = "heartbeat_failed"
+			result.Error = runErr.Error()
+			return result
+		}
+		result.Status = "heartbeat_terminal"
+		return result
+	}
+
 	timeout := defaultOhMyCodeAssignTimeout
 	if m.config.OhMyCode.AssignTimeoutSeconds > 0 {
 		timeout = time.Duration(m.config.OhMyCode.AssignTimeoutSeconds) * time.Second
@@ -65,6 +118,14 @@ func (m *Manager) dispatchOhMyCodeRuntime(ctx context.Context, request agentrunt
 	}
 	result.Status = "assigned"
 	return result
+}
+
+func parseOhMyCodeHeartbeatID(output string) string {
+	match := ohMyCodeHeartbeatIDPattern.FindStringSubmatch(output)
+	if len(match) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(match[1])
 }
 
 func (m *Manager) dispatchCodexAppRuntime(ctx context.Context, request agentruntime.DispatchRequest) agentruntime.DispatchResult {

--- a/internal/agent/runtime_dispatch_test.go
+++ b/internal/agent/runtime_dispatch_test.go
@@ -38,6 +38,67 @@ print("assigned")
 	}
 }
 
+func TestDispatchRuntimeOhMyCodeHeartbeatUsesHeartbeatRun(t *testing.T) {
+	workspace := t.TempDir()
+	script := filepath.Join(workspace, "agent_manager.py")
+	scriptBody := `import sys
+if sys.argv[1:] != ["heartbeat", "run", "main", "--timeout", "7m0s"]:
+    raise SystemExit("unexpected args: " + repr(sys.argv[1:]))
+if sys.stdin.read() != "":
+    raise SystemExit("heartbeat command must not receive an assign prompt")
+print("Heartbeat: main")
+print("   HB_ID: 20260805-001500")
+print("Heartbeat completed successfully")
+`
+	if err := os.WriteFile(script, []byte(scriptBody), 0700); err != nil {
+		t.Fatalf("write agent manager: %v", err)
+	}
+	manager := NewManager(&config.AgentsConfig{OhMyCode: &config.OhMyCodeConfig{
+		Enabled:            true,
+		Workspace:          workspace,
+		AgentManagerScript: script,
+		DefaultAgent:       "main",
+		AllowedAgents:      []string{"main"},
+	}})
+
+	request := runtimeTestRequest(agentruntime.OhMyCode, "run-1")
+	request.DispatchMode = agentruntime.DispatchModeHeartbeatRun
+	request.Timeout = 7 * time.Minute
+	request.Text = ""
+	result := manager.DispatchRuntime(context.Background(), request)
+	if result.Status != "heartbeat_terminal" || result.Error != "" || result.Agent != "main" || result.EnvelopeID != "20260805-001500" {
+		t.Fatalf("unexpected heartbeat result: %#v", result)
+	}
+}
+
+func TestDispatchRuntimeOhMyCodeHeartbeatFailureIsTerminal(t *testing.T) {
+	workspace := t.TempDir()
+	script := filepath.Join(workspace, "agent_manager.py")
+	scriptBody := `import sys
+
+print("HB_ID: 20260805-001505")
+print("heartbeat failed")
+raise SystemExit(1)
+`
+	if err := os.WriteFile(script, []byte(scriptBody), 0700); err != nil {
+		t.Fatalf("write agent manager: %v", err)
+	}
+	manager := NewManager(&config.AgentsConfig{OhMyCode: &config.OhMyCodeConfig{
+		Enabled:            true,
+		Workspace:          workspace,
+		AgentManagerScript: script,
+		DefaultAgent:       "main",
+		AllowedAgents:      []string{"main"},
+	}})
+
+	request := runtimeTestRequest(agentruntime.OhMyCode, "run-1")
+	request.DispatchMode = agentruntime.DispatchModeHeartbeatRun
+	result := manager.DispatchRuntime(context.Background(), request)
+	if result.Status != "heartbeat_failed" || result.Error == "" || result.EnvelopeID != "20260805-001505" {
+		t.Fatalf("heartbeat failure must be terminal and non-retryable: %#v", result)
+	}
+}
+
 func TestDispatchRuntimeCoalescesCodexAppHeartbeatInbox(t *testing.T) {
 	inbox := filepath.Join(t.TempDir(), "codex-inbox")
 	manager := NewManager(&config.AgentsConfig{CodexAppCDP: &config.CodexAppCDPConfig{
@@ -123,6 +184,20 @@ func TestDispatchRuntimeRejectsInvalidTargetAndText(t *testing.T) {
 	result = manager.DispatchRuntime(context.Background(), request)
 	if result.Status != "error" || !strings.Contains(result.Error, "text is required") {
 		t.Fatalf("unexpected empty text result: %#v", result)
+	}
+
+	request = runtimeTestRequest(agentruntime.CodexAppCDP, "run-1")
+	request.DispatchMode = agentruntime.DispatchModeHeartbeatRun
+	result = manager.DispatchRuntime(context.Background(), request)
+	if result.Status != "error" || !strings.Contains(result.Error, "requires an ohMyCode heartbeat request") {
+		t.Fatalf("unexpected incompatible dispatch mode result: %#v", result)
+	}
+
+	request = runtimeTestRequest(agentruntime.OhMyCode, "run-1")
+	request.DispatchMode = "other"
+	result = manager.DispatchRuntime(context.Background(), request)
+	if result.Status != "error" || !strings.Contains(result.Error, "unsupported runtime dispatch mode") {
+		t.Fatalf("unexpected unsupported dispatch mode result: %#v", result)
 	}
 }
 

--- a/internal/agentruntime/runtime.go
+++ b/internal/agentruntime/runtime.go
@@ -11,6 +11,10 @@ const (
 	OhMyCode      = "ohMyCode"
 	CodexAppCDP   = "codexAppCDP"
 	ClaudeDesktop = "claudeDesktop"
+
+	// DispatchModeHeartbeatRun asks the ohMyCode adapter to execute the
+	// agent-manager heartbeat lifecycle instead of enqueueing a generic task.
+	DispatchModeHeartbeatRun = "heartbeatRun"
 )
 
 // DispatchRequest is an internal agent wakeup that is not associated with a
@@ -26,10 +30,13 @@ type DispatchRequest struct {
 	ExpiresAt    time.Time
 	CoalesceKey  string
 	CronProfiles []string
+	DispatchMode string
+	Timeout      time.Duration
 }
 
-// DispatchResult reports whether a runtime accepted, queued, or rejected a
-// wakeup. It does not imply that the agent completed the resulting work.
+// DispatchResult reports a runtime delivery outcome. Most statuses only mean
+// accepted, queued, or rejected; an explicitly completion-aware dispatch mode
+// may report a terminal lifecycle outcome instead.
 type DispatchResult struct {
 	Runtime    string
 	Agent      string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,8 @@ import (
 
 var agentNamePattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
 
+const maxHeartbeatTimeoutSeconds = 24 * 60 * 60
+
 // Config represents the main configuration.
 type Config struct {
 	Gateway  *GatewayConfig  `yaml:"gateway"`
@@ -299,6 +301,8 @@ type HeartbeatJobConfig struct {
 	Runtime            string            `yaml:"runtime"`
 	Agent              string            `yaml:"agent"`
 	Text               string            `yaml:"text"`
+	DispatchMode       string            `yaml:"dispatchMode,omitempty"`
+	TimeoutSeconds     int               `yaml:"timeoutSeconds,omitempty"`
 	Cron               string            `yaml:"cron"`
 	Timezone           string            `yaml:"timezone"`
 	AgentCronProfiles  map[string]string `yaml:"agentCronProfiles,omitempty"`
@@ -465,6 +469,7 @@ func validateHeartbeatConfig(cfg *Config) error {
 		job.Runtime = strings.TrimSpace(job.Runtime)
 		job.Agent = strings.TrimSpace(job.Agent)
 		job.Text = strings.TrimSpace(job.Text)
+		job.DispatchMode = strings.TrimSpace(job.DispatchMode)
 		job.Cron = strings.TrimSpace(job.Cron)
 		job.Timezone = strings.TrimSpace(job.Timezone)
 
@@ -485,8 +490,20 @@ func validateHeartbeatConfig(cfg *Config) error {
 		if err := validateAgentName(job.Agent); err != nil {
 			return fmt.Errorf("%s.agent: %w", prefix, err)
 		}
-		if job.Text == "" {
+		if job.Text == "" && job.DispatchMode != "heartbeatRun" {
 			return fmt.Errorf("%s.text: required", prefix)
+		}
+		if job.TimeoutSeconds < 0 || job.TimeoutSeconds > maxHeartbeatTimeoutSeconds {
+			return fmt.Errorf("%s.timeoutSeconds: must be between 0 and %d", prefix, maxHeartbeatTimeoutSeconds)
+		}
+		switch job.DispatchMode {
+		case "":
+		case "heartbeatRun":
+			if job.Runtime != "ohMyCode" {
+				return fmt.Errorf("%s.dispatchMode: heartbeatRun requires runtime ohMyCode", prefix)
+			}
+		default:
+			return fmt.Errorf("%s.dispatchMode: unsupported mode %q", prefix, job.DispatchMode)
 		}
 		if job.Cron == "" {
 			return fmt.Errorf("%s.cron: required", prefix)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -485,6 +485,38 @@ func TestLoadConfigAcceptsHeartbeatJobs(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAcceptsOhMyCodeHeartbeatRunMode(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`agents:
+  ohMyCode:
+    enabled: true
+    workspace: /tmp/oh-my-code
+    defaultAgent: main
+    allowedAgents: [main]
+  heartbeat:
+    enabled: true
+    jobs:
+      - id: main
+        runtime: ohMyCode
+        agent: main
+        dispatchMode: heartbeatRun
+        timeoutSeconds: 480
+        cron: "*/5 * * * *"
+        timezone: Asia/Shanghai
+`)
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	job := cfg.Agents.Heartbeat.Jobs[0]
+	if job.DispatchMode != "heartbeatRun" || job.TimeoutSeconds != 480 || job.Text != "" {
+		t.Fatalf("unexpected heartbeatRun job: %#v", job)
+	}
+}
+
 func TestValidateHeartbeatConfigRejectsInvalidJobs(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -560,6 +592,34 @@ func TestValidateHeartbeatConfigRejectsInvalidJobs(t *testing.T) {
 				cfg.Agents.Heartbeat.Jobs[0].AgentCronProfiles[" idle "] = "0 */2 * * *"
 			},
 			wantError: "duplicate profile",
+		},
+		{
+			name: "unsupported dispatch mode",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].DispatchMode = "other"
+			},
+			wantError: "unsupported mode",
+		},
+		{
+			name: "heartbeat run requires oh my code",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].DispatchMode = "heartbeatRun"
+			},
+			wantError: "requires runtime ohMyCode",
+		},
+		{
+			name: "negative timeout",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].TimeoutSeconds = -1
+			},
+			wantError: "timeoutSeconds",
+		},
+		{
+			name: "timeout above one day",
+			mutate: func(cfg *Config) {
+				cfg.Agents.Heartbeat.Jobs[0].TimeoutSeconds = 86401
+			},
+			wantError: "timeoutSeconds",
 		},
 	}
 

--- a/internal/heartbeat/scheduler.go
+++ b/internal/heartbeat/scheduler.go
@@ -40,6 +40,8 @@ type JobStatus struct {
 	ID                    string `json:"id"`
 	Runtime               string `json:"runtime"`
 	Agent                 string `json:"agent"`
+	DispatchMode          string `json:"dispatch_mode,omitempty"`
+	TimeoutSeconds        int    `json:"timeout_seconds,omitempty"`
 	ConfiguredCron        string `json:"configured_cron"`
 	EffectiveProfile      string `json:"effective_profile,omitempty"`
 	EffectiveCron         string `json:"effective_cron"`
@@ -393,6 +395,8 @@ func (s *Scheduler) runDue(now time.Time) {
 					ExpiresAt:    job.state.NextRunAt,
 					CoalesceKey:  "heartbeat:" + id,
 					CronProfiles: profiles,
+					DispatchMode: job.config.DispatchMode,
+					Timeout:      time.Duration(job.config.TimeoutSeconds) * time.Second,
 				},
 			})
 		default:
@@ -484,6 +488,8 @@ func (s *Scheduler) jobStatusLocked(job *compiledJob) JobStatus {
 		ID:                    job.config.ID,
 		Runtime:               job.config.Runtime,
 		Agent:                 job.config.Agent,
+		DispatchMode:          job.config.DispatchMode,
+		TimeoutSeconds:        job.config.TimeoutSeconds,
 		ConfiguredCron:        job.config.Cron,
 		EffectiveProfile:      job.state.EffectiveProfile,
 		EffectiveCron:         job.effectiveCron(),

--- a/internal/heartbeat/scheduler_test.go
+++ b/internal/heartbeat/scheduler_test.go
@@ -125,6 +125,36 @@ func TestSchedulerCalculatesTimezoneAndDispatchesRuntimeEnvelope(t *testing.T) {
 	}
 }
 
+func TestSchedulerPassesCompletionAwareDispatchSettings(t *testing.T) {
+	base := time.Date(2026, 7, 26, 1, 55, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	dispatcher := &recordingDispatcher{result: agentruntime.DispatchResult{Status: "heartbeat_terminal"}}
+	cfg := heartbeatTestConfig("")
+	cfg.Jobs[0].Runtime = agentruntime.OhMyCode
+	cfg.Jobs[0].DispatchMode = agentruntime.DispatchModeHeartbeatRun
+	cfg.Jobs[0].TimeoutSeconds = 480
+	cfg.Jobs[0].Text = ""
+	scheduler, err := newScheduler(cfg, t.TempDir(), dispatcher, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+
+	status := scheduler.Status().Jobs[0]
+	if status.DispatchMode != agentruntime.DispatchModeHeartbeatRun || status.TimeoutSeconds != 480 {
+		t.Fatalf("missing completion-aware status: %#v", status)
+	}
+
+	due := time.Date(2026, 7, 26, 2, 0, 0, 0, time.UTC)
+	clock.Set(due)
+	scheduler.runDue(due)
+	waitForScheduler(t, scheduler, func(job JobStatus) bool { return job.LastDispatchStatus == "heartbeat_terminal" })
+
+	requests := dispatcher.Requests()
+	if len(requests) != 1 || requests[0].DispatchMode != agentruntime.DispatchModeHeartbeatRun || requests[0].Timeout != 8*time.Minute {
+		t.Fatalf("unexpected dispatch settings: %#v", requests)
+	}
+}
+
 func TestSchedulerProfileIsIdempotentPersistsAndSkipsMissedRuns(t *testing.T) {
 	statePath := t.TempDir() + "/heartbeat-state.json"
 	base := time.Date(2026, 7, 26, 0, 5, 0, 0, time.UTC)
@@ -292,6 +322,31 @@ func TestSchedulerEnforcesGlobalCapacityAndRecordsFailure(t *testing.T) {
 	})
 	if got := len(dispatcher.Requests()); got != maxDispatchAttempts {
 		t.Fatalf("dispatch attempts=%d want %d", got, maxDispatchAttempts)
+	}
+}
+
+func TestSchedulerDoesNotRetryTerminalHeartbeatFailure(t *testing.T) {
+	base := time.Date(2026, 7, 26, 0, 0, 0, 0, time.UTC)
+	clock := &testClock{now: base}
+	dispatcher := &recordingDispatcher{result: agentruntime.DispatchResult{
+		Status: "heartbeat_failed",
+		Error:  "agent-manager heartbeat failed",
+	}}
+	cfg := heartbeatTestConfig("")
+	cfg.Jobs[0].Cron = "* * * * *"
+	scheduler, err := newScheduler(cfg, t.TempDir(), dispatcher, clock.Now, time.Hour)
+	if err != nil {
+		t.Fatalf("newScheduler: %v", err)
+	}
+	scheduler.retryDelay = func(int) time.Duration { return 0 }
+
+	due := base.Add(time.Minute)
+	clock.Set(due)
+	scheduler.runDue(due)
+	waitForScheduler(t, scheduler, func(job JobStatus) bool { return job.LastDispatchStatus == "heartbeat_failed" })
+
+	if got := len(dispatcher.Requests()); got != 1 {
+		t.Fatalf("terminal heartbeat failure attempts=%d want 1", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in `heartbeatRun` dispatch mode for `ohMyCode` heartbeat jobs
- execute `agent-manager heartbeat run` and hold the scheduler's in-flight lease until the heartbeat lifecycle reaches a terminal result
- surface the agent-manager heartbeat ID in `/status` and avoid unsafe scheduler retries after terminal heartbeat failures
- preserve generic `agent-manager assign` delivery as the default for backward compatibility

## Motivation

Generic `ohMyCode` delivery returns when agent-manager accepts an assignment. For native heartbeats, that releases FractalBot's overlap guard before ACK, skip, or failure, so a later cron tick can enqueue duplicate work while the prior heartbeat is still running.

The explicit completion-aware mode lets agent-manager remain authoritative for heartbeat prompts, busy/pending handling, ACKs, and audit semantics while FractalBot remains responsible for cron scheduling and persisted profiles.

## Configuration

```yaml
- id: main
  runtime: ohMyCode
  agent: main
  dispatchMode: heartbeatRun
  timeoutSeconds: 480
  cron: "*/5 * * * *"
  timezone: Asia/Shanghai
```

`text` is optional in this mode because agent-manager owns the canonical heartbeat prompt. The timeout defaults to eight minutes and is capped at 24 hours.

## Compatibility and failure behavior

- Existing jobs without `dispatchMode` retain generic assignment behavior.
- `heartbeatRun` is rejected for non-`ohMyCode` runtimes.
- Terminal agent-manager failures use `heartbeat_failed`, not generic `error`, so FractalBot does not repeat an already-started heartbeat.
- The command gets a 30-second process grace period beyond the configured agent-manager timeout.

## Verification

- `gofmt -l .`
- `git diff --check`
- `go test ./... -count=1`
- `go test -race ./internal/agent ./internal/heartbeat -count=1`
- `go vet ./...`
- `go build ./cmd/fractalbot`
